### PR TITLE
feat(export): add platform-ready export with image resizing and caption

### DIFF
--- a/app/(dashboard)/workspace/generate-content/text-to-image/page.tsx
+++ b/app/(dashboard)/workspace/generate-content/text-to-image/page.tsx
@@ -2056,7 +2056,7 @@ export default function TextToImagePage() {
                   
                   {/* Vault Folders by Profile */}
                   {vaultProfiles.map((profile) => {
-                    const folders = (vaultFoldersByProfile[profile.id] || []).filter(f => !f.isDefault);
+                    const folders = vaultFoldersByProfile[profile.id] || [];
                     if (folders.length === 0) return null;
                     
                     return (

--- a/app/(dashboard)/workspace/generate-content/text-to-image/page.tsx
+++ b/app/(dashboard)/workspace/generate-content/text-to-image/page.tsx
@@ -2056,7 +2056,7 @@ export default function TextToImagePage() {
                   
                   {/* Vault Folders by Profile */}
                   {vaultProfiles.map((profile) => {
-                    const folders = vaultFoldersByProfile[profile.id] || [];
+                    const folders = (vaultFoldersByProfile[profile.id] || []).filter(f => !f.isDefault);
                     if (folders.length === 0) return null;
                     
                     return (

--- a/app/(dashboard)/workspace/generated-content/page.tsx
+++ b/app/(dashboard)/workspace/generated-content/page.tsx
@@ -68,7 +68,10 @@ import {
   AlertTriangle,
   Folder,
   FolderInput,
+  FileOutput,
 } from "lucide-react";
+
+import { PlatformExportModal } from "@/components/export";
 
 // Types
 interface GeneratedImage {
@@ -440,6 +443,7 @@ export default function GeneratedContentPage() {
 
   // Interaction Improvements State
   const [selectionMode, setSelectionMode] = useState(false); // Show all checkboxes
+  const [showExportModal, setShowExportModal] = useState(false); // Platform export modal
   const [contextMenu, setContextMenu] = useState<{
     x: number;
     y: number;
@@ -3629,6 +3633,13 @@ export default function GeneratedContentPage() {
                     <span>Download</span>
                   </button>
                   <button
+                    onClick={() => setShowExportModal(true)}
+                    className="flex items-center space-x-2 bg-pink-600 hover:bg-pink-700 text-white px-4 py-2 rounded-lg font-medium shadow-md transition-all duration-200"
+                  >
+                    <FileOutput className="w-4 h-4" />
+                    <span>Platform Export</span>
+                  </button>
+                  <button
                     onClick={bulkUploadToS3}
                     className="flex items-center space-x-2 bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded-lg font-medium shadow-md transition-all duration-200"
                   >
@@ -6315,6 +6326,33 @@ export default function GeneratedContentPage() {
           </div>
         </div>
       )}
+
+      {/* Platform Export Modal */}
+      <PlatformExportModal
+        isOpen={showExportModal}
+        onClose={() => setShowExportModal(false)}
+        images={allContent
+          .filter(item => selectedItems.has(item.id))
+          .filter(item => item.itemType === 'image')
+          .map(item => ({
+            url: getBestMediaUrl({
+              awsS3Key: item.awsS3Key,
+              awsS3Url: item.awsS3Url,
+              s3Key: item.s3Key,
+              networkVolumePath: item.networkVolumePath,
+              dataUrl: item.dataUrl,
+              url: item.url,
+              id: item.id,
+              filename: item.filename,
+              type: 'image'
+            }) || '',
+            filename: item.filename,
+          }))}
+        onExportComplete={(result) => {
+          showToast('success', `Exported ${result.fileCount} files to ${result.filename}`);
+          setShowExportModal(false);
+        }}
+      />
 
     </div>
   );

--- a/app/api/export/platform-ready/route.ts
+++ b/app/api/export/platform-ready/route.ts
@@ -1,0 +1,346 @@
+/**
+ * V1a Platform-Ready Export API
+ *
+ * POST /api/export/platform-ready
+ *
+ * Exports content with platform-specific formatting:
+ * - Auto-resizes images for each platform's specs
+ * - Replaces caption variables ({{model_name}}, {{price}}, etc.)
+ * - Generates organized ZIP with platform folders
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
+import { z } from 'zod';
+
+import {
+  PlatformId,
+  PLATFORM_SPECS,
+  getRecommendedDimension,
+  PLATFORM_FOLDER_NAMES,
+} from '@/lib/export/platform-specs';
+import {
+  formatCaption,
+  CaptionVariables,
+  generateCaptionFile,
+} from '@/lib/export/caption-formatter';
+import { resizeImage, ResizeOptions } from '@/lib/export/image-resizer';
+import {
+  generateExportZip,
+  ExportContentItem,
+  PlatformExportConfig,
+} from '@/lib/export/zip-generator';
+
+// Request validation schema
+const ExportRequestSchema = z.object({
+  // Content to export - either URLs or S3 keys
+  images: z.array(
+    z.object({
+      url: z.string().optional(),
+      s3Key: z.string().optional(),
+      filename: z.string(),
+      caption: z.string().optional(),
+    })
+  ).min(1, 'At least one image is required'),
+
+  // Target platforms
+  platforms: z.array(
+    z.enum([
+      'onlyfans',
+      'fansly',
+      'fanvue',
+      'instagram-posts',
+      'instagram-stories',
+      'instagram-reels',
+      'twitter',
+      'tiktok',
+    ])
+  ).min(1, 'At least one platform is required'),
+
+  // Caption template (optional - uses per-image captions if not provided)
+  captionTemplate: z.string().optional(),
+
+  // Variables for caption replacement
+  variables: z.object({
+    model_name: z.string().optional(),
+    price: z.union([z.string(), z.number()]).optional(),
+    platform: z.string().optional(),
+    subscription_price: z.union([z.string(), z.number()]).optional(),
+    bundle_price: z.union([z.string(), z.number()]).optional(),
+    tip_amount: z.union([z.string(), z.number()]).optional(),
+    username: z.string().optional(),
+    link: z.string().optional(),
+    date: z.string().optional(),
+  }).optional(),
+
+  // Export configuration
+  exportName: z.string().default('export'),
+  modelName: z.string().optional(),
+  includeManifest: z.boolean().default(true),
+
+  // Image options
+  imageQuality: z.number().min(1).max(100).default(85),
+  imageFormat: z.enum(['jpeg', 'png', 'webp']).default('jpeg'),
+});
+
+type ExportRequest = z.infer<typeof ExportRequestSchema>;
+
+// Initialize S3 client
+function getS3Client() {
+  return new S3Client({
+    region: process.env.AWS_REGION || process.env.S3_REGION || 'us-east-1',
+    credentials: {
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID || process.env.S3_ACCESS_KEY_ID || '',
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || process.env.S3_SECRET_ACCESS_KEY || '',
+    },
+  });
+}
+
+/**
+ * Fetch image data from URL or S3
+ */
+async function fetchImageData(
+  image: { url?: string; s3Key?: string; filename: string }
+): Promise<Buffer> {
+  // Try S3 first
+  if (image.s3Key) {
+    try {
+      const s3Client = getS3Client();
+      const bucket = process.env.AWS_S3_BUCKET || process.env.S3_BUCKET || '';
+
+      const command = new GetObjectCommand({
+        Bucket: bucket,
+        Key: image.s3Key,
+      });
+
+      const response = await s3Client.send(command);
+
+      if (response.Body) {
+        const chunks: Uint8Array[] = [];
+        // @ts-expect-error - Body is a readable stream
+        for await (const chunk of response.Body) {
+          chunks.push(chunk);
+        }
+        return Buffer.concat(chunks);
+      }
+    } catch (error) {
+      console.error(`Failed to fetch from S3: ${image.s3Key}`, error);
+      // Fall through to URL fetch
+    }
+  }
+
+  // Try URL
+  if (image.url) {
+    try {
+      const response = await fetch(image.url);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      const arrayBuffer = await response.arrayBuffer();
+      return Buffer.from(arrayBuffer);
+    } catch (error) {
+      console.error(`Failed to fetch from URL: ${image.url}`, error);
+      throw error;
+    }
+  }
+
+  throw new Error(`No valid source for image: ${image.filename}`);
+}
+
+/**
+ * POST /api/export/platform-ready
+ */
+export async function POST(request: NextRequest) {
+  try {
+    // Auth check
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    // Parse and validate request
+    const body = await request.json();
+    const validationResult = ExportRequestSchema.safeParse(body);
+
+    if (!validationResult.success) {
+      return NextResponse.json(
+        {
+          error: 'Invalid request',
+          details: validationResult.error.flatten(),
+        },
+        { status: 400 }
+      );
+    }
+
+    const {
+      images,
+      platforms,
+      captionTemplate,
+      variables = {},
+      exportName,
+      modelName,
+      includeManifest,
+      imageQuality,
+      imageFormat,
+    } = validationResult.data;
+
+    console.log(`📦 Starting platform-ready export: ${images.length} images, ${platforms.length} platforms`);
+
+    // Process each platform
+    const platformConfigs: PlatformExportConfig[] = [];
+
+    for (const platformId of platforms) {
+      const dimension = getRecommendedDimension(platformId);
+      if (!dimension) {
+        console.warn(`Unknown platform: ${platformId}, skipping`);
+        continue;
+      }
+
+      console.log(`📐 Processing platform: ${platformId} (${dimension.width}x${dimension.height})`);
+
+      const platformItems: ExportContentItem[] = [];
+
+      // Process each image for this platform
+      for (const image of images) {
+        try {
+          // Fetch original image
+          const originalData = await fetchImageData(image);
+
+          // Resize for this platform
+          const resizeOptions: ResizeOptions = {
+            width: dimension.width,
+            height: dimension.height,
+            mode: 'cover',
+            position: 'attention',
+            format: imageFormat,
+            quality: imageQuality,
+          };
+
+          const resized = await resizeImage(originalData, resizeOptions);
+
+          // Format caption
+          let caption = image.caption || captionTemplate || '';
+          if (caption) {
+            // Add platform to variables for this export
+            const platformVariables: CaptionVariables = {
+              ...variables,
+              platform: PLATFORM_SPECS[platformId]?.name || platformId,
+            };
+
+            const formatted = formatCaption(caption, platformVariables, {
+              platform: platformId,
+              truncate: true,
+              enforceHashtagLimit: true,
+              removeEmptyVariables: true,
+            });
+
+            caption = formatted.text;
+          }
+
+          platformItems.push({
+            filename: image.filename,
+            data: resized.buffer,
+            mimeType: resized.mimeType,
+            caption,
+          });
+
+        } catch (error) {
+          console.error(`Failed to process image ${image.filename} for ${platformId}:`, error);
+          // Continue with other images
+        }
+      }
+
+      if (platformItems.length > 0) {
+        platformConfigs.push({
+          platformId,
+          items: platformItems,
+        });
+      }
+    }
+
+    if (platformConfigs.length === 0) {
+      return NextResponse.json(
+        { error: 'No images were successfully processed' },
+        { status: 400 }
+      );
+    }
+
+    // Generate ZIP
+    console.log(`📦 Generating ZIP with ${platformConfigs.length} platforms`);
+
+    const exportResult = await generateExportZip({
+      name: exportName,
+      platforms: platformConfigs,
+      includeManifest,
+      modelName,
+    });
+
+    console.log(`✅ Export complete: ${exportResult.filename} (${exportResult.fileCount} files, ${Math.round(exportResult.totalSize / 1024)}KB)`);
+
+    // Return ZIP as download (convert Buffer to Uint8Array for proper BodyInit compatibility)
+    return new NextResponse(new Uint8Array(exportResult.buffer), {
+      headers: {
+        'Content-Type': 'application/zip',
+        'Content-Disposition': `attachment; filename="${exportResult.filename}"`,
+        'Content-Length': exportResult.buffer.length.toString(),
+        'X-Export-File-Count': exportResult.fileCount.toString(),
+        'X-Export-Platforms': exportResult.platforms.join(','),
+      },
+    });
+
+  } catch (error) {
+    console.error('Export error:', error);
+    return NextResponse.json(
+      {
+        error: 'Export failed',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * GET /api/export/platform-ready
+ *
+ * Returns available platforms and their specs for UI
+ * Note: This endpoint doesn't require auth since it just returns public config data
+ */
+export async function GET() {
+  try {
+    // Return platform specs for UI to display (no auth needed for config data)
+    const platforms = Object.entries(PLATFORM_SPECS).map(([id, spec]) => ({
+      id,
+      name: spec.name,
+      shortName: spec.shortName,
+      icon: spec.icon,
+      color: spec.color,
+      dimensions: spec.dimensions,
+      captionLimits: spec.captionLimits,
+      folderName: PLATFORM_FOLDER_NAMES[id as PlatformId],
+    }));
+
+    return NextResponse.json({
+      platforms,
+      supportedVariables: [
+        { key: 'model_name', description: 'Model/persona name' },
+        { key: 'price', description: 'Generic price value' },
+        { key: 'platform', description: 'Platform name (auto-set per platform)' },
+        { key: 'subscription_price', description: 'Subscription price' },
+        { key: 'bundle_price', description: 'Bundle price' },
+        { key: 'tip_amount', description: 'Tip amount' },
+        { key: 'username', description: 'Username/handle' },
+        { key: 'link', description: 'Profile link' },
+        { key: 'date', description: 'Current date' },
+      ],
+    });
+
+  } catch (error) {
+    console.error('Error fetching platform specs:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch platform specs' },
+      { status: 500 }
+    );
+  }
+}

--- a/components/export/ExportPreview.tsx
+++ b/components/export/ExportPreview.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import React from 'react';
+import { Image as ImageIcon, FileText, FolderOpen, Download, Info } from 'lucide-react';
+import { PlatformId, PLATFORM_SPECS, PLATFORM_FOLDER_NAMES } from '@/lib/export/platform-specs';
+
+interface ExportImage {
+  url?: string;
+  filename: string;
+  caption?: string;
+}
+
+interface ExportPreviewProps {
+  images: ExportImage[];
+  selectedPlatforms: PlatformId[];
+  exportName: string;
+  modelName?: string;
+  captionTemplate?: string;
+  variables?: Record<string, string | number | undefined>;
+}
+
+export default function ExportPreview({
+  images,
+  selectedPlatforms,
+  exportName,
+  modelName,
+  captionTemplate,
+  variables = {},
+}: ExportPreviewProps) {
+  // Calculate export statistics
+  const totalImages = images.length;
+  const totalPlatforms = selectedPlatforms.length;
+  const totalFiles = totalImages * totalPlatforms; // Images per platform
+  const captionsCount = totalPlatforms; // One captions.txt per platform folder
+
+  // Preview variable replacement
+  const previewCaption = React.useMemo(() => {
+    if (!captionTemplate) return null;
+
+    let preview = captionTemplate;
+    Object.entries(variables).forEach(([key, value]) => {
+      if (value !== undefined) {
+        preview = preview.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), String(value));
+      }
+    });
+
+    // Highlight unreplaced variables
+    preview = preview.replace(/\{\{(\w+)\}\}/g, '<span class="text-amber-500">{{$1}}</span>');
+
+    return preview;
+  }, [captionTemplate, variables]);
+
+  if (totalImages === 0 || totalPlatforms === 0) {
+    return (
+      <div className="text-center py-8 border-2 border-dashed border-gray-200 dark:border-gray-700 rounded-xl bg-gray-50/50 dark:bg-gray-900/30">
+        <Download className="w-10 h-10 text-gray-300 dark:text-gray-600 mx-auto mb-3" />
+        <p className="text-sm font-medium text-gray-500 dark:text-gray-400">
+          {totalImages === 0 ? 'No images selected' : 'No platforms selected'}
+        </p>
+        <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">
+          {totalImages === 0 ? 'Select images to export' : 'Select at least one platform'}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Export Summary */}
+      <div className="p-4 bg-gradient-to-br from-purple-50 to-blue-50 dark:from-purple-900/20 dark:to-blue-900/20 border border-purple-200 dark:border-purple-800 rounded-xl">
+        <h4 className="font-medium text-gray-900 dark:text-white mb-3 flex items-center gap-2">
+          <FolderOpen className="w-4 h-4 text-purple-600 dark:text-purple-400" />
+          Export Preview
+        </h4>
+
+        {/* Stats Grid */}
+        <div className="grid grid-cols-3 gap-4 mb-4">
+          <div className="text-center">
+            <div className="text-2xl font-bold text-purple-600 dark:text-purple-400">
+              {totalImages}
+            </div>
+            <div className="text-xs text-gray-500 dark:text-gray-400">Images</div>
+          </div>
+          <div className="text-center">
+            <div className="text-2xl font-bold text-blue-600 dark:text-blue-400">
+              {totalPlatforms}
+            </div>
+            <div className="text-xs text-gray-500 dark:text-gray-400">Platforms</div>
+          </div>
+          <div className="text-center">
+            <div className="text-2xl font-bold text-green-600 dark:text-green-400">
+              {totalFiles + captionsCount + 2}
+            </div>
+            <div className="text-xs text-gray-500 dark:text-gray-400">Total Files</div>
+          </div>
+        </div>
+
+        {/* Folder Structure Preview */}
+        <div className="bg-white/60 dark:bg-gray-800/60 rounded-lg p-3 font-mono text-xs">
+          <div className="text-gray-600 dark:text-gray-300">
+            <span className="text-purple-600 dark:text-purple-400">📁</span>{' '}
+            {exportName || 'export'}-{new Date().toISOString().split('T')[0]}.zip
+          </div>
+          <div className="ml-4 mt-1 space-y-1">
+            {selectedPlatforms.slice(0, 4).map((platformId) => {
+              const folderName = PLATFORM_FOLDER_NAMES[platformId];
+              const spec = PLATFORM_SPECS[platformId];
+              const dim = spec?.dimensions.find((d) => d.recommended) || spec?.dimensions[0];
+
+              return (
+                <div key={platformId} className="text-gray-500 dark:text-gray-400">
+                  <span className="text-blue-600 dark:text-blue-400">📂</span> {folderName}/
+                  <div className="ml-4 space-y-0.5 text-gray-400 dark:text-gray-500">
+                    <div>
+                      <ImageIcon className="inline w-3 h-3 mr-1" />
+                      image-001.jpg
+                      {dim && (
+                        <span className="text-[10px] ml-1 text-gray-300 dark:text-gray-600">
+                          ({dim.width}x{dim.height})
+                        </span>
+                      )}
+                    </div>
+                    {totalImages > 1 && (
+                      <div className="text-gray-300 dark:text-gray-600">
+                        ... {totalImages - 1} more
+                      </div>
+                    )}
+                    <div>
+                      <FileText className="inline w-3 h-3 mr-1" />
+                      captions.txt
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+            {selectedPlatforms.length > 4 && (
+              <div className="text-gray-300 dark:text-gray-600">
+                ... {selectedPlatforms.length - 4} more platforms
+              </div>
+            )}
+            <div className="text-gray-500 dark:text-gray-400 pt-1">
+              <FileText className="inline w-3 h-3 mr-1" />
+              manifest.json
+            </div>
+            <div className="text-gray-500 dark:text-gray-400">
+              <FileText className="inline w-3 h-3 mr-1" />
+              README.txt
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Caption Preview */}
+      {(captionTemplate || previewCaption) && (
+        <div className="p-4 bg-gray-50 dark:bg-gray-900/50 border border-gray-200 dark:border-gray-700 rounded-xl">
+          <h4 className="font-medium text-gray-900 dark:text-white mb-2 flex items-center gap-2">
+            <FileText className="w-4 h-4 text-gray-600 dark:text-gray-400" />
+            Caption Preview
+          </h4>
+          <div
+            className="text-sm text-gray-600 dark:text-gray-300 bg-white dark:bg-gray-800 p-3 rounded-lg border border-gray-200 dark:border-gray-700 whitespace-pre-wrap"
+            dangerouslySetInnerHTML={{ __html: previewCaption || 'No caption template provided' }}
+          />
+          {Object.values(variables).some((v) => v === undefined) && (
+            <p className="text-xs text-amber-600 dark:text-amber-400 mt-2 flex items-center gap-1">
+              <Info className="w-3 h-3" />
+              Some variables are not set and will be removed
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Selected Images Thumbnails */}
+      {images.length > 0 && images[0].url && (
+        <div className="space-y-2">
+          <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+            Selected Images ({images.length})
+          </h4>
+          <div className="flex flex-wrap gap-2">
+            {images.slice(0, 8).map((image, index) => (
+              <div
+                key={index}
+                className="relative w-14 h-14 rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700"
+              >
+                {image.url ? (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={image.url}
+                    alt={image.filename}
+                    className="w-full h-full object-cover"
+                  />
+                ) : (
+                  <div className="w-full h-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center">
+                    <ImageIcon className="w-6 h-6 text-gray-400" />
+                  </div>
+                )}
+              </div>
+            ))}
+            {images.length > 8 && (
+              <div className="w-14 h-14 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-100 dark:bg-gray-800 flex items-center justify-center">
+                <span className="text-xs font-medium text-gray-500 dark:text-gray-400">
+                  +{images.length - 8}
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Model name */}
+      {modelName && (
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          Model: <span className="font-medium">{modelName}</span>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/components/export/PlatformExportModal.tsx
+++ b/components/export/PlatformExportModal.tsx
@@ -1,0 +1,464 @@
+'use client';
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  X,
+  Download,
+  Loader2,
+  FileText,
+  Settings2,
+  ChevronDown,
+  ChevronUp,
+  AlertCircle,
+  CheckCircle,
+} from 'lucide-react';
+import PlatformSelector, { usePlatformSelection } from './PlatformSelector';
+import ExportPreview from './ExportPreview';
+import { PlatformId } from '@/lib/export/platform-specs';
+
+interface ExportImage {
+  url?: string;
+  s3Key?: string;
+  filename: string;
+  caption?: string;
+}
+
+interface PlatformExportModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  images: ExportImage[];
+  defaultModelName?: string;
+  defaultCaption?: string;
+  onExportComplete?: (result: { filename: string; fileCount: number }) => void;
+}
+
+type ExportStatus = 'idle' | 'exporting' | 'success' | 'error';
+
+// Variable keys for caption templates
+const VARIABLE_KEYS = [
+  'model_name',
+  'price',
+  'subscription_price',
+  'bundle_price',
+  'tip_amount',
+  'username',
+  'link',
+] as const;
+
+type VariableKey = typeof VARIABLE_KEYS[number];
+type Variables = Record<VariableKey, string>;
+
+export default function PlatformExportModal({
+  isOpen,
+  onClose,
+  images,
+  defaultModelName = '',
+  defaultCaption = '',
+  onExportComplete,
+}: PlatformExportModalProps) {
+  const [mounted, setMounted] = useState(false);
+  const [exportStatus, setExportStatus] = useState<ExportStatus>('idle');
+  const [exportError, setExportError] = useState<string | null>(null);
+  const [exportProgress, setExportProgress] = useState<string>('');
+
+  // Form state
+  const [exportName, setExportName] = useState(defaultModelName || 'export');
+  const [modelName, setModelName] = useState(defaultModelName);
+  const [captionTemplate, setCaptionTemplate] = useState(defaultCaption);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [imageQuality, setImageQuality] = useState(85);
+  const [imageFormat, setImageFormat] = useState<'jpeg' | 'png' | 'webp'>('jpeg');
+
+  // Variables state
+  const [variables, setVariables] = useState<Record<string, string>>({
+    model_name: defaultModelName,
+  });
+
+  // Platform selection
+  const {
+    selectedPlatforms,
+    togglePlatform,
+    selectAll,
+    clearAll,
+  } = usePlatformSelection(['onlyfans', 'instagram-posts']);
+
+  // Handle client-side mounting for portal
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
+
+  // Reset state when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      setExportStatus('idle');
+      setExportError(null);
+      setExportProgress('');
+      if (defaultModelName) {
+        setExportName(defaultModelName);
+        setModelName(defaultModelName);
+        setVariables((prev) => ({ ...prev, model_name: defaultModelName }));
+      }
+      if (defaultCaption) {
+        setCaptionTemplate(defaultCaption);
+      }
+    }
+  }, [isOpen, defaultModelName, defaultCaption]);
+
+  // Update variable
+  const handleVariableChange = useCallback((key: string, value: string) => {
+    setVariables((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  // Insert variable into caption
+  const insertVariable = useCallback((key: string) => {
+    setCaptionTemplate((prev) => `${prev}{{${key}}}`);
+  }, []);
+
+  // Handle export
+  const handleExport = async () => {
+    if (images.length === 0 || selectedPlatforms.length === 0) {
+      setExportError('Please select images and at least one platform');
+      return;
+    }
+
+    setExportStatus('exporting');
+    setExportError(null);
+    setExportProgress('Preparing export...');
+
+    try {
+      setExportProgress('Processing images...');
+
+      // Build variables object (only include non-empty values)
+      const exportVariables: Record<string, string | number | undefined> = {};
+      Object.entries(variables).forEach(([key, value]) => {
+        if (value && value.trim()) {
+          exportVariables[key] = value.trim();
+        }
+      });
+
+      const response = await fetch('/api/export/platform-ready', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          images: images.map((img) => ({
+            url: img.url,
+            s3Key: img.s3Key,
+            filename: img.filename,
+            caption: img.caption,
+          })),
+          platforms: selectedPlatforms,
+          captionTemplate: captionTemplate || undefined,
+          variables: exportVariables,
+          exportName,
+          modelName: modelName || undefined,
+          includeManifest: true,
+          imageQuality,
+          imageFormat,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || 'Export failed');
+      }
+
+      setExportProgress('Generating ZIP file...');
+
+      // Get filename from response headers
+      const contentDisposition = response.headers.get('Content-Disposition');
+      const filenameMatch = contentDisposition?.match(/filename="(.+)"/);
+      const filename = filenameMatch?.[1] || `${exportName}-export.zip`;
+
+      // Get file count from headers
+      const fileCount = parseInt(response.headers.get('X-Export-File-Count') || '0', 10);
+
+      // Download the file
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      window.URL.revokeObjectURL(url);
+
+      setExportStatus('success');
+      setExportProgress(`Downloaded ${filename}`);
+
+      // Notify parent
+      if (onExportComplete) {
+        onExportComplete({ filename, fileCount });
+      }
+
+      // Auto-close after success
+      setTimeout(() => {
+        onClose();
+      }, 2000);
+    } catch (error) {
+      console.error('Export error:', error);
+      setExportStatus('error');
+      setExportError(error instanceof Error ? error.message : 'Export failed');
+      setExportProgress('');
+    }
+  };
+
+  if (!isOpen || !mounted) return null;
+
+  const canExport = images.length > 0 && selectedPlatforms.length > 0 && exportStatus !== 'exporting';
+
+  const modalContent = (
+    <div
+      className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white dark:bg-gray-800 rounded-2xl shadow-2xl max-w-3xl w-full mx-4 border border-gray-200 dark:border-gray-700 max-h-[90vh] overflow-hidden flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="p-6 border-b border-gray-200 dark:border-gray-700 shrink-0">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-white flex items-center gap-2">
+                <Download className="w-5 h-5 text-purple-600 dark:text-purple-400" />
+                Platform-Ready Export
+              </h3>
+              <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                Export {images.length} image{images.length !== 1 ? 's' : ''} with platform-optimized sizing
+              </p>
+            </div>
+            <button
+              onClick={onClose}
+              disabled={exportStatus === 'exporting'}
+              className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors disabled:opacity-50"
+            >
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+        </div>
+
+        {/* Content - Scrollable */}
+        <div className="flex-1 overflow-y-auto p-6 space-y-6">
+          {/* Export Name & Model */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Export Name
+              </label>
+              <input
+                type="text"
+                value={exportName}
+                onChange={(e) => setExportName(e.target.value)}
+                placeholder="my-export"
+                disabled={exportStatus === 'exporting'}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-400 focus:ring-2 focus:ring-purple-500 focus:border-transparent disabled:opacity-50"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Model Name (Optional)
+              </label>
+              <input
+                type="text"
+                value={modelName}
+                onChange={(e) => {
+                  setModelName(e.target.value);
+                  handleVariableChange('model_name', e.target.value);
+                }}
+                placeholder="Enter model name"
+                disabled={exportStatus === 'exporting'}
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-400 focus:ring-2 focus:ring-purple-500 focus:border-transparent disabled:opacity-50"
+              />
+            </div>
+          </div>
+
+          {/* Platform Selection */}
+          <PlatformSelector
+            selectedPlatforms={selectedPlatforms}
+            onTogglePlatform={togglePlatform}
+            onSelectAll={selectAll}
+            onClearAll={clearAll}
+            disabled={exportStatus === 'exporting'}
+          />
+
+          {/* Caption Template */}
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <label className="text-sm font-medium text-gray-700 dark:text-gray-300 flex items-center gap-2">
+                <FileText className="w-4 h-4" />
+                Caption Template
+              </label>
+              <div className="flex flex-wrap gap-1">
+                {VARIABLE_KEYS.slice(0, 4).map((key) => (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => insertVariable(key)}
+                    disabled={exportStatus === 'exporting'}
+                    className="text-[10px] px-1.5 py-0.5 bg-purple-100 dark:bg-purple-900/30 text-purple-700 dark:text-purple-300 rounded hover:bg-purple-200 dark:hover:bg-purple-900/50 disabled:opacity-50"
+                  >
+                    {`{{${key}}}`}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <textarea
+              value={captionTemplate}
+              onChange={(e) => setCaptionTemplate(e.target.value)}
+              placeholder="Enter caption template with variables like {{model_name}}, {{price}}..."
+              rows={3}
+              disabled={exportStatus === 'exporting'}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-400 focus:ring-2 focus:ring-purple-500 focus:border-transparent disabled:opacity-50 resize-none font-mono text-sm"
+            />
+          </div>
+
+          {/* Variable Values */}
+          {captionTemplate && captionTemplate.includes('{{') && (
+            <div className="space-y-3 p-4 bg-gray-50 dark:bg-gray-900/50 rounded-lg border border-gray-200 dark:border-gray-700">
+              <h4 className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                Variable Values
+              </h4>
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+                {VARIABLE_KEYS.filter((key) =>
+                  captionTemplate.includes(`{{${key}}}`)
+                ).map((key) => (
+                  <div key={key}>
+                    <label className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+                      {key.replace(/_/g, ' ')}
+                    </label>
+                    <input
+                      type="text"
+                      value={variables[key] || ''}
+                      onChange={(e) => handleVariableChange(key, e.target.value)}
+                      placeholder={`Enter ${key.replace(/_/g, ' ')}`}
+                      disabled={exportStatus === 'exporting'}
+                      className="w-full px-2 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-400 focus:ring-2 focus:ring-purple-500 focus:border-transparent disabled:opacity-50"
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Advanced Options */}
+          <div className="border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">
+            <button
+              type="button"
+              onClick={() => setShowAdvanced(!showAdvanced)}
+              className="w-full flex items-center justify-between px-4 py-3 bg-gray-50 dark:bg-gray-900/50 hover:bg-gray-100 dark:hover:bg-gray-900/70 transition-colors"
+            >
+              <span className="text-sm font-medium text-gray-700 dark:text-gray-300 flex items-center gap-2">
+                <Settings2 className="w-4 h-4" />
+                Advanced Options
+              </span>
+              {showAdvanced ? (
+                <ChevronUp className="w-4 h-4 text-gray-400" />
+              ) : (
+                <ChevronDown className="w-4 h-4 text-gray-400" />
+              )}
+            </button>
+
+            {showAdvanced && (
+              <div className="p-4 space-y-4 bg-white dark:bg-gray-800">
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                      Image Quality ({imageQuality}%)
+                    </label>
+                    <input
+                      type="range"
+                      min="50"
+                      max="100"
+                      value={imageQuality}
+                      onChange={(e) => setImageQuality(parseInt(e.target.value))}
+                      disabled={exportStatus === 'exporting'}
+                      className="w-full accent-purple-600"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                      Output Format
+                    </label>
+                    <select
+                      value={imageFormat}
+                      onChange={(e) => setImageFormat(e.target.value as 'jpeg' | 'png' | 'webp')}
+                      disabled={exportStatus === 'exporting'}
+                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-purple-500 focus:border-transparent disabled:opacity-50"
+                    >
+                      <option value="jpeg">JPEG (smaller size)</option>
+                      <option value="png">PNG (lossless)</option>
+                      <option value="webp">WebP (modern)</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Export Preview */}
+          <ExportPreview
+            images={images}
+            selectedPlatforms={selectedPlatforms}
+            exportName={exportName}
+            modelName={modelName}
+            captionTemplate={captionTemplate}
+            variables={variables}
+          />
+        </div>
+
+        {/* Footer */}
+        <div className="p-4 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50 shrink-0">
+          {/* Status Messages */}
+          {exportStatus === 'error' && exportError && (
+            <div className="mb-3 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg flex items-center gap-2 text-sm text-red-700 dark:text-red-300">
+              <AlertCircle className="w-4 h-4 shrink-0" />
+              {exportError}
+            </div>
+          )}
+
+          {exportStatus === 'success' && (
+            <div className="mb-3 p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg flex items-center gap-2 text-sm text-green-700 dark:text-green-300">
+              <CheckCircle className="w-4 h-4 shrink-0" />
+              {exportProgress}
+            </div>
+          )}
+
+          {/* Action Buttons */}
+          <div className="flex gap-3">
+            <button
+              onClick={onClose}
+              disabled={exportStatus === 'exporting'}
+              className="flex-1 px-4 py-2.5 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 font-medium rounded-lg transition-colors disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleExport}
+              disabled={!canExport}
+              className="flex-1 px-4 py-2.5 bg-purple-600 hover:bg-purple-700 text-white font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+            >
+              {exportStatus === 'exporting' ? (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  {exportProgress || 'Exporting...'}
+                </>
+              ) : (
+                <>
+                  <Download className="w-4 h-4" />
+                  Export ZIP
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(modalContent, document.body);
+}

--- a/components/export/PlatformSelector.tsx
+++ b/components/export/PlatformSelector.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import React from 'react';
+import { Check } from 'lucide-react';
+import { PlatformId, PLATFORM_SPECS } from '@/lib/export/platform-specs';
+
+interface PlatformSelectorProps {
+  selectedPlatforms: PlatformId[];
+  onTogglePlatform: (platformId: PlatformId) => void;
+  onSelectAll?: () => void;
+  onClearAll?: () => void;
+  disabled?: boolean;
+}
+
+const PLATFORM_ORDER: PlatformId[] = [
+  'onlyfans',
+  'fansly',
+  'fanvue',
+  'instagram-posts',
+  'instagram-stories',
+  'instagram-reels',
+  'twitter',
+  'tiktok',
+];
+
+export default function PlatformSelector({
+  selectedPlatforms,
+  onTogglePlatform,
+  onSelectAll,
+  onClearAll,
+  disabled = false,
+}: PlatformSelectorProps) {
+  const allSelected = selectedPlatforms.length === PLATFORM_ORDER.length;
+  const noneSelected = selectedPlatforms.length === 0;
+
+  return (
+    <div className="space-y-3">
+      {/* Header with Select/Clear All */}
+      <div className="flex items-center justify-between">
+        <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+          Select Platforms
+        </label>
+        <div className="flex gap-2">
+          {onSelectAll && (
+            <button
+              type="button"
+              onClick={onSelectAll}
+              disabled={disabled || allSelected}
+              className="text-xs text-purple-600 dark:text-purple-400 hover:text-purple-700 dark:hover:text-purple-300 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Select All
+            </button>
+          )}
+          {onClearAll && onSelectAll && (
+            <span className="text-gray-300 dark:text-gray-600">|</span>
+          )}
+          {onClearAll && (
+            <button
+              type="button"
+              onClick={onClearAll}
+              disabled={disabled || noneSelected}
+              className="text-xs text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Clear All
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Platform Grid */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        {PLATFORM_ORDER.map((platformId) => {
+          const spec = PLATFORM_SPECS[platformId];
+          if (!spec) return null;
+
+          const isSelected = selectedPlatforms.includes(platformId);
+          const recommendedDim = spec.dimensions.find((d) => d.recommended) || spec.dimensions[0];
+
+          return (
+            <button
+              key={platformId}
+              type="button"
+              onClick={() => onTogglePlatform(platformId)}
+              disabled={disabled}
+              className={`
+                relative flex flex-col items-center gap-1.5 p-3 rounded-lg border-2 transition-all
+                disabled:opacity-50 disabled:cursor-not-allowed
+                ${
+                  isSelected
+                    ? 'border-purple-500 bg-purple-50 dark:bg-purple-900/20'
+                    : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 bg-white dark:bg-gray-800'
+                }
+              `}
+            >
+              {/* Checkmark indicator */}
+              {isSelected && (
+                <div className="absolute top-1.5 right-1.5 w-4 h-4 bg-purple-500 rounded-full flex items-center justify-center">
+                  <Check className="w-3 h-3 text-white" />
+                </div>
+              )}
+
+              {/* Platform icon/emoji */}
+              <span className="text-xl">{spec.icon}</span>
+
+              {/* Platform name */}
+              <span
+                className={`text-xs font-medium text-center ${
+                  isSelected
+                    ? 'text-purple-900 dark:text-purple-100'
+                    : 'text-gray-700 dark:text-gray-300'
+                }`}
+              >
+                {spec.shortName}
+              </span>
+
+              {/* Dimensions hint */}
+              <span
+                className={`text-[10px] ${
+                  isSelected
+                    ? 'text-purple-600 dark:text-purple-400'
+                    : 'text-gray-400 dark:text-gray-500'
+                }`}
+              >
+                {recommendedDim.width}x{recommendedDim.height}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Selection count */}
+      <p className="text-xs text-gray-500 dark:text-gray-400 text-right">
+        {selectedPlatforms.length} of {PLATFORM_ORDER.length} platforms selected
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Hook for managing platform selection state
+ */
+export function usePlatformSelection(initialPlatforms: PlatformId[] = []) {
+  const [selectedPlatforms, setSelectedPlatforms] = React.useState<PlatformId[]>(initialPlatforms);
+
+  const togglePlatform = React.useCallback((platformId: PlatformId) => {
+    setSelectedPlatforms((prev) =>
+      prev.includes(platformId)
+        ? prev.filter((p) => p !== platformId)
+        : [...prev, platformId]
+    );
+  }, []);
+
+  const selectAll = React.useCallback(() => {
+    setSelectedPlatforms([...PLATFORM_ORDER]);
+  }, []);
+
+  const clearAll = React.useCallback(() => {
+    setSelectedPlatforms([]);
+  }, []);
+
+  const reset = React.useCallback((platforms: PlatformId[] = []) => {
+    setSelectedPlatforms(platforms);
+  }, []);
+
+  return {
+    selectedPlatforms,
+    togglePlatform,
+    selectAll,
+    clearAll,
+    reset,
+  };
+}

--- a/components/export/index.ts
+++ b/components/export/index.ts
@@ -1,0 +1,12 @@
+/**
+ * V1a Platform-Ready Export Components
+ *
+ * These components enable the "core magic" of Tastyy.AI:
+ * - PlatformExportModal: Main export modal with all functionality
+ * - PlatformSelector: Platform checkbox grid
+ * - ExportPreview: Preview of export structure and caption
+ */
+
+export { default as PlatformExportModal } from './PlatformExportModal';
+export { default as PlatformSelector, usePlatformSelection } from './PlatformSelector';
+export { default as ExportPreview } from './ExportPreview';

--- a/components/social-media/vault/VaultContent.tsx
+++ b/components/social-media/vault/VaultContent.tsx
@@ -2231,6 +2231,7 @@ export function VaultContent() {
             }));
         })()}
         defaultModelName={selectedProfile?.name || ''}
+        profileId={selectedProfileId || undefined}
         onExportComplete={(result) => {
           showToast(`Exported ${result.fileCount} files to ${result.filename}`, 'success');
           setShowExportModal(false);

--- a/components/social-media/vault/VaultContent.tsx
+++ b/components/social-media/vault/VaultContent.tsx
@@ -53,7 +53,10 @@ import {
   Sparkles,
   Maximize2,
   Wand2,
+  FileOutput,
 } from "lucide-react";
+
+import { PlatformExportModal } from "@/components/export";
 
 interface InstagramProfile {
   id: string;
@@ -517,6 +520,7 @@ export function VaultContent() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [selectionMode, setSelectionMode] = useState(false);
   const [showPreviewInfo, setShowPreviewInfo] = useState(false);
+  const [showExportModal, setShowExportModal] = useState(false);
   const contentRef = useRef<HTMLDivElement>(null);
 
   // Debounce search for better performance
@@ -1924,8 +1928,18 @@ export function VaultContent() {
                   <Upload className="w-5 h-5" />
                 </button>
               )}
+              {/* Mobile Export button */}
+              {vaultItems.filter(item => item.fileType.startsWith('image/')).length > 0 && (
+                <button
+                  onClick={() => setShowExportModal(true)}
+                  className="p-2 bg-purple-600 hover:bg-purple-700 text-white rounded-lg transition-colors"
+                  title="Platform Export"
+                >
+                  <FileOutput className="w-5 h-5" />
+                </button>
+              )}
             </div>
-            
+
             {/* Desktop header row */}
             <div className="hidden lg:flex items-center justify-between">
               <div>
@@ -1951,9 +1965,19 @@ export function VaultContent() {
                     <Upload className="w-4 h-4" /> Upload
                   </button>
                 )}
+                {/* Desktop Export button */}
+                {vaultItems.filter(item => item.fileType.startsWith('image/')).length > 0 && (
+                  <button
+                    onClick={() => setShowExportModal(true)}
+                    className="flex items-center gap-2 px-4 py-2 bg-purple-600 hover:bg-purple-700 text-white rounded-lg font-medium transition-colors"
+                    title="Export for platforms"
+                  >
+                    <FileOutput className="w-4 h-4" /> Export
+                  </button>
+                )}
               </div>
             </div>
-            
+
             {/* Mobile shared folder info */}
             {isViewingShared && selectedSharedFolder && (
               <p className="text-sm text-gray-400 flex items-center gap-1 lg:hidden mb-3">
@@ -2142,8 +2166,8 @@ export function VaultContent() {
                   </button>
                 )}
                 
-                <button 
-                  onClick={handleDownloadZip} 
+                <button
+                  onClick={handleDownloadZip}
                   disabled={isDownloading}
                   className="flex items-center gap-1.5 px-2 sm:px-3 py-1.5 sm:py-2 text-xs sm:text-sm font-medium text-emerald-400 hover:bg-emerald-600/20 rounded-lg transition-colors disabled:opacity-50"
                   title="Download"
@@ -2151,7 +2175,16 @@ export function VaultContent() {
                   {isDownloading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Download className="w-4 h-4" />}
                   <span className="hidden md:inline">Download</span>
                 </button>
-                
+
+                <button
+                  onClick={() => setShowExportModal(true)}
+                  className="flex items-center gap-1.5 px-2 sm:px-3 py-1.5 sm:py-2 text-xs sm:text-sm font-medium text-purple-400 hover:bg-purple-600/20 rounded-lg transition-colors"
+                  title="Platform Export"
+                >
+                  <FileOutput className="w-4 h-4" />
+                  <span className="hidden md:inline">Export</span>
+                </button>
+
                 {canEdit && (
                   <button 
                     onClick={handleBulkDelete} 
@@ -2180,6 +2213,29 @@ export function VaultContent() {
           )}
         </div>
       </div>
+
+      {/* Platform Export Modal */}
+      <PlatformExportModal
+        isOpen={showExportModal}
+        onClose={() => setShowExportModal(false)}
+        images={(() => {
+          // If items are selected, use selected images. Otherwise, use all images.
+          const imagesToExport = selectedItems.size > 0
+            ? vaultItems.filter(item => selectedItems.has(item.id))
+            : vaultItems;
+          return imagesToExport
+            .filter(item => item.fileType.startsWith('image/'))
+            .map(item => ({
+              url: item.awsS3Url,
+              filename: item.fileName,
+            }));
+        })()}
+        defaultModelName={selectedProfile?.name || ''}
+        onExportComplete={(result) => {
+          showToast(`Exported ${result.fileCount} files to ${result.filename}`, 'success');
+          setShowExportModal(false);
+        }}
+      />
     </>
   );
 }

--- a/lib/export/caption-formatter.ts
+++ b/lib/export/caption-formatter.ts
@@ -1,0 +1,355 @@
+/**
+ * V1a Caption Formatter - Variable replacement and platform-specific formatting
+ *
+ * Supports variables like {{model_name}}, {{price}}, {{platform}} and applies
+ * platform-specific formatting rules (character limits, hashtag limits, etc.)
+ */
+
+import { PlatformId, PLATFORM_SPECS } from './platform-specs';
+
+/**
+ * Supported caption variables
+ */
+export interface CaptionVariables {
+  model_name?: string;
+  price?: string | number;
+  platform?: string;
+  subscription_price?: string | number;
+  bundle_price?: string | number;
+  tip_amount?: string | number;
+  username?: string;
+  link?: string;
+  date?: string;
+  custom?: Record<string, string>;
+}
+
+/**
+ * Caption formatting options
+ */
+export interface FormatOptions {
+  /** Target platform for formatting rules */
+  platform?: PlatformId;
+  /** Whether to truncate to platform limits */
+  truncate?: boolean;
+  /** Whether to strip hashtags if over limit */
+  enforceHashtagLimit?: boolean;
+  /** Custom hashtags to append */
+  appendHashtags?: string[];
+  /** Whether to remove empty variable placeholders */
+  removeEmptyVariables?: boolean;
+}
+
+/**
+ * Result of formatting a caption
+ */
+export interface FormattedCaption {
+  text: string;
+  originalLength: number;
+  finalLength: number;
+  truncated: boolean;
+  hashtagCount: number;
+  hashtagsRemoved: number;
+  warnings: string[];
+}
+
+/**
+ * Variable pattern for matching {{variable_name}}
+ */
+const VARIABLE_PATTERN = /\{\{(\w+)\}\}/g;
+
+/**
+ * Hashtag pattern for counting
+ */
+const HASHTAG_PATTERN = /#[\w]+/g;
+
+/**
+ * Extract all variables used in a caption text
+ */
+export function extractVariables(text: string): string[] {
+  const matches = text.matchAll(VARIABLE_PATTERN);
+  return [...new Set([...matches].map(m => m[1]))];
+}
+
+/**
+ * Check if caption contains any variables
+ */
+export function hasVariables(text: string): boolean {
+  return VARIABLE_PATTERN.test(text);
+}
+
+/**
+ * Replace variables in caption text
+ */
+export function replaceVariables(
+  text: string,
+  variables: CaptionVariables,
+  removeEmpty: boolean = false
+): string {
+  return text.replace(VARIABLE_PATTERN, (match, varName) => {
+    // Check standard variables
+    if (varName in variables) {
+      const value = variables[varName as keyof CaptionVariables];
+      if (value !== undefined && value !== null && value !== '') {
+        return String(value);
+      }
+    }
+
+    // Check custom variables
+    if (variables.custom && varName in variables.custom) {
+      return variables.custom[varName];
+    }
+
+    // Return empty string or original placeholder
+    return removeEmpty ? '' : match;
+  });
+}
+
+/**
+ * Count hashtags in text
+ */
+export function countHashtags(text: string): number {
+  const matches = text.match(HASHTAG_PATTERN);
+  return matches ? matches.length : 0;
+}
+
+/**
+ * Extract all hashtags from text
+ */
+export function extractHashtags(text: string): string[] {
+  const matches = text.match(HASHTAG_PATTERN);
+  return matches || [];
+}
+
+/**
+ * Remove excess hashtags to meet platform limit
+ */
+export function enforceHashtagLimit(text: string, limit: number): { text: string; removed: number } {
+  const hashtags = extractHashtags(text);
+  if (hashtags.length <= limit) {
+    return { text, removed: 0 };
+  }
+
+  // Keep first N hashtags, remove the rest
+  const hashtagsToRemove = hashtags.slice(limit);
+  let newText = text;
+
+  for (const hashtag of hashtagsToRemove) {
+    // Remove hashtag and any trailing space
+    newText = newText.replace(new RegExp(`${hashtag}\\s*`, 'g'), '');
+  }
+
+  return {
+    text: newText.trim(),
+    removed: hashtagsToRemove.length,
+  };
+}
+
+/**
+ * Truncate text to a maximum length, preserving word boundaries
+ */
+export function truncateText(text: string, maxLength: number): { text: string; truncated: boolean } {
+  if (text.length <= maxLength) {
+    return { text, truncated: false };
+  }
+
+  // Find the last space before the limit
+  let truncateAt = maxLength;
+  const lastSpace = text.lastIndexOf(' ', maxLength - 3); // -3 for "..."
+
+  if (lastSpace > maxLength * 0.8) {
+    truncateAt = lastSpace;
+  }
+
+  return {
+    text: text.substring(0, truncateAt).trim() + '...',
+    truncated: true,
+  };
+}
+
+/**
+ * Format caption for a specific platform with all rules applied
+ */
+export function formatCaption(
+  text: string,
+  variables: CaptionVariables,
+  options: FormatOptions = {}
+): FormattedCaption {
+  const {
+    platform,
+    truncate = true,
+    enforceHashtagLimit: enforceHashtags = true,
+    appendHashtags = [],
+    removeEmptyVariables = true,
+  } = options;
+
+  const warnings: string[] = [];
+  const originalLength = text.length;
+
+  // Step 1: Replace variables
+  let formatted = replaceVariables(text, variables, removeEmptyVariables);
+
+  // Step 2: Append any additional hashtags
+  if (appendHashtags.length > 0) {
+    const hashtagString = appendHashtags
+      .map(h => (h.startsWith('#') ? h : `#${h}`))
+      .join(' ');
+    formatted = `${formatted}\n\n${hashtagString}`;
+  }
+
+  // Step 3: Apply platform-specific rules
+  let hashtagsRemoved = 0;
+  let truncated = false;
+
+  if (platform) {
+    const spec = PLATFORM_SPECS[platform];
+    if (spec) {
+      // Enforce hashtag limit
+      if (enforceHashtags && spec.captionLimits.hashtagLimit) {
+        const result = enforceHashtagLimit(formatted, spec.captionLimits.hashtagLimit);
+        formatted = result.text;
+        hashtagsRemoved = result.removed;
+        if (hashtagsRemoved > 0) {
+          warnings.push(`Removed ${hashtagsRemoved} hashtag(s) to meet ${platform} limit of ${spec.captionLimits.hashtagLimit}`);
+        }
+      }
+
+      // Truncate to character limit
+      if (truncate && formatted.length > spec.captionLimits.maxLength) {
+        const result = truncateText(formatted, spec.captionLimits.maxLength);
+        formatted = result.text;
+        truncated = result.truncated;
+        if (truncated) {
+          warnings.push(`Caption truncated to ${spec.captionLimits.maxLength} characters for ${platform}`);
+        }
+      }
+    }
+  }
+
+  return {
+    text: formatted,
+    originalLength,
+    finalLength: formatted.length,
+    truncated,
+    hashtagCount: countHashtags(formatted),
+    hashtagsRemoved,
+    warnings,
+  };
+}
+
+/**
+ * Format caption for multiple platforms at once
+ */
+export function formatCaptionForPlatforms(
+  text: string,
+  variables: CaptionVariables,
+  platforms: PlatformId[],
+  baseOptions: Omit<FormatOptions, 'platform'> = {}
+): Record<PlatformId, FormattedCaption> {
+  const results: Partial<Record<PlatformId, FormattedCaption>> = {};
+
+  for (const platform of platforms) {
+    results[platform] = formatCaption(text, variables, {
+      ...baseOptions,
+      platform,
+    });
+  }
+
+  return results as Record<PlatformId, FormattedCaption>;
+}
+
+/**
+ * Generate caption.txt content for export
+ */
+export function generateCaptionFile(
+  caption: string,
+  variables: CaptionVariables,
+  platform: PlatformId
+): string {
+  const formatted = formatCaption(caption, variables, { platform });
+
+  const lines = [
+    `Caption for ${PLATFORM_SPECS[platform]?.name || platform}`,
+    '='.repeat(40),
+    '',
+    formatted.text,
+  ];
+
+  if (formatted.warnings.length > 0) {
+    lines.push('', '---', 'Notes:', ...formatted.warnings.map(w => `- ${w}`));
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Validate caption before export
+ */
+export function validateCaption(text: string, platform: PlatformId): {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+} {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const spec = PLATFORM_SPECS[platform];
+
+  if (!spec) {
+    errors.push(`Unknown platform: ${platform}`);
+    return { valid: false, errors, warnings };
+  }
+
+  // Check for unreplaced variables
+  const unreplacedVars = extractVariables(text);
+  if (unreplacedVars.length > 0) {
+    warnings.push(`Caption contains unreplaced variables: ${unreplacedVars.join(', ')}`);
+  }
+
+  // Check length
+  if (text.length > spec.captionLimits.maxLength) {
+    warnings.push(`Caption exceeds ${platform} limit (${text.length}/${spec.captionLimits.maxLength} chars)`);
+  }
+
+  // Check hashtag count
+  const hashtagCount = countHashtags(text);
+  if (spec.captionLimits.hashtagLimit && hashtagCount > spec.captionLimits.hashtagLimit) {
+    warnings.push(`Too many hashtags for ${platform} (${hashtagCount}/${spec.captionLimits.hashtagLimit})`);
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    warnings,
+  };
+}
+
+/**
+ * Get a preview of how the caption will look with variables replaced
+ */
+export function previewCaption(
+  text: string,
+  variables: CaptionVariables,
+  platform?: PlatformId
+): string {
+  const formatted = formatCaption(text, variables, {
+    platform,
+    truncate: false,
+    enforceHashtagLimit: false,
+    removeEmptyVariables: false,
+  });
+  return formatted.text;
+}
+
+/**
+ * Sample variables for preview/testing
+ */
+export const SAMPLE_VARIABLES: CaptionVariables = {
+  model_name: 'Jessica',
+  price: '9.99',
+  platform: 'OnlyFans',
+  subscription_price: '9.99',
+  bundle_price: '25',
+  tip_amount: '10',
+  username: '@jessica_model',
+  link: 'onlyfans.com/jessica',
+  date: new Date().toLocaleDateString(),
+};

--- a/lib/export/image-resizer.ts
+++ b/lib/export/image-resizer.ts
@@ -1,0 +1,464 @@
+/**
+ * V1a Image Resizer - Platform-optimized image resizing using Sharp
+ *
+ * Resizes images to platform-specific dimensions while maintaining quality
+ * and handling various aspect ratio scenarios (crop, fit, fill).
+ */
+
+import sharp from 'sharp';
+import { PlatformId, PlatformDimension, PLATFORM_SPECS, getRecommendedDimension } from './platform-specs';
+
+/**
+ * Resize mode options
+ */
+export type ResizeMode = 'cover' | 'contain' | 'fill' | 'inside' | 'outside';
+
+/**
+ * Image position for cropping
+ */
+export type CropPosition =
+  | 'center'
+  | 'top'
+  | 'right top'
+  | 'right'
+  | 'right bottom'
+  | 'bottom'
+  | 'left bottom'
+  | 'left'
+  | 'left top'
+  | 'attention'  // Focus on region with highest attention
+  | 'entropy';   // Focus on region with highest entropy
+
+/**
+ * Output format options
+ */
+export type OutputFormat = 'jpeg' | 'png' | 'webp' | 'avif';
+
+/**
+ * Resize options
+ */
+export interface ResizeOptions {
+  /** Target width */
+  width: number;
+  /** Target height */
+  height: number;
+  /** Resize mode (default: 'cover' for cropping to fill) */
+  mode?: ResizeMode;
+  /** Crop position when using 'cover' mode (default: 'attention') */
+  position?: CropPosition;
+  /** Output format (default: 'jpeg') */
+  format?: OutputFormat;
+  /** Quality for lossy formats (1-100, default: 85) */
+  quality?: number;
+  /** Background color for 'contain' mode (default: white) */
+  background?: { r: number; g: number; b: number; alpha?: number };
+  /** Whether to sharpen after resize (default: true) */
+  sharpen?: boolean;
+  /** Strip metadata (default: true) */
+  stripMetadata?: boolean;
+}
+
+/**
+ * Resize result
+ */
+export interface ResizeResult {
+  /** Resized image data as Buffer */
+  buffer: Buffer;
+  /** Output format */
+  format: OutputFormat;
+  /** Final width */
+  width: number;
+  /** Final height */
+  height: number;
+  /** File size in bytes */
+  size: number;
+  /** MIME type */
+  mimeType: string;
+}
+
+/**
+ * Batch resize result for multiple platforms
+ */
+export interface BatchResizeResult {
+  platformId: PlatformId;
+  dimension: PlatformDimension;
+  result: ResizeResult;
+}
+
+/**
+ * Get MIME type for output format
+ */
+function getMimeType(format: OutputFormat): string {
+  const mimeTypes: Record<OutputFormat, string> = {
+    jpeg: 'image/jpeg',
+    png: 'image/png',
+    webp: 'image/webp',
+    avif: 'image/avif',
+  };
+  return mimeTypes[format];
+}
+
+/**
+ * Map position string to Sharp position
+ */
+function getSharpPosition(position: CropPosition): string {
+  const positionMap: Record<CropPosition, string> = {
+    'center': 'center',
+    'top': 'top',
+    'right top': 'right top',
+    'right': 'right',
+    'right bottom': 'right bottom',
+    'bottom': 'bottom',
+    'left bottom': 'left bottom',
+    'left': 'left',
+    'left top': 'left top',
+    'attention': 'attention',
+    'entropy': 'entropy',
+  };
+  return positionMap[position];
+}
+
+/**
+ * Resize an image to specified dimensions
+ */
+export async function resizeImage(
+  input: Buffer | string,
+  options: ResizeOptions
+): Promise<ResizeResult> {
+  const {
+    width,
+    height,
+    mode = 'cover',
+    position = 'attention',
+    format = 'jpeg',
+    quality = 85,
+    background = { r: 255, g: 255, b: 255 },
+    sharpen = true,
+    stripMetadata = true,
+  } = options;
+
+  // Start with input
+  let pipeline = sharp(input);
+
+  // Get metadata first to check orientation
+  const metadata = await pipeline.metadata();
+
+  // Rotate based on EXIF orientation
+  pipeline = pipeline.rotate();
+
+  // Apply resize based on mode
+  switch (mode) {
+    case 'cover':
+      // Crop to fill the target dimensions
+      pipeline = pipeline.resize(width, height, {
+        fit: 'cover',
+        position: getSharpPosition(position),
+      });
+      break;
+
+    case 'contain':
+      // Fit within dimensions, add background
+      pipeline = pipeline.resize(width, height, {
+        fit: 'contain',
+        background,
+      });
+      break;
+
+    case 'fill':
+      // Stretch to fill (may distort)
+      pipeline = pipeline.resize(width, height, {
+        fit: 'fill',
+      });
+      break;
+
+    case 'inside':
+      // Fit inside, no upscaling
+      pipeline = pipeline.resize(width, height, {
+        fit: 'inside',
+        withoutEnlargement: true,
+      });
+      break;
+
+    case 'outside':
+      // Cover but allow overflow
+      pipeline = pipeline.resize(width, height, {
+        fit: 'outside',
+      });
+      break;
+  }
+
+  // Apply sharpening after resize
+  if (sharpen) {
+    pipeline = pipeline.sharpen({
+      sigma: 0.5,
+      m1: 0.5,
+      m2: 0.5,
+    });
+  }
+
+  // Strip metadata if requested
+  if (stripMetadata) {
+    pipeline = pipeline.withMetadata({});
+  } else if (metadata.orientation) {
+    // Keep other metadata but fix orientation
+    pipeline = pipeline.withMetadata({ orientation: 1 });
+  }
+
+  // Apply output format
+  switch (format) {
+    case 'jpeg':
+      pipeline = pipeline.jpeg({
+        quality,
+        mozjpeg: true, // Better compression
+      });
+      break;
+
+    case 'png':
+      pipeline = pipeline.png({
+        compressionLevel: 9,
+        palette: true,
+      });
+      break;
+
+    case 'webp':
+      pipeline = pipeline.webp({
+        quality,
+        effort: 6,
+      });
+      break;
+
+    case 'avif':
+      pipeline = pipeline.avif({
+        quality,
+        effort: 6,
+      });
+      break;
+  }
+
+  // Execute pipeline
+  const buffer = await pipeline.toBuffer();
+
+  return {
+    buffer,
+    format,
+    width,
+    height,
+    size: buffer.length,
+    mimeType: getMimeType(format),
+  };
+}
+
+/**
+ * Resize an image for a specific platform using recommended dimensions
+ */
+export async function resizeForPlatform(
+  input: Buffer | string,
+  platformId: PlatformId,
+  options: Partial<Omit<ResizeOptions, 'width' | 'height'>> = {}
+): Promise<ResizeResult> {
+  const dimension = getRecommendedDimension(platformId);
+  if (!dimension) {
+    throw new Error(`Unknown platform: ${platformId}`);
+  }
+
+  return resizeImage(input, {
+    width: dimension.width,
+    height: dimension.height,
+    ...options,
+  });
+}
+
+/**
+ * Resize an image for multiple platforms at once
+ */
+export async function resizeForPlatforms(
+  input: Buffer | string,
+  platformIds: PlatformId[],
+  options: Partial<Omit<ResizeOptions, 'width' | 'height'>> = {}
+): Promise<BatchResizeResult[]> {
+  const results: BatchResizeResult[] = [];
+
+  for (const platformId of platformIds) {
+    const dimension = getRecommendedDimension(platformId);
+    if (!dimension) continue;
+
+    const result = await resizeImage(input, {
+      width: dimension.width,
+      height: dimension.height,
+      ...options,
+    });
+
+    results.push({
+      platformId,
+      dimension,
+      result,
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Resize for all dimensions of a platform (not just recommended)
+ */
+export async function resizeForAllPlatformDimensions(
+  input: Buffer | string,
+  platformId: PlatformId,
+  options: Partial<Omit<ResizeOptions, 'width' | 'height'>> = {}
+): Promise<{ dimension: PlatformDimension; result: ResizeResult }[]> {
+  const spec = PLATFORM_SPECS[platformId];
+  if (!spec) {
+    throw new Error(`Unknown platform: ${platformId}`);
+  }
+
+  const results: { dimension: PlatformDimension; result: ResizeResult }[] = [];
+
+  for (const dimension of spec.dimensions) {
+    const result = await resizeImage(input, {
+      width: dimension.width,
+      height: dimension.height,
+      ...options,
+    });
+
+    results.push({ dimension, result });
+  }
+
+  return results;
+}
+
+/**
+ * Get image metadata without resizing
+ */
+export async function getImageMetadata(input: Buffer | string) {
+  const metadata = await sharp(input).metadata();
+  return {
+    width: metadata.width,
+    height: metadata.height,
+    format: metadata.format,
+    space: metadata.space,
+    channels: metadata.channels,
+    depth: metadata.depth,
+    hasAlpha: metadata.hasAlpha,
+    orientation: metadata.orientation,
+    size: metadata.size,
+  };
+}
+
+/**
+ * Calculate what dimensions an image will be after resizing
+ */
+export function calculateResizeDimensions(
+  originalWidth: number,
+  originalHeight: number,
+  targetWidth: number,
+  targetHeight: number,
+  mode: ResizeMode = 'cover'
+): { width: number; height: number } {
+  const originalRatio = originalWidth / originalHeight;
+  const targetRatio = targetWidth / targetHeight;
+
+  switch (mode) {
+    case 'cover':
+    case 'fill':
+      // Always returns exact target dimensions
+      return { width: targetWidth, height: targetHeight };
+
+    case 'contain':
+    case 'inside':
+      // Fit within target, maintaining aspect ratio
+      if (originalRatio > targetRatio) {
+        // Image is wider than target
+        return {
+          width: targetWidth,
+          height: Math.round(targetWidth / originalRatio),
+        };
+      } else {
+        // Image is taller than target
+        return {
+          width: Math.round(targetHeight * originalRatio),
+          height: targetHeight,
+        };
+      }
+
+    case 'outside':
+      // Cover target, maintaining aspect ratio
+      if (originalRatio > targetRatio) {
+        return {
+          width: Math.round(targetHeight * originalRatio),
+          height: targetHeight,
+        };
+      } else {
+        return {
+          width: targetWidth,
+          height: Math.round(targetWidth / originalRatio),
+        };
+      }
+
+    default:
+      return { width: targetWidth, height: targetHeight };
+  }
+}
+
+/**
+ * Create a thumbnail for preview
+ */
+export async function createThumbnail(
+  input: Buffer | string,
+  size: number = 200
+): Promise<ResizeResult> {
+  return resizeImage(input, {
+    width: size,
+    height: size,
+    mode: 'cover',
+    format: 'jpeg',
+    quality: 70,
+  });
+}
+
+/**
+ * Optimize an image without resizing (just compression)
+ */
+export async function optimizeImage(
+  input: Buffer | string,
+  options: {
+    format?: OutputFormat;
+    quality?: number;
+    stripMetadata?: boolean;
+  } = {}
+): Promise<ResizeResult> {
+  const { format = 'jpeg', quality = 85, stripMetadata = true } = options;
+
+  const metadata = await sharp(input).metadata();
+
+  let pipeline = sharp(input).rotate();
+
+  if (stripMetadata) {
+    pipeline = pipeline.withMetadata({});
+  }
+
+  switch (format) {
+    case 'jpeg':
+      pipeline = pipeline.jpeg({ quality, mozjpeg: true });
+      break;
+    case 'png':
+      pipeline = pipeline.png({ compressionLevel: 9 });
+      break;
+    case 'webp':
+      pipeline = pipeline.webp({ quality });
+      break;
+    case 'avif':
+      pipeline = pipeline.avif({ quality });
+      break;
+  }
+
+  const buffer = await pipeline.toBuffer();
+
+  return {
+    buffer,
+    format,
+    width: metadata.width || 0,
+    height: metadata.height || 0,
+    size: buffer.length,
+    mimeType: getMimeType(format),
+  };
+}

--- a/lib/export/index.ts
+++ b/lib/export/index.ts
@@ -1,0 +1,17 @@
+/**
+ * V1a Export System
+ *
+ * Platform-ready content export utilities for multi-platform management.
+ */
+
+// Platform specifications and constants
+export * from './platform-specs';
+
+// Caption formatting and variable replacement
+export * from './caption-formatter';
+
+// ZIP generation for batch exports
+export * from './zip-generator';
+
+// Image resizing for platform-specific dimensions
+export * from './image-resizer';

--- a/lib/export/platform-specs.ts
+++ b/lib/export/platform-specs.ts
@@ -1,0 +1,289 @@
+/**
+ * V1a Platform Specs - Dimension configurations for platform-ready exports
+ *
+ * These specs define the optimal image dimensions for each platform,
+ * ensuring content is formatted correctly for maximum engagement.
+ */
+
+export type PlatformId =
+  | 'onlyfans'
+  | 'fansly'
+  | 'fanvue'
+  | 'instagram-posts'
+  | 'instagram-stories'
+  | 'instagram-reels'
+  | 'twitter'
+  | 'tiktok';
+
+export type AspectRatio = '3:4' | '4:3' | '4:5' | '1:1' | '9:16' | '16:9';
+
+export interface PlatformDimension {
+  width: number;
+  height: number;
+  aspectRatio: AspectRatio;
+  label: string;
+  recommended?: boolean;
+}
+
+export interface PlatformSpec {
+  id: PlatformId;
+  name: string;
+  shortName: string;
+  icon: string; // Lucide icon name
+  color: string; // Tailwind color
+  dimensions: PlatformDimension[];
+  captionLimits: {
+    maxLength: number;
+    hashtagLimit?: number;
+    mentionLimit?: number;
+  };
+  fileFormats: string[];
+  maxFileSize: number; // in MB
+  notes?: string;
+}
+
+export const PLATFORM_SPECS: Record<PlatformId, PlatformSpec> = {
+  'onlyfans': {
+    id: 'onlyfans',
+    name: 'OnlyFans',
+    shortName: 'OF',
+    icon: 'Heart',
+    color: 'blue',
+    dimensions: [
+      { width: 1200, height: 1600, aspectRatio: '3:4', label: 'Portrait (3:4)', recommended: true },
+      { width: 1600, height: 1200, aspectRatio: '4:3', label: 'Landscape (4:3)' },
+      { width: 1200, height: 1200, aspectRatio: '1:1', label: 'Square (1:1)' },
+    ],
+    captionLimits: {
+      maxLength: 1000,
+    },
+    fileFormats: ['jpg', 'jpeg', 'png', 'gif', 'mp4'],
+    maxFileSize: 50,
+    notes: 'Portrait format performs best for feed content',
+  },
+
+  'fansly': {
+    id: 'fansly',
+    name: 'Fansly',
+    shortName: 'Fansly',
+    icon: 'Star',
+    color: 'cyan',
+    dimensions: [
+      { width: 1200, height: 1600, aspectRatio: '3:4', label: 'Portrait (3:4)', recommended: true },
+      { width: 1600, height: 1200, aspectRatio: '4:3', label: 'Landscape (4:3)' },
+      { width: 1200, height: 1200, aspectRatio: '1:1', label: 'Square (1:1)' },
+    ],
+    captionLimits: {
+      maxLength: 1000,
+    },
+    fileFormats: ['jpg', 'jpeg', 'png', 'gif', 'mp4'],
+    maxFileSize: 50,
+    notes: 'Similar specs to OnlyFans',
+  },
+
+  'fanvue': {
+    id: 'fanvue',
+    name: 'Fanvue',
+    shortName: 'Fanvue',
+    icon: 'Sparkles',
+    color: 'purple',
+    dimensions: [
+      { width: 1200, height: 1600, aspectRatio: '3:4', label: 'Portrait (3:4)', recommended: true },
+      { width: 1600, height: 1200, aspectRatio: '4:3', label: 'Landscape (4:3)' },
+      { width: 1200, height: 1200, aspectRatio: '1:1', label: 'Square (1:1)' },
+    ],
+    captionLimits: {
+      maxLength: 1000,
+    },
+    fileFormats: ['jpg', 'jpeg', 'png', 'gif', 'mp4'],
+    maxFileSize: 50,
+    notes: 'Similar specs to OnlyFans',
+  },
+
+  'instagram-posts': {
+    id: 'instagram-posts',
+    name: 'Instagram Posts',
+    shortName: 'IG Posts',
+    icon: 'Instagram',
+    color: 'pink',
+    dimensions: [
+      { width: 1080, height: 1350, aspectRatio: '4:5', label: 'Portrait (4:5)', recommended: true },
+      { width: 1080, height: 1080, aspectRatio: '1:1', label: 'Square (1:1)' },
+    ],
+    captionLimits: {
+      maxLength: 2200,
+      hashtagLimit: 30,
+      mentionLimit: 20,
+    },
+    fileFormats: ['jpg', 'jpeg', 'png'],
+    maxFileSize: 8,
+    notes: '4:5 portrait takes up more screen space in feed',
+  },
+
+  'instagram-stories': {
+    id: 'instagram-stories',
+    name: 'Instagram Stories',
+    shortName: 'IG Stories',
+    icon: 'Circle',
+    color: 'pink',
+    dimensions: [
+      { width: 1080, height: 1920, aspectRatio: '9:16', label: 'Full Screen (9:16)', recommended: true },
+    ],
+    captionLimits: {
+      maxLength: 2200,
+      hashtagLimit: 10,
+    },
+    fileFormats: ['jpg', 'jpeg', 'png', 'mp4'],
+    maxFileSize: 8,
+    notes: 'Keep important content in center 1080x1420 safe zone',
+  },
+
+  'instagram-reels': {
+    id: 'instagram-reels',
+    name: 'Instagram Reels',
+    shortName: 'IG Reels',
+    icon: 'Play',
+    color: 'pink',
+    dimensions: [
+      { width: 1080, height: 1920, aspectRatio: '9:16', label: 'Full Screen (9:16)', recommended: true },
+    ],
+    captionLimits: {
+      maxLength: 2200,
+      hashtagLimit: 30,
+    },
+    fileFormats: ['mp4'],
+    maxFileSize: 650,
+    notes: 'Videos up to 90 seconds',
+  },
+
+  'twitter': {
+    id: 'twitter',
+    name: 'Twitter / X',
+    shortName: 'X',
+    icon: 'Twitter',
+    color: 'slate',
+    dimensions: [
+      { width: 1200, height: 675, aspectRatio: '16:9', label: 'Landscape (16:9)', recommended: true },
+      { width: 1200, height: 1200, aspectRatio: '1:1', label: 'Square (1:1)' },
+    ],
+    captionLimits: {
+      maxLength: 280,
+      hashtagLimit: 2, // Best practice, not enforced
+    },
+    fileFormats: ['jpg', 'jpeg', 'png', 'gif', 'mp4'],
+    maxFileSize: 15,
+    notes: 'Keep tweets concise; 1-2 hashtags max for engagement',
+  },
+
+  'tiktok': {
+    id: 'tiktok',
+    name: 'TikTok',
+    shortName: 'TikTok',
+    icon: 'Music',
+    color: 'rose',
+    dimensions: [
+      { width: 1080, height: 1920, aspectRatio: '9:16', label: 'Full Screen (9:16)', recommended: true },
+    ],
+    captionLimits: {
+      maxLength: 4000,
+      hashtagLimit: 5, // Best practice
+    },
+    fileFormats: ['mp4'],
+    maxFileSize: 287,
+    notes: 'Videos perform best; 3-5 relevant hashtags',
+  },
+};
+
+/**
+ * Get all platforms as an array for iteration
+ */
+export function getAllPlatforms(): PlatformSpec[] {
+  return Object.values(PLATFORM_SPECS);
+}
+
+/**
+ * Get platform spec by ID
+ */
+export function getPlatformSpec(platformId: PlatformId): PlatformSpec | undefined {
+  return PLATFORM_SPECS[platformId];
+}
+
+/**
+ * Get recommended dimension for a platform
+ */
+export function getRecommendedDimension(platformId: PlatformId): PlatformDimension | undefined {
+  const spec = PLATFORM_SPECS[platformId];
+  if (!spec) return undefined;
+  return spec.dimensions.find(d => d.recommended) || spec.dimensions[0];
+}
+
+/**
+ * Get all platforms grouped by category
+ */
+export function getPlatformsByCategory() {
+  return {
+    subscription: [
+      PLATFORM_SPECS['onlyfans'],
+      PLATFORM_SPECS['fansly'],
+      PLATFORM_SPECS['fanvue'],
+    ],
+    social: [
+      PLATFORM_SPECS['instagram-posts'],
+      PLATFORM_SPECS['instagram-stories'],
+      PLATFORM_SPECS['instagram-reels'],
+      PLATFORM_SPECS['twitter'],
+      PLATFORM_SPECS['tiktok'],
+    ],
+  };
+}
+
+/**
+ * Platform-specific folder names for export ZIP structure
+ */
+export const PLATFORM_FOLDER_NAMES: Record<PlatformId, string> = {
+  'onlyfans': 'OnlyFans',
+  'fansly': 'Fansly',
+  'fanvue': 'Fanvue',
+  'instagram-posts': 'Instagram-Posts',
+  'instagram-stories': 'Instagram-Stories',
+  'instagram-reels': 'Instagram-Reels',
+  'twitter': 'Twitter',
+  'tiktok': 'TikTok',
+};
+
+/**
+ * Content type definitions for two-axis tagging
+ * Axis 1: What's in the content
+ */
+export const CONTENT_TYPES = [
+  { id: 'solo', label: 'Solo', description: 'Single person content' },
+  { id: 'bg', label: 'B/G', description: 'Boy/Girl content' },
+  { id: 'gg', label: 'G/G', description: 'Girl/Girl content' },
+  { id: 'anal', label: 'Anal', description: 'Anal content' },
+  { id: 'squirting', label: 'Squirting', description: 'Squirting content' },
+  { id: 'bundles', label: 'Bundles', description: 'Bundle/set content' },
+  { id: 'bts', label: 'BTS', description: 'Behind the scenes' },
+  { id: 'tease', label: 'Tease', description: 'Teaser content' },
+  { id: 'explicit', label: 'Explicit', description: 'Explicit content' },
+  { id: 'sfw', label: 'SFW', description: 'Safe for work content' },
+] as const;
+
+/**
+ * Message type definitions for two-axis tagging
+ * Axis 2: Operational purpose of the message
+ */
+export const MESSAGE_TYPES = [
+  { id: 'bundle_unlock', label: 'Bundle Unlock', description: 'Promoting bundle purchases' },
+  { id: 'tip_me', label: 'Tip Me', description: 'Tip request messages' },
+  { id: 'mass_message', label: 'Mass Message', description: 'Broadcast to all subscribers' },
+  { id: 'dm_funnel', label: 'DM Funnel', description: 'Direct message conversation starters' },
+  { id: 'wall_bump', label: 'Wall Bump', description: 'Wall/feed post engagement' },
+  { id: 'renew', label: 'Renew', description: 'Subscription renewal prompts' },
+  { id: 'welcome', label: 'Welcome', description: 'New subscriber welcome messages' },
+  { id: 'promo', label: 'Promo', description: 'Promotional content' },
+  { id: 'engagement', label: 'Engagement', description: 'Engagement-focused content' },
+  { id: 'custom', label: 'Custom', description: 'Custom request responses' },
+] as const;
+
+export type ContentTypeId = typeof CONTENT_TYPES[number]['id'];
+export type MessageTypeId = typeof MESSAGE_TYPES[number]['id'];

--- a/lib/export/zip-generator.ts
+++ b/lib/export/zip-generator.ts
@@ -1,0 +1,378 @@
+/**
+ * V1a ZIP Generator - Create platform-ready export packages
+ *
+ * Generates structured ZIP files with content organized by platform,
+ * including properly sized images and caption.txt files.
+ */
+
+import JSZip from 'jszip';
+import { PlatformId, PLATFORM_FOLDER_NAMES } from './platform-specs';
+
+/**
+ * Content item to include in the export
+ */
+export interface ExportContentItem {
+  /** Original filename */
+  filename: string;
+  /** File data as Buffer, Blob, or base64 string */
+  data: Buffer | Blob | string;
+  /** MIME type */
+  mimeType: string;
+  /** Caption text (will be written to caption.txt) */
+  caption?: string;
+  /** Optional metadata to include */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Platform export configuration
+ */
+export interface PlatformExportConfig {
+  platformId: PlatformId;
+  /** Content items for this platform (already resized) */
+  items: ExportContentItem[];
+  /** Optional subfolder within the platform folder */
+  subfolder?: string;
+}
+
+/**
+ * Export package configuration
+ */
+export interface ExportPackageConfig {
+  /** Name for the export (used in ZIP filename and root folder) */
+  name: string;
+  /** Platform configurations */
+  platforms: PlatformExportConfig[];
+  /** Include a manifest.json with export details */
+  includeManifest?: boolean;
+  /** Optional model name for the manifest */
+  modelName?: string;
+  /** Compression level (0-9, default 6) */
+  compressionLevel?: number;
+}
+
+/**
+ * Export result with ZIP data and metadata
+ */
+export interface ExportResult {
+  /** ZIP file as Blob */
+  blob: Blob;
+  /** ZIP file as Buffer (for server-side) */
+  buffer: Buffer;
+  /** Suggested filename */
+  filename: string;
+  /** Total number of files in the ZIP */
+  fileCount: number;
+  /** Total uncompressed size in bytes */
+  totalSize: number;
+  /** Platforms included */
+  platforms: PlatformId[];
+  /** Manifest data if included */
+  manifest?: ExportManifest;
+}
+
+/**
+ * Manifest structure for export tracking
+ */
+export interface ExportManifest {
+  version: string;
+  exportedAt: string;
+  exportName: string;
+  modelName?: string;
+  platforms: {
+    platformId: PlatformId;
+    folderName: string;
+    itemCount: number;
+    items: {
+      filename: string;
+      hasCaption: boolean;
+    }[];
+  }[];
+  totalItems: number;
+}
+
+/**
+ * Generate a clean filename from the export name
+ */
+function sanitizeFilename(name: string): string {
+  return name
+    .replace(/[^a-zA-Z0-9\s-_]/g, '')
+    .replace(/\s+/g, '-')
+    .toLowerCase();
+}
+
+/**
+ * Get file extension from filename or mime type
+ */
+function getExtension(filename: string, mimeType?: string): string {
+  const fromFilename = filename.split('.').pop()?.toLowerCase();
+  if (fromFilename && fromFilename.length <= 4) {
+    return fromFilename;
+  }
+
+  // Fallback to mime type
+  const mimeExtensions: Record<string, string> = {
+    'image/jpeg': 'jpg',
+    'image/png': 'png',
+    'image/gif': 'gif',
+    'image/webp': 'webp',
+    'video/mp4': 'mp4',
+    'video/quicktime': 'mov',
+  };
+
+  return mimeType ? mimeExtensions[mimeType] || 'bin' : 'bin';
+}
+
+/**
+ * Convert various data formats to Uint8Array for JSZip
+ */
+async function toUint8Array(data: Buffer | Blob | string): Promise<Uint8Array> {
+  if (Buffer.isBuffer(data)) {
+    return new Uint8Array(data);
+  }
+
+  if (data instanceof Blob) {
+    const arrayBuffer = await data.arrayBuffer();
+    return new Uint8Array(arrayBuffer);
+  }
+
+  // Assume base64 string
+  if (typeof data === 'string') {
+    // Remove data URL prefix if present
+    const base64 = data.replace(/^data:[^;]+;base64,/, '');
+    const binaryString = atob(base64);
+    const bytes = new Uint8Array(binaryString.length);
+    for (let i = 0; i < binaryString.length; i++) {
+      bytes[i] = binaryString.charCodeAt(i);
+    }
+    return bytes;
+  }
+
+  throw new Error('Unsupported data format');
+}
+
+/**
+ * Create a manifest for the export
+ */
+function createManifest(config: ExportPackageConfig): ExportManifest {
+  const platforms = config.platforms.map(p => ({
+    platformId: p.platformId,
+    folderName: PLATFORM_FOLDER_NAMES[p.platformId],
+    itemCount: p.items.length,
+    items: p.items.map(item => ({
+      filename: item.filename,
+      hasCaption: !!item.caption,
+    })),
+  }));
+
+  return {
+    version: '1.0',
+    exportedAt: new Date().toISOString(),
+    exportName: config.name,
+    modelName: config.modelName,
+    platforms,
+    totalItems: platforms.reduce((sum, p) => sum + p.itemCount, 0),
+  };
+}
+
+/**
+ * Generate a platform-ready export ZIP package
+ */
+export async function generateExportZip(config: ExportPackageConfig): Promise<ExportResult> {
+  const zip = new JSZip();
+  const rootFolder = sanitizeFilename(config.name) || 'export';
+  const compressionLevel = config.compressionLevel ?? 6;
+
+  let fileCount = 0;
+  let totalSize = 0;
+  const includedPlatforms: PlatformId[] = [];
+
+  // Create root folder
+  const root = zip.folder(rootFolder);
+  if (!root) {
+    throw new Error('Failed to create root folder in ZIP');
+  }
+
+  // Process each platform
+  for (const platformConfig of config.platforms) {
+    const { platformId, items, subfolder } = platformConfig;
+
+    if (items.length === 0) continue;
+
+    includedPlatforms.push(platformId);
+    const platformFolderName = PLATFORM_FOLDER_NAMES[platformId];
+
+    // Create platform folder path
+    let platformFolder = root.folder(platformFolderName);
+    if (!platformFolder) continue;
+
+    // Add subfolder if specified
+    if (subfolder) {
+      platformFolder = platformFolder.folder(subfolder);
+      if (!platformFolder) continue;
+    }
+
+    // Track captions for this platform folder
+    const captions: string[] = [];
+
+    // Add each content item
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      const ext = getExtension(item.filename, item.mimeType);
+
+      // Generate sequential filename: image-001.jpg, image-002.jpg, etc.
+      const paddedIndex = String(i + 1).padStart(3, '0');
+      const newFilename = `image-${paddedIndex}.${ext}`;
+
+      // Convert and add file data
+      const fileData = await toUint8Array(item.data);
+      platformFolder.file(newFilename, fileData, {
+        compression: 'DEFLATE',
+        compressionOptions: { level: compressionLevel },
+      });
+
+      fileCount++;
+      totalSize += fileData.length;
+
+      // Collect caption
+      if (item.caption) {
+        captions.push(`[${newFilename}]\n${item.caption}`);
+      }
+    }
+
+    // Add combined caption.txt file for this platform
+    if (captions.length > 0) {
+      const captionContent = captions.join('\n\n---\n\n');
+      const header = `Captions for ${platformFolderName}\nExported: ${new Date().toLocaleString()}\nTotal items: ${items.length}\n${'='.repeat(50)}\n\n`;
+      platformFolder.file('captions.txt', header + captionContent);
+      fileCount++;
+    }
+  }
+
+  // Add manifest if requested
+  let manifest: ExportManifest | undefined;
+  if (config.includeManifest) {
+    manifest = createManifest(config);
+    root.file('manifest.json', JSON.stringify(manifest, null, 2));
+    fileCount++;
+  }
+
+  // Add a README
+  const readmeContent = `# ${config.name} Export
+
+Exported: ${new Date().toLocaleString()}
+${config.modelName ? `Model: ${config.modelName}` : ''}
+
+## Contents
+
+${includedPlatforms.map(p => `- ${PLATFORM_FOLDER_NAMES[p]}/`).join('\n')}
+
+## Usage
+
+Each platform folder contains:
+- Resized images optimized for that platform
+- captions.txt with suggested captions for each image
+
+---
+Generated by Tastyy.AI Platform Export
+`;
+
+  root.file('README.txt', readmeContent);
+  fileCount++;
+
+  // Generate the ZIP
+  const blob = await zip.generateAsync({
+    type: 'blob',
+    compression: 'DEFLATE',
+    compressionOptions: { level: compressionLevel },
+  });
+
+  const arrayBuffer = await blob.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+
+  // Generate filename with timestamp
+  const timestamp = new Date().toISOString().split('T')[0];
+  const filename = `${rootFolder}-${timestamp}.zip`;
+
+  return {
+    blob,
+    buffer,
+    filename,
+    fileCount,
+    totalSize,
+    platforms: includedPlatforms,
+    manifest,
+  };
+}
+
+/**
+ * Generate a simple ZIP with files (no platform organization)
+ */
+export async function generateSimpleZip(
+  files: { filename: string; data: Buffer | Blob | string }[],
+  zipName: string = 'export'
+): Promise<{ blob: Blob; buffer: Buffer; filename: string }> {
+  const zip = new JSZip();
+
+  for (const file of files) {
+    const fileData = await toUint8Array(file.data);
+    zip.file(file.filename, fileData);
+  }
+
+  const blob = await zip.generateAsync({
+    type: 'blob',
+    compression: 'DEFLATE',
+  });
+
+  const arrayBuffer = await blob.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+  const filename = `${sanitizeFilename(zipName)}.zip`;
+
+  return { blob, buffer, filename };
+}
+
+/**
+ * Add files to an existing JSZip instance (for streaming/chunked exports)
+ */
+export function createZipBuilder() {
+  const zip = new JSZip();
+  let fileCount = 0;
+
+  return {
+    /**
+     * Add a file to the ZIP
+     */
+    async addFile(path: string, data: Buffer | Blob | string) {
+      const fileData = await toUint8Array(data);
+      zip.file(path, fileData);
+      fileCount++;
+    },
+
+    /**
+     * Add a folder
+     */
+    addFolder(path: string) {
+      return zip.folder(path);
+    },
+
+    /**
+     * Generate the final ZIP
+     */
+    async generate(): Promise<{ blob: Blob; buffer: Buffer; fileCount: number }> {
+      const blob = await zip.generateAsync({
+        type: 'blob',
+        compression: 'DEFLATE',
+      });
+      const arrayBuffer = await blob.arrayBuffer();
+      const buffer = Buffer.from(arrayBuffer);
+      return { blob, buffer, fileCount };
+    },
+
+    /**
+     * Get current file count
+     */
+    getFileCount() {
+      return fileCount;
+    },
+  };
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -47,6 +47,7 @@ const isPublicApiRoute = createRouteMatcher([
   '/api/cron(.*)', // ✅ Add cron routes as public (protected by CRON_SECRET)
   '/api/sexting-sets(.*)', // ✅ Add sexting sets routes (handle their own auth)
   '/api/sexting-sets/media(.*)', // ✅ Add sexting sets media proxy as public
+  '/api/export/platform-ready', // ✅ V1a: Platform specs endpoint (GET only returns public config)
 ]);
 
 // ✅ Special handling for API routes that need custom auth


### PR DESCRIPTION
…on templates

- Add PlatformExportModal with multi-platform selection (OnlyFans, Instagram, Fansly, etc.)
- Implement platform-specific image resizing with optimal dimensions
- Add caption template system with variable substitution (model_name, price, etc.)
- Create ZIP generator with organized platform folders and manifest
- Add Caption Bank dropdown to select from saved captions per profile
- Integrate export modal into Vault and Generated Content pages