### PR TITLE
feat: Add pricing templates and enhanced OF model pricing management

### DIFF
--- a/app/[tenant]/(dashboard)/of-models/[modelSlug]/assets/page.tsx
+++ b/app/[tenant]/(dashboard)/of-models/[modelSlug]/assets/page.tsx
@@ -52,7 +52,7 @@ const assetTypeConfig: Record<string, { icon: React.ComponentType<any>; color: s
 
 export default function OfModelAssetsPage() {
   const params = useParams();
-  const slug = params.slug as string;
+  const modelSlug = params.modelSlug as string;
   const [model, setModel] = useState<OfModel | null>(null);
   const [assets, setAssets] = useState<Asset[]>([]);
   const [loading, setLoading] = useState(true);
@@ -62,14 +62,14 @@ export default function OfModelAssetsPage() {
   const [showAddModal, setShowAddModal] = useState(false);
 
   useEffect(() => {
-    if (slug) {
+    if (modelSlug) {
       loadModel();
     }
-  }, [slug]);
+  }, [modelSlug]);
 
   const loadModel = async () => {
     try {
-      const response = await fetch(`/api/of-models/`);
+      const response = await fetch(`/api/of-models/${modelSlug}`);
       if (response.ok) {
         const result = await response.json();
         setModel(result.data);

--- a/app/[tenant]/(dashboard)/of-models/[modelSlug]/details/page.tsx
+++ b/app/[tenant]/(dashboard)/of-models/[modelSlug]/details/page.tsx
@@ -148,21 +148,21 @@ function Section({
 
 export default function OfModelDetailsPage() {
   const params = useParams();
-  const slug = params.slug as string;
+  const modelSlug = params.modelSlug as string;
   const [model, setModel] = useState<OfModel | null>(null);
   const [details, setDetails] = useState<OfModelDetails | null>(null);
   const [loading, setLoading] = useState(true);
   const [showEditModal, setShowEditModal] = useState(false);
 
   useEffect(() => {
-    if (slug) {
+    if (modelSlug) {
       loadModel();
     }
-  }, [slug]);
+  }, [modelSlug]);
 
   const loadModel = async () => {
     try {
-      const response = await fetch(`/api/of-models/`);
+      const response = await fetch(`/api/of-models/${modelSlug}`);
       if (response.ok) {
         const result = await response.json();
         setModel(result.data);

--- a/app/[tenant]/(dashboard)/of-models/[modelSlug]/layout.tsx
+++ b/app/[tenant]/(dashboard)/of-models/[modelSlug]/layout.tsx
@@ -117,35 +117,35 @@ export default function OfModelLayout({
 }) {
   const params = useParams();
   const pathname = usePathname();
-  const slug = params.slug as string;
+  const modelSlug = params.modelSlug as string;
   const [model, setModel] = useState<OfModel | null>(null);
   const [loading, setLoading] = useState(true);
 
   const storeModel = useOfModelStore((state) => state.selectedModel);
 
   useEffect(() => {
-    if (slug) {
+    if (modelSlug) {
       loadModel();
     }
-  }, [slug]);
+  }, [modelSlug]);
 
   const loadModel = async () => {
     try {
       setLoading(true);
-      const response = await fetch(`/api/of-models/`);
+      const response = await fetch(`/api/of-models/${modelSlug}`);
       if (response.ok) {
         const result = await response.json();
         setModel(result.data);
       } else {
         const error = await response.json().catch(() => ({ error: 'Unknown error' }));
         console.error('API error loading model:', response.status, error);
-        if (storeModel && storeModel.slug === slug) {
+        if (storeModel && storeModel.slug === modelSlug) {
           setModel(storeModel as OfModel);
         }
       }
     } catch (error) {
       console.error('Error loading model:', error);
-      if (storeModel && storeModel.slug === slug) {
+      if (storeModel && storeModel.slug === modelSlug) {
         setModel(storeModel as OfModel);
       }
     } finally {
@@ -153,11 +153,14 @@ export default function OfModelLayout({
     }
   };
 
+  // Build base path from current pathname (strips any sub-route like /pricing, /assets, /details)
+  const basePath = pathname.replace(/\/(pricing|assets|details)$/, '');
+
   const tabs = [
-    { name: 'Overview', href: `/of-models/`, icon: User, exact: true },
-    { name: 'Pricing', href: `/of-models//pricing`, icon: DollarSign },
-    { name: 'Assets', href: `/of-models//assets`, icon: Image },
-    { name: 'Details', href: `/of-models//details`, icon: FileText },
+    { name: 'Overview', href: basePath, icon: User, exact: true },
+    { name: 'Pricing', href: `${basePath}/pricing`, icon: DollarSign },
+    { name: 'Assets', href: `${basePath}/assets`, icon: Image },
+    { name: 'Details', href: `${basePath}/details`, icon: FileText },
   ];
 
   const isActive = (tab: { href: string; exact?: boolean }) => {
@@ -213,7 +216,7 @@ export default function OfModelLayout({
         </div>
         <div className="relative z-10 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
           <Link
-            href="/of-models"
+            href="../"
             className="inline-flex items-center gap-2 text-sm text-zinc-500 hover:text-white transition-colors mb-8"
           >
             <ChevronLeft className="w-4 h-4" />
@@ -229,7 +232,7 @@ export default function OfModelLayout({
               The model you're looking for doesn't exist or has been removed.
             </p>
             <Link
-              href="/of-models"
+              href="../"
               className="group relative inline-flex items-center gap-2 px-6 py-3 rounded-xl font-medium text-white overflow-hidden"
             >
               <div className="absolute inset-0 bg-gradient-to-r from-violet-600 to-fuchsia-600" />
@@ -258,7 +261,7 @@ export default function OfModelLayout({
       <div className="relative z-10 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Back Button */}
         <Link
-          href="/of-models"
+          href="../"
           className="inline-flex items-center gap-2 text-sm text-zinc-500 hover:text-white transition-colors mb-8 group"
         >
           <ChevronLeft className="w-4 h-4 group-hover:-translate-x-1 transition-transform" />

--- a/app/[tenant]/(dashboard)/of-models/[modelSlug]/pricing/page.tsx
+++ b/app/[tenant]/(dashboard)/of-models/[modelSlug]/pricing/page.tsx
@@ -18,12 +18,19 @@ import {
   Package,
   Sparkles,
   AlertCircle,
+  FileText,
+  Download,
+  Check,
 } from 'lucide-react';
 
 interface PricingItem {
   id: string;
   name: string;
   price: number;
+  priceType: 'FIXED' | 'RANGE' | 'MINIMUM';
+  priceMin: number | null;
+  priceMax: number | null;
+  isFree: boolean;
   description: string | null;
   order: number;
   isActive: boolean;
@@ -35,6 +42,7 @@ interface PricingCategory {
   slug: string;
   description: string | null;
   order: number;
+  isGlobal: boolean;
   items: PricingItem[];
 }
 
@@ -45,7 +53,7 @@ interface OfModel {
 
 export default function OfModelPricingPage() {
   const params = useParams();
-  const slug = params.slug as string;
+  const modelSlug = params.modelSlug as string;
   const [model, setModel] = useState<OfModel | null>(null);
   const [categories, setCategories] = useState<PricingCategory[]>([]);
   const [loading, setLoading] = useState(true);
@@ -56,16 +64,17 @@ export default function OfModelPricingPage() {
   const [showEditItemModal, setShowEditItemModal] = useState(false);
   const [selectedCategory, setSelectedCategory] = useState<PricingCategory | null>(null);
   const [selectedItem, setSelectedItem] = useState<PricingItem | null>(null);
+  const [showApplyTemplateModal, setShowApplyTemplateModal] = useState(false);
 
   useEffect(() => {
-    if (slug) {
+    if (modelSlug) {
       loadModelAndPricing();
     }
-  }, [slug]);
+  }, [modelSlug]);
 
   const loadModelAndPricing = async () => {
     try {
-      const response = await fetch(`/api/of-models/`);
+      const response = await fetch(`/api/of-models/${modelSlug}`);
       if (response.ok) {
         const result = await response.json();
         setModel(result.data);
@@ -216,15 +225,24 @@ export default function OfModelPricingPage() {
               <p className="text-sm text-zinc-500">Manage pricing categories and items</p>
             </div>
           </div>
-          <button
-            onClick={() => setShowAddCategoryModal(true)}
-            className="group relative inline-flex items-center gap-2 px-4 py-2.5 rounded-xl font-medium text-white overflow-hidden transition-all"
-          >
-            <div className="absolute inset-0 bg-gradient-to-r from-violet-600 to-fuchsia-600" />
-            <div className="absolute inset-0 bg-gradient-to-r from-violet-500 to-fuchsia-500 opacity-0 group-hover:opacity-100 transition-opacity" />
-            <Plus className="relative w-4 h-4" />
-            <span className="relative text-sm">Add Category</span>
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setShowApplyTemplateModal(true)}
+              className="group inline-flex items-center gap-2 px-4 py-2.5 rounded-xl font-medium text-white bg-zinc-800/80 border border-zinc-700/50 hover:border-violet-500/50 hover:bg-zinc-800 transition-all"
+            >
+              <FileText className="w-4 h-4 text-violet-400" />
+              <span className="text-sm">Apply Template</span>
+            </button>
+            <button
+              onClick={() => setShowAddCategoryModal(true)}
+              className="group relative inline-flex items-center gap-2 px-4 py-2.5 rounded-xl font-medium text-white overflow-hidden transition-all"
+            >
+              <div className="absolute inset-0 bg-gradient-to-r from-violet-600 to-fuchsia-600" />
+              <div className="absolute inset-0 bg-gradient-to-r from-violet-500 to-fuchsia-500 opacity-0 group-hover:opacity-100 transition-opacity" />
+              <Plus className="relative w-4 h-4" />
+              <span className="relative text-sm">Add Category</span>
+            </button>
+          </div>
         </div>
 
         {/* Categories */}
@@ -268,7 +286,14 @@ export default function OfModelPricingPage() {
                   </div>
 
                   <div className="flex-1 min-w-0">
-                    <h3 className="font-medium text-white">{category.name}</h3>
+                    <div className="flex items-center gap-2">
+                      <h3 className="font-medium text-white">{category.name}</h3>
+                      {category.isGlobal && (
+                        <span className="px-2 py-0.5 bg-blue-500/20 rounded text-[10px] font-medium text-blue-400 uppercase border border-blue-500/30">
+                          Global
+                        </span>
+                      )}
+                    </div>
                     {category.description && (
                       <p className="text-sm text-zinc-500 truncate">{category.description}</p>
                     )}
@@ -345,6 +370,16 @@ export default function OfModelPricingPage() {
                               <span className={`font-medium ${item.isActive ? 'text-white' : 'text-zinc-500'}`}>
                                 {item.name}
                               </span>
+                              {item.isFree && (
+                                <span className="px-2 py-0.5 bg-emerald-500/20 rounded text-[10px] font-medium text-emerald-400 uppercase border border-emerald-500/30">
+                                  Free
+                                </span>
+                              )}
+                              {!item.isFree && item.priceType !== 'FIXED' && (
+                                <span className="px-2 py-0.5 bg-zinc-800/50 rounded text-[10px] font-medium text-zinc-400 uppercase">
+                                  {item.priceType}
+                                </span>
+                              )}
                               {!item.isActive && (
                                 <span className="px-2 py-0.5 bg-zinc-800/50 rounded text-[10px] font-medium text-zinc-500 uppercase">
                                   Inactive
@@ -357,7 +392,15 @@ export default function OfModelPricingPage() {
                           </div>
 
                           <div className="text-lg font-semibold text-emerald-400">
-                            ${item.price.toFixed(2)}
+                            {item.isFree ? (
+                              'FREE'
+                            ) : item.priceType === 'RANGE' && item.priceMin !== null && item.priceMax !== null ? (
+                              `$${item.priceMin.toFixed(2)} - $${item.priceMax.toFixed(2)}`
+                            ) : item.priceType === 'MINIMUM' && item.priceMin !== null ? (
+                              `From $${item.priceMin.toFixed(2)}`
+                            ) : (
+                              `$${item.price.toFixed(2)}`
+                            )}
                           </div>
 
                           <div className="flex items-center gap-1">
@@ -449,6 +492,17 @@ export default function OfModelPricingPage() {
             setShowEditItemModal(false);
             setSelectedCategory(null);
             setSelectedItem(null);
+            loadPricing(model.id);
+          }}
+        />
+      )}
+
+      {showApplyTemplateModal && model && (
+        <ApplyTemplateModal
+          modelId={model.id}
+          onClose={() => setShowApplyTemplateModal(false)}
+          onSuccess={() => {
+            setShowApplyTemplateModal(false);
             loadPricing(model.id);
           }}
         />
@@ -628,6 +682,10 @@ function ItemModal({
   const isEdit = !!item;
   const [name, setName] = useState(item?.name || '');
   const [price, setPrice] = useState(item?.price.toString() || '');
+  const [priceType, setPriceType] = useState<'FIXED' | 'RANGE' | 'MINIMUM'>(item?.priceType || 'FIXED');
+  const [priceMin, setPriceMin] = useState(item?.priceMin?.toString() || '');
+  const [priceMax, setPriceMax] = useState(item?.priceMax?.toString() || '');
+  const [isFree, setIsFree] = useState(item?.isFree ?? false);
   const [description, setDescription] = useState(item?.description || '');
   const [isActive, setIsActive] = useState(item?.isActive ?? true);
   const [saving, setSaving] = useState(false);
@@ -651,7 +709,11 @@ function ItemModal({
         body: JSON.stringify({
           ...(isEdit && { itemId: item.id }),
           name: name.trim(),
-          price: parseFloat(price),
+          price: isFree ? 0 : parseFloat(price || '0'),
+          priceType: isFree ? 'FIXED' : priceType,
+          priceMin: isFree ? null : (priceMin ? parseFloat(priceMin) : null),
+          priceMax: isFree ? null : (priceMax ? parseFloat(priceMax) : null),
+          isFree,
           description: description.trim() || null,
           isActive,
         }),
@@ -707,24 +769,143 @@ function ItemModal({
             />
           </div>
 
+          {/* Free Toggle */}
           <div>
-            <label className="block text-sm font-medium text-zinc-400 mb-2">
-              Price <span className="text-rose-400">*</span>
-            </label>
-            <div className="relative">
-              <span className="absolute left-4 top-1/2 -translate-y-1/2 text-zinc-500 font-medium">$</span>
-              <input
-                type="number"
-                step="0.01"
-                min="0"
-                value={price}
-                onChange={(e) => setPrice(e.target.value)}
-                placeholder="0.00"
-                className="w-full pl-8 pr-4 py-3 bg-zinc-800/50 border border-zinc-700/50 rounded-xl text-white placeholder-zinc-600 focus:outline-none focus:border-violet-500/50 transition-colors"
-                required
-              />
+            <label className="block text-sm font-medium text-zinc-400 mb-2">Pricing</label>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setIsFree(false)}
+                className={`flex-1 flex items-center justify-center gap-2 px-4 py-3 rounded-xl text-sm font-medium transition-all ${
+                  !isFree
+                    ? 'bg-violet-500/10 text-violet-400 border border-violet-500/30'
+                    : 'bg-zinc-800/50 border border-zinc-700/50 text-zinc-500 hover:text-zinc-400'
+                }`}
+              >
+                <DollarSign className="w-4 h-4" />
+                Paid
+              </button>
+              <button
+                type="button"
+                onClick={() => setIsFree(true)}
+                className={`flex-1 flex items-center justify-center gap-2 px-4 py-3 rounded-xl text-sm font-medium transition-all ${
+                  isFree
+                    ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/30'
+                    : 'bg-zinc-800/50 border border-zinc-700/50 text-zinc-500 hover:text-zinc-400'
+                }`}
+              >
+                <Sparkles className="w-4 h-4" />
+                Free
+              </button>
             </div>
           </div>
+
+          {/* Price Type (only if not free) */}
+          {!isFree && (
+            <div>
+              <label className="block text-sm font-medium text-zinc-400 mb-2">Price Type</label>
+              <div className="flex gap-2">
+                {(['FIXED', 'RANGE', 'MINIMUM'] as const).map((type) => (
+                  <button
+                    key={type}
+                    type="button"
+                    onClick={() => setPriceType(type)}
+                    className={`flex-1 px-3 py-2 rounded-lg text-sm font-medium transition-all ${
+                      priceType === type
+                        ? 'bg-violet-500/10 text-violet-400 border border-violet-500/30'
+                        : 'bg-zinc-800/50 border border-zinc-700/50 text-zinc-500 hover:text-zinc-400'
+                    }`}
+                  >
+                    {type === 'MINIMUM' ? 'Min' : type.charAt(0) + type.slice(1).toLowerCase()}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Price Inputs (only if not free) */}
+          {!isFree && priceType === 'FIXED' && (
+            <div>
+              <label className="block text-sm font-medium text-zinc-400 mb-2">
+                Price <span className="text-rose-400">*</span>
+              </label>
+              <div className="relative">
+                <span className="absolute left-4 top-1/2 -translate-y-1/2 text-zinc-500 font-medium">$</span>
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={price}
+                  onChange={(e) => setPrice(e.target.value)}
+                  placeholder="0.00"
+                  className="w-full pl-8 pr-4 py-3 bg-zinc-800/50 border border-zinc-700/50 rounded-xl text-white placeholder-zinc-600 focus:outline-none focus:border-violet-500/50 transition-colors"
+                  required
+                />
+              </div>
+            </div>
+          )}
+
+          {!isFree && priceType === 'RANGE' && (
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-zinc-400 mb-2">
+                  Min Price <span className="text-rose-400">*</span>
+                </label>
+                <div className="relative">
+                  <span className="absolute left-4 top-1/2 -translate-y-1/2 text-zinc-500 font-medium">$</span>
+                  <input
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    value={priceMin}
+                    onChange={(e) => setPriceMin(e.target.value)}
+                    placeholder="0.00"
+                    className="w-full pl-8 pr-4 py-3 bg-zinc-800/50 border border-zinc-700/50 rounded-xl text-white placeholder-zinc-600 focus:outline-none focus:border-violet-500/50 transition-colors"
+                    required
+                  />
+                </div>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-zinc-400 mb-2">
+                  Max Price <span className="text-rose-400">*</span>
+                </label>
+                <div className="relative">
+                  <span className="absolute left-4 top-1/2 -translate-y-1/2 text-zinc-500 font-medium">$</span>
+                  <input
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    value={priceMax}
+                    onChange={(e) => setPriceMax(e.target.value)}
+                    placeholder="0.00"
+                    className="w-full pl-8 pr-4 py-3 bg-zinc-800/50 border border-zinc-700/50 rounded-xl text-white placeholder-zinc-600 focus:outline-none focus:border-violet-500/50 transition-colors"
+                    required
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+
+          {!isFree && priceType === 'MINIMUM' && (
+            <div>
+              <label className="block text-sm font-medium text-zinc-400 mb-2">
+                Starting Price <span className="text-rose-400">*</span>
+              </label>
+              <div className="relative">
+                <span className="absolute left-4 top-1/2 -translate-y-1/2 text-zinc-500 font-medium">$</span>
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={priceMin}
+                  onChange={(e) => setPriceMin(e.target.value)}
+                  placeholder="0.00"
+                  className="w-full pl-8 pr-4 py-3 bg-zinc-800/50 border border-zinc-700/50 rounded-xl text-white placeholder-zinc-600 focus:outline-none focus:border-violet-500/50 transition-colors"
+                  required
+                />
+              </div>
+            </div>
+          )}
 
           <div>
             <label className="block text-sm font-medium text-zinc-400 mb-2">Description</label>
@@ -785,6 +966,334 @@ function ItemModal({
             </button>
           </div>
         </form>
+      </div>
+    </div>,
+    document.body
+  );
+}
+
+// Apply Template Modal
+interface PricingTemplate {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  category: string;
+  pageType: string;
+  isDefault: boolean;
+  items?: {
+    id: string;
+    name: string;
+    priceType: string;
+    priceFixed: number | null;
+    priceMin: number | null;
+    priceMax: number | null;
+    description: string | null;
+    order: number;
+    isActive: boolean;
+  }[];
+}
+
+function ApplyTemplateModal({
+  modelId,
+  onClose,
+  onSuccess,
+}: {
+  modelId: string;
+  onClose: () => void;
+  onSuccess: () => void;
+}) {
+  const [templates, setTemplates] = useState<PricingTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedTemplate, setSelectedTemplate] = useState<PricingTemplate | null>(null);
+  const [applyMode, setApplyMode] = useState<'replace' | 'merge'>('replace');
+  const [applying, setApplying] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const [categoryFilter, setCategoryFilter] = useState('');
+
+  useEffect(() => {
+    setMounted(true);
+    loadTemplates();
+    return () => setMounted(false);
+  }, []);
+
+  const loadTemplates = async () => {
+    try {
+      setLoading(true);
+      const params = new URLSearchParams();
+      params.append('includeItems', 'true');
+      params.append('activeOnly', 'true');
+      if (categoryFilter) params.append('category', categoryFilter);
+
+      const response = await fetch(`/api/pricing-templates?${params.toString()}`);
+      if (response.ok) {
+        const result = await response.json();
+        setTemplates(result.data || []);
+      }
+    } catch (error) {
+      console.error('Error loading templates:', error);
+      toast.error('Failed to load templates');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (mounted) {
+      loadTemplates();
+    }
+  }, [categoryFilter, mounted]);
+
+  if (!mounted) return null;
+
+  const handleApply = async () => {
+    if (!selectedTemplate) {
+      toast.error('Please select a template');
+      return;
+    }
+
+    try {
+      setApplying(true);
+      const response = await fetch(`/api/of-models/${modelId}/pricing/apply-template`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          templateId: selectedTemplate.id,
+          mode: applyMode,
+        }),
+      });
+
+      if (response.ok) {
+        const result = await response.json();
+        toast.success(result.message || 'Template applied successfully');
+        onSuccess();
+      } else {
+        const error = await response.json();
+        toast.error(error.error || 'Failed to apply template');
+      }
+    } catch (error) {
+      toast.error('Failed to apply template');
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  const getCategoryBadgeColor = (category: string) => {
+    switch (category) {
+      case 'PORN_ACCURATE':
+        return 'bg-rose-500/10 text-rose-400 border-rose-500/30';
+      case 'PORN_SCAM':
+        return 'bg-red-500/10 text-red-400 border-red-500/30';
+      case 'GF_ACCURATE':
+        return 'bg-pink-500/10 text-pink-400 border-pink-500/30';
+      case 'GF_SCAM':
+        return 'bg-fuchsia-500/10 text-fuchsia-400 border-fuchsia-500/30';
+      case 'BUNDLE_BASED':
+        return 'bg-violet-500/10 text-violet-400 border-violet-500/30';
+      default:
+        return 'bg-zinc-500/10 text-zinc-400 border-zinc-500/30';
+    }
+  };
+
+  const formatPrice = (item: NonNullable<PricingTemplate['items']>[0]) => {
+    if (item.priceType === 'FIXED' && item.priceFixed !== null) {
+      return `$${item.priceFixed.toFixed(2)}`;
+    }
+    if (item.priceType === 'RANGE' && item.priceMin !== null && item.priceMax !== null) {
+      return `$${item.priceMin.toFixed(2)} - $${item.priceMax.toFixed(2)}`;
+    }
+    if (item.priceType === 'MINIMUM' && item.priceMin !== null) {
+      return `From $${item.priceMin.toFixed(2)}`;
+    }
+    return '-';
+  };
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/80 backdrop-blur-sm" onClick={onClose} />
+
+      <div className="relative w-full max-w-2xl max-h-[90vh] bg-zinc-900 border border-zinc-800 rounded-2xl shadow-2xl overflow-hidden flex flex-col animate-fadeIn">
+        <div className="absolute top-0 left-1/2 -translate-x-1/2 w-1/2 h-px bg-gradient-to-r from-transparent via-violet-500 to-transparent" />
+
+        {/* Header */}
+        <div className="flex items-center justify-between p-5 border-b border-zinc-800 flex-shrink-0">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-lg bg-violet-500/10">
+              <FileText className="w-5 h-5 text-violet-400" />
+            </div>
+            <div>
+              <h2 className="text-lg font-medium text-white">Apply Pricing Template</h2>
+              <p className="text-sm text-zinc-500">Select a template to apply to this creator</p>
+            </div>
+          </div>
+          <button onClick={onClose} className="p-2 rounded-lg text-zinc-500 hover:text-white hover:bg-zinc-800 transition-colors">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto p-5 space-y-4">
+          {/* Category Filter */}
+          <div>
+            <label className="block text-sm font-medium text-zinc-400 mb-2">Filter by Category</label>
+            <select
+              value={categoryFilter}
+              onChange={(e) => setCategoryFilter(e.target.value)}
+              className="w-full px-4 py-3 bg-zinc-800/50 border border-zinc-700/50 rounded-xl text-white focus:outline-none focus:border-violet-500/50"
+            >
+              <option value="">All Categories</option>
+              <option value="PORN_ACCURATE">Porn Accurate</option>
+              <option value="PORN_SCAM">Porn Scam</option>
+              <option value="GF_ACCURATE">GF Accurate</option>
+              <option value="GF_SCAM">GF Scam</option>
+              <option value="BUNDLE_BASED">Bundle Based</option>
+              <option value="CUSTOM">Custom</option>
+            </select>
+          </div>
+
+          {/* Templates List */}
+          <div>
+            <label className="block text-sm font-medium text-zinc-400 mb-2">Select Template</label>
+            {loading ? (
+              <div className="space-y-3">
+                {[...Array(3)].map((_, i) => (
+                  <div key={i} className="h-20 bg-zinc-800/30 rounded-xl animate-pulse" />
+                ))}
+              </div>
+            ) : templates.length === 0 ? (
+              <div className="text-center py-8 text-zinc-500 bg-zinc-800/30 rounded-xl border border-dashed border-zinc-700/50">
+                <FileText className="w-10 h-10 mx-auto mb-3 text-zinc-600" />
+                <p className="text-sm">No templates available</p>
+                <p className="text-xs text-zinc-600 mt-1">Create templates in Settings &gt; Pricing Templates</p>
+              </div>
+            ) : (
+              <div className="space-y-2 max-h-64 overflow-y-auto">
+                {templates.map((template) => (
+                  <button
+                    key={template.id}
+                    onClick={() => setSelectedTemplate(template)}
+                    className={`w-full text-left p-4 rounded-xl border transition-all ${
+                      selectedTemplate?.id === template.id
+                        ? 'bg-violet-500/10 border-violet-500/50'
+                        : 'bg-zinc-800/30 border-zinc-700/50 hover:border-zinc-600/50'
+                    }`}
+                  >
+                    <div className="flex items-start justify-between">
+                      <div className="flex-1">
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium text-white">{template.name}</span>
+                          {template.isDefault && (
+                            <span className="px-1.5 py-0.5 bg-amber-500/10 text-amber-400 text-[10px] font-medium rounded border border-amber-500/30">
+                              DEFAULT
+                            </span>
+                          )}
+                        </div>
+                        {template.description && (
+                          <p className="text-sm text-zinc-500 mt-1">{template.description}</p>
+                        )}
+                        <div className="flex items-center gap-2 mt-2">
+                          <span className={`px-2 py-0.5 text-[10px] font-medium rounded border ${getCategoryBadgeColor(template.category)}`}>
+                            {template.category.replace('_', ' ')}
+                          </span>
+                          <span className="text-xs text-zinc-500">
+                            {template.items?.length || 0} item{(template.items?.length || 0) !== 1 ? 's' : ''}
+                          </span>
+                        </div>
+                      </div>
+                      <div className={`w-5 h-5 rounded-full border-2 flex items-center justify-center transition-colors ${
+                        selectedTemplate?.id === template.id
+                          ? 'border-violet-500 bg-violet-500'
+                          : 'border-zinc-600'
+                      }`}>
+                        {selectedTemplate?.id === template.id && (
+                          <Check className="w-3 h-3 text-white" />
+                        )}
+                      </div>
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Preview */}
+          {selectedTemplate && selectedTemplate.items && selectedTemplate.items.length > 0 && (
+            <div>
+              <label className="block text-sm font-medium text-zinc-400 mb-2">Template Preview</label>
+              <div className="bg-zinc-800/30 rounded-xl border border-zinc-700/50 p-4">
+                <div className="space-y-2 max-h-40 overflow-y-auto">
+                  {selectedTemplate.items.map((item, index) => (
+                    <div key={index} className="flex items-center justify-between py-2 border-b border-zinc-700/30 last:border-0">
+                      <div className="flex items-center gap-2">
+                        <Tag className="w-4 h-4 text-emerald-400" />
+                        <span className="text-sm text-white">{item.name}</span>
+                      </div>
+                      <span className="text-sm font-medium text-emerald-400">{formatPrice(item)}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Apply Mode */}
+          <div>
+            <label className="block text-sm font-medium text-zinc-400 mb-2">Apply Mode</label>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => setApplyMode('replace')}
+                className={`flex-1 flex items-center justify-center gap-2 px-4 py-3 rounded-xl text-sm font-medium transition-all ${
+                  applyMode === 'replace'
+                    ? 'bg-violet-500/10 text-violet-400 border border-violet-500/30'
+                    : 'bg-zinc-800/50 border border-zinc-700/50 text-zinc-500 hover:text-zinc-400'
+                }`}
+              >
+                <span className={`w-2 h-2 rounded-full ${applyMode === 'replace' ? 'bg-violet-400' : 'bg-zinc-600'}`} />
+                Replace Existing
+              </button>
+              <button
+                type="button"
+                onClick={() => setApplyMode('merge')}
+                className={`flex-1 flex items-center justify-center gap-2 px-4 py-3 rounded-xl text-sm font-medium transition-all ${
+                  applyMode === 'merge'
+                    ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/30'
+                    : 'bg-zinc-800/50 border border-zinc-700/50 text-zinc-500 hover:text-zinc-400'
+                }`}
+              >
+                <span className={`w-2 h-2 rounded-full ${applyMode === 'merge' ? 'bg-emerald-400' : 'bg-zinc-600'}`} />
+                Merge with Existing
+              </button>
+            </div>
+            <p className="text-xs text-zinc-500 mt-2">
+              {applyMode === 'replace'
+                ? 'This will delete all existing pricing and replace it with the template.'
+                : 'This will add the template items alongside existing pricing.'}
+            </p>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex gap-3 p-5 border-t border-zinc-800 flex-shrink-0">
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex-1 px-4 py-3 bg-zinc-800 border border-zinc-700 text-zinc-300 rounded-xl hover:bg-zinc-700 transition-colors font-medium"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleApply}
+            disabled={applying || !selectedTemplate}
+            className="flex-1 relative px-4 py-3 rounded-xl font-medium text-white overflow-hidden disabled:opacity-50"
+          >
+            <div className="absolute inset-0 bg-gradient-to-r from-violet-600 to-fuchsia-600" />
+            <span className="relative flex items-center justify-center gap-2">
+              <Download className="w-4 h-4" />
+              {applying ? 'Applying...' : 'Apply Template'}
+            </span>
+          </button>
+        </div>
       </div>
     </div>,
     document.body

--- a/app/[tenant]/(dashboard)/of-models/page.tsx
+++ b/app/[tenant]/(dashboard)/of-models/page.tsx
@@ -132,7 +132,7 @@ export default function OfModelsPage() {
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
-  const [statusFilter, setStatusFilter] = useState<string>('ALL');
+  const [statusFilter, setStatusFilter] = useState<string>('ACTIVE');
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -229,11 +229,11 @@ export default function OfModelsPage() {
                   <Crown className="w-6 h-6 text-violet-400" />
                 </div>
                 <h1 className="text-4xl sm:text-5xl font-light tracking-tight text-white">
-                  Models
+                  OF Creators
                 </h1>
               </div>
               <p className="text-zinc-500 text-lg font-light max-w-xl">
-                Curate and manage your creator portfolio with precision
+                Profiles, assets, and pricing at a glance
               </p>
             </div>
 
@@ -643,7 +643,7 @@ function ModelCard({
       <div className="relative p-4 space-y-3">
         <div>
           <Link
-            href={`/of-models/${model.slug}`}
+            href={`of-models/${model.slug}`}
             onClick={() => setStoreSelectedModel(model as any)}
             className="block"
           >
@@ -665,7 +665,7 @@ function ModelCard({
           </div>
 
           <Link
-            href={`/of-models/${model.slug}`}
+            href={`of-models/${model.slug}`}
             onClick={() => setStoreSelectedModel(model as any)}
             className="flex items-center gap-1.5 text-xs font-medium text-violet-400 hover:text-violet-300 transition-colors"
           >
@@ -724,7 +724,7 @@ function ModelListItem({
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-3">
           <Link
-            href={`/of-models/${model.slug}`}
+            href={`of-models/${model.slug}`}
             onClick={() => setStoreSelectedModel(model as any)}
           >
             <h3 className="font-medium text-white hover:text-violet-300 transition-colors truncate">
@@ -787,7 +787,7 @@ function ModelListItem({
       {/* Actions */}
       <div className="flex items-center gap-1">
         <Link
-          href={`/of-models/${model.slug}`}
+          href={`of-models/${model.slug}`}
           onClick={() => setStoreSelectedModel(model as any)}
           className="p-2 rounded-lg text-zinc-500 hover:text-white hover:bg-zinc-800 transition-all"
         >

--- a/app/[tenant]/(dashboard)/settings/page.tsx
+++ b/app/[tenant]/(dashboard)/settings/page.tsx
@@ -29,7 +29,11 @@ import {
   Users,
   Crown,
   Plus,
+  DollarSign,
+  ChevronRight,
 } from "lucide-react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
 
 interface UserProfile {
   id: string;
@@ -71,6 +75,8 @@ interface OrganizationMember {
 
 export default function SettingsPage() {
   const { user } = useUser();
+  const params = useParams();
+  const tenant = params.tenant as string;
   const queryClient = useQueryClient();
   const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
   const [organization, setOrganization] = useState<Organization | null>(null);
@@ -861,6 +867,39 @@ export default function SettingsPage() {
                 {formatDate(userProfile.updatedAt)}
               </span>
             </div>
+          </div>
+        </div>
+
+        {/* Quick Links Card */}
+        <div className="rounded-3xl border border-white/10 bg-white/5 p-6 shadow-2xl shadow-cyan-900/30 backdrop-blur">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-violet-500/20 text-violet-200">
+              <Settings className="w-5 h-5" />
+            </div>
+            <h2 className="text-xl font-bold text-white">Quick Links</h2>
+          </div>
+
+          <div className="space-y-3">
+            {/* Pricing Templates Link */}
+            <Link
+              href={`/${tenant}/settings/pricing-templates`}
+              className="group flex items-center justify-between p-4 rounded-2xl border border-white/10 bg-slate-950/60 hover:border-violet-500/30 hover:bg-violet-500/5 transition-all"
+            >
+              <div className="flex items-center gap-4">
+                <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br from-emerald-500/20 to-teal-500/20 text-emerald-300">
+                  <DollarSign className="w-6 h-6" />
+                </div>
+                <div>
+                  <h3 className="text-base font-semibold text-white group-hover:text-violet-200 transition-colors">
+                    Pricing Templates
+                  </h3>
+                  <p className="text-sm text-slate-400">
+                    Create and manage reusable pricing templates for OF Creators
+                  </p>
+                </div>
+              </div>
+              <ChevronRight className="w-5 h-5 text-slate-400 group-hover:text-violet-300 group-hover:translate-x-1 transition-all" />
+            </Link>
           </div>
         </div>
 

--- a/app/[tenant]/(dashboard)/settings/pricing-templates/page.tsx
+++ b/app/[tenant]/(dashboard)/settings/pricing-templates/page.tsx
@@ -1,0 +1,1052 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { toast } from 'sonner';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import {
+  Plus,
+  Pencil,
+  Trash2,
+  ChevronDown,
+  ChevronRight,
+  DollarSign,
+  X,
+  Tag,
+  Layers,
+  FileText,
+  Sparkles,
+  ArrowLeft,
+  Filter,
+  Eye,
+  EyeOff,
+  Copy,
+  MoreHorizontal,
+} from 'lucide-react';
+
+interface PricingTemplateItem {
+  id: string;
+  name: string;
+  priceType: 'FIXED' | 'RANGE' | 'MINIMUM';
+  priceFixed: number | null;
+  priceMin: number | null;
+  priceMax: number | null;
+  isFree: boolean;
+  description: string | null;
+  order: number;
+  isActive: boolean;
+}
+
+interface PricingTemplate {
+  id: string;
+  name: string;
+  slug: string;
+  description: string | null;
+  category: string;
+  pageType: string;
+  isDefault: boolean;
+  isActive: boolean;
+  createdAt: string;
+  items?: PricingTemplateItem[];
+}
+
+interface CategoryOption {
+  value: string;
+  label: string;
+  description: string;
+}
+
+interface PageTypeOption {
+  value: string;
+  label: string;
+  description: string;
+}
+
+interface PriceTypeOption {
+  value: string;
+  label: string;
+  description: string;
+}
+
+export default function PricingTemplatesPage() {
+  const params = useParams();
+  const tenant = params.tenant as string;
+  const [templates, setTemplates] = useState<PricingTemplate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [expandedTemplates, setExpandedTemplates] = useState<Set<string>>(new Set());
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [showEditModal, setShowEditModal] = useState(false);
+  const [selectedTemplate, setSelectedTemplate] = useState<PricingTemplate | null>(null);
+  const [categoryFilter, setCategoryFilter] = useState<string>('');
+  const [pageTypeFilter, setPageTypeFilter] = useState<string>('');
+  const [showInactive, setShowInactive] = useState(false);
+
+  // Options for dropdowns
+  const [categories, setCategories] = useState<CategoryOption[]>([]);
+  const [pageTypes, setPageTypes] = useState<PageTypeOption[]>([]);
+  const [priceTypes, setPriceTypes] = useState<PriceTypeOption[]>([]);
+
+  useEffect(() => {
+    loadCategories();
+    loadTemplates();
+  }, [categoryFilter, pageTypeFilter, showInactive]);
+
+  const loadCategories = async () => {
+    try {
+      const response = await fetch('/api/pricing-templates/categories');
+      if (response.ok) {
+        const result = await response.json();
+        setCategories(result.data.categories);
+        setPageTypes(result.data.pageTypes);
+        setPriceTypes(result.data.priceTypes);
+      }
+    } catch (error) {
+      console.error('Error loading categories:', error);
+    }
+  };
+
+  const loadTemplates = async () => {
+    try {
+      setLoading(true);
+      const params = new URLSearchParams();
+      params.append('includeItems', 'true');
+      if (categoryFilter) params.append('category', categoryFilter);
+      if (pageTypeFilter) params.append('pageType', pageTypeFilter);
+      params.append('activeOnly', (!showInactive).toString());
+
+      const response = await fetch(`/api/pricing-templates?${params.toString()}`);
+      if (response.ok) {
+        const result = await response.json();
+        setTemplates(result.data || []);
+      }
+    } catch (error) {
+      console.error('Error loading templates:', error);
+      toast.error('Failed to load templates');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const toggleTemplate = (templateId: string) => {
+    setExpandedTemplates((prev) => {
+      const newSet = new Set(prev);
+      if (newSet.has(templateId)) {
+        newSet.delete(templateId);
+      } else {
+        newSet.add(templateId);
+      }
+      return newSet;
+    });
+  };
+
+  const handleDeleteTemplate = async (template: PricingTemplate) => {
+    if (template.isDefault) {
+      toast.error('Cannot delete system default templates');
+      return;
+    }
+    if (!confirm(`Delete template "${template.name}"?`)) return;
+
+    try {
+      const response = await fetch(`/api/pricing-templates/${template.id}?hard=true`, {
+        method: 'DELETE',
+      });
+
+      if (response.ok) {
+        toast.success('Template deleted');
+        loadTemplates();
+      } else {
+        const error = await response.json();
+        toast.error(error.error || 'Failed to delete template');
+      }
+    } catch (error) {
+      toast.error('Failed to delete template');
+    }
+  };
+
+  const handleDuplicateTemplate = async (template: PricingTemplate) => {
+    try {
+      // Fetch full template with items
+      const response = await fetch(`/api/pricing-templates/${template.id}`);
+      if (!response.ok) throw new Error('Failed to fetch template');
+
+      const result = await response.json();
+      const fullTemplate = result.data;
+
+      // Create new template with copied data
+      const createResponse = await fetch('/api/pricing-templates', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: `${fullTemplate.name} (Copy)`,
+          slug: `${fullTemplate.slug}-copy-${Date.now()}`,
+          description: fullTemplate.description,
+          category: fullTemplate.category,
+          pageType: fullTemplate.pageType,
+          isDefault: false,
+          items: fullTemplate.items?.map((item: PricingTemplateItem) => ({
+            name: item.name,
+            priceType: item.priceType,
+            priceFixed: item.priceFixed,
+            priceMin: item.priceMin,
+            priceMax: item.priceMax,
+            description: item.description,
+            order: item.order,
+            isActive: item.isActive,
+          })),
+        }),
+      });
+
+      if (createResponse.ok) {
+        toast.success('Template duplicated');
+        loadTemplates();
+      } else {
+        const error = await createResponse.json();
+        toast.error(error.error || 'Failed to duplicate template');
+      }
+    } catch (error) {
+      toast.error('Failed to duplicate template');
+    }
+  };
+
+  const getCategoryBadgeColor = (category: string) => {
+    switch (category) {
+      case 'PORN_ACCURATE':
+        return 'bg-rose-500/10 text-rose-400 border-rose-500/30';
+      case 'PORN_SCAM':
+        return 'bg-red-500/10 text-red-400 border-red-500/30';
+      case 'GF_ACCURATE':
+        return 'bg-pink-500/10 text-pink-400 border-pink-500/30';
+      case 'GF_SCAM':
+        return 'bg-fuchsia-500/10 text-fuchsia-400 border-fuchsia-500/30';
+      case 'BUNDLE_BASED':
+        return 'bg-violet-500/10 text-violet-400 border-violet-500/30';
+      default:
+        return 'bg-zinc-500/10 text-zinc-400 border-zinc-500/30';
+    }
+  };
+
+  const getPageTypeBadgeColor = (pageType: string) => {
+    switch (pageType) {
+      case 'FREE':
+        return 'bg-emerald-500/10 text-emerald-400 border-emerald-500/30';
+      case 'PAID':
+        return 'bg-amber-500/10 text-amber-400 border-amber-500/30';
+      case 'VIP':
+        return 'bg-purple-500/10 text-purple-400 border-purple-500/30';
+      default:
+        return 'bg-blue-500/10 text-blue-400 border-blue-500/30';
+    }
+  };
+
+  const formatPrice = (item: PricingTemplateItem) => {
+    if (item.isFree) {
+      return 'FREE';
+    }
+    if (item.priceType === 'FIXED' && item.priceFixed !== null) {
+      return `$${item.priceFixed.toFixed(2)}`;
+    }
+    if (item.priceType === 'RANGE' && item.priceMin !== null && item.priceMax !== null) {
+      return `$${item.priceMin.toFixed(2)} - $${item.priceMax.toFixed(2)}`;
+    }
+    if (item.priceType === 'MINIMUM' && item.priceMin !== null) {
+      return `From $${item.priceMin.toFixed(2)}`;
+    }
+    return '-';
+  };
+
+  if (loading && templates.length === 0) {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center gap-4">
+          <Link
+            href={`/${tenant}/settings`}
+            className="p-2 rounded-xl text-zinc-400 hover:text-white hover:bg-zinc-800/50 transition-colors"
+          >
+            <ArrowLeft className="w-5 h-5" />
+          </Link>
+          <div>
+            <div className="h-7 w-48 bg-zinc-800/50 rounded-lg animate-pulse" />
+            <div className="h-4 w-64 bg-zinc-800/30 rounded mt-2 animate-pulse" />
+          </div>
+        </div>
+        <div className="bg-zinc-900/50 border border-zinc-800/50 rounded-2xl p-6">
+          <div className="space-y-4">
+            {[...Array(3)].map((_, i) => (
+              <div key={i} className="h-20 bg-zinc-800/30 rounded-xl animate-pulse" />
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <Link
+            href={`/${tenant}/settings`}
+            className="p-2 rounded-xl text-zinc-400 hover:text-white hover:bg-zinc-800/50 transition-colors"
+          >
+            <ArrowLeft className="w-5 h-5" />
+          </Link>
+          <div>
+            <h1 className="text-2xl font-bold text-white">Pricing Templates</h1>
+            <p className="text-sm text-zinc-500">Create and manage reusable pricing templates for OF Creators</p>
+          </div>
+        </div>
+        <button
+          onClick={() => setShowCreateModal(true)}
+          className="group relative inline-flex items-center gap-2 px-4 py-2.5 rounded-xl font-medium text-white overflow-hidden transition-all"
+        >
+          <div className="absolute inset-0 bg-gradient-to-r from-violet-600 to-fuchsia-600" />
+          <div className="absolute inset-0 bg-gradient-to-r from-violet-500 to-fuchsia-500 opacity-0 group-hover:opacity-100 transition-opacity" />
+          <Plus className="relative w-4 h-4" />
+          <span className="relative text-sm">New Template</span>
+        </button>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="flex items-center gap-2">
+          <Filter className="w-4 h-4 text-zinc-500" />
+          <span className="text-sm text-zinc-500">Filters:</span>
+        </div>
+
+        <select
+          value={categoryFilter}
+          onChange={(e) => setCategoryFilter(e.target.value)}
+          className="px-3 py-2 bg-zinc-800/50 border border-zinc-700/50 rounded-lg text-sm text-white focus:outline-none focus:border-violet-500/50"
+        >
+          <option value="">All Categories</option>
+          {categories.map((cat) => (
+            <option key={cat.value} value={cat.value}>
+              {cat.label}
+            </option>
+          ))}
+        </select>
+
+        <select
+          value={pageTypeFilter}
+          onChange={(e) => setPageTypeFilter(e.target.value)}
+          className="px-3 py-2 bg-zinc-800/50 border border-zinc-700/50 rounded-lg text-sm text-white focus:outline-none focus:border-violet-500/50"
+        >
+          <option value="">All Page Types</option>
+          {pageTypes.map((pt) => (
+            <option key={pt.value} value={pt.value}>
+              {pt.label}
+            </option>
+          ))}
+        </select>
+
+        <button
+          onClick={() => setShowInactive(!showInactive)}
+          className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors ${
+            showInactive
+              ? 'bg-violet-500/20 text-violet-400 border border-violet-500/30'
+              : 'bg-zinc-800/50 text-zinc-400 border border-zinc-700/50 hover:border-zinc-600/50'
+          }`}
+        >
+          {showInactive ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}
+          {showInactive ? 'Showing Inactive' : 'Hide Inactive'}
+        </button>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div className="bg-zinc-900/50 border border-zinc-800/50 rounded-2xl p-5">
+          <div className="flex items-start justify-between mb-3">
+            <div className="p-2.5 rounded-xl bg-violet-500/10">
+              <FileText className="w-5 h-5 text-violet-400" />
+            </div>
+          </div>
+          <p className="text-xs font-medium text-zinc-500 uppercase tracking-wider mb-1">Total Templates</p>
+          <p className="text-2xl font-medium text-white">{templates.length}</p>
+        </div>
+        <div className="bg-zinc-900/50 border border-zinc-800/50 rounded-2xl p-5">
+          <div className="flex items-start justify-between mb-3">
+            <div className="p-2.5 rounded-xl bg-emerald-500/10">
+              <Tag className="w-5 h-5 text-emerald-400" />
+            </div>
+          </div>
+          <p className="text-xs font-medium text-zinc-500 uppercase tracking-wider mb-1">Total Items</p>
+          <p className="text-2xl font-medium text-white">
+            {templates.reduce((acc, t) => acc + (t.items?.length || 0), 0)}
+          </p>
+        </div>
+        <div className="bg-zinc-900/50 border border-zinc-800/50 rounded-2xl p-5">
+          <div className="flex items-start justify-between mb-3">
+            <div className="p-2.5 rounded-xl bg-amber-500/10">
+              <Sparkles className="w-5 h-5 text-amber-400" />
+            </div>
+          </div>
+          <p className="text-xs font-medium text-zinc-500 uppercase tracking-wider mb-1">Default Templates</p>
+          <p className="text-2xl font-medium text-white">
+            {templates.filter((t) => t.isDefault).length}
+          </p>
+        </div>
+      </div>
+
+      {/* Templates List */}
+      <div className="bg-zinc-900/50 border border-zinc-800/50 rounded-2xl overflow-hidden">
+        <div className="flex items-center justify-between p-5 border-b border-zinc-800/50">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-lg bg-violet-500/10">
+              <Layers className="w-5 h-5 text-violet-400" />
+            </div>
+            <div>
+              <h2 className="text-lg font-medium text-white">Templates</h2>
+              <p className="text-sm text-zinc-500">Click to expand and see items</p>
+            </div>
+          </div>
+        </div>
+
+        <div className="divide-y divide-zinc-800/50">
+          {templates.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-16 text-center">
+              <div className="p-4 rounded-2xl bg-zinc-800/30 mb-4">
+                <FileText className="w-10 h-10 text-zinc-600" />
+              </div>
+              <h3 className="text-lg font-medium text-white mb-2">No templates found</h3>
+              <p className="text-zinc-500 mb-6 max-w-sm">
+                {categoryFilter || pageTypeFilter
+                  ? 'Try adjusting your filters or create a new template'
+                  : 'Create your first pricing template to get started'}
+              </p>
+              <button
+                onClick={() => setShowCreateModal(true)}
+                className="group relative inline-flex items-center gap-2 px-5 py-2.5 rounded-xl font-medium text-white overflow-hidden"
+              >
+                <div className="absolute inset-0 bg-gradient-to-r from-violet-600 to-fuchsia-600" />
+                <Sparkles className="relative w-4 h-4" />
+                <span className="relative">Create Template</span>
+              </button>
+            </div>
+          ) : (
+            templates.map((template) => (
+              <div key={template.id}>
+                {/* Template Header */}
+                <div
+                  className="flex items-center gap-4 p-4 hover:bg-zinc-800/20 cursor-pointer transition-colors"
+                  onClick={() => toggleTemplate(template.id)}
+                >
+                  <button className="p-1 text-zinc-500 hover:text-zinc-300 transition-colors">
+                    {expandedTemplates.has(template.id) ? (
+                      <ChevronDown className="w-5 h-5" />
+                    ) : (
+                      <ChevronRight className="w-5 h-5" />
+                    )}
+                  </button>
+
+                  <div className="p-2 rounded-lg bg-zinc-800/50">
+                    <FileText className="w-4 h-4 text-violet-400" />
+                  </div>
+
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <h3 className="font-medium text-white">{template.name}</h3>
+                      {template.isDefault && (
+                        <span className="px-2 py-0.5 bg-amber-500/10 text-amber-400 text-[10px] font-medium rounded border border-amber-500/30">
+                          DEFAULT
+                        </span>
+                      )}
+                      {!template.isActive && (
+                        <span className="px-2 py-0.5 bg-zinc-500/10 text-zinc-500 text-[10px] font-medium rounded border border-zinc-500/30">
+                          INACTIVE
+                        </span>
+                      )}
+                    </div>
+                    {template.description && (
+                      <p className="text-sm text-zinc-500 truncate">{template.description}</p>
+                    )}
+                  </div>
+
+                  <div className="flex items-center gap-2">
+                    <span className={`px-2 py-1 text-[10px] font-medium rounded border ${getCategoryBadgeColor(template.category)}`}>
+                      {template.category.replace('_', ' ')}
+                    </span>
+                    <span className={`px-2 py-1 text-[10px] font-medium rounded border ${getPageTypeBadgeColor(template.pageType)}`}>
+                      {template.pageType.replace('_', ' ')}
+                    </span>
+                    <span className="px-2.5 py-1 bg-zinc-800/50 rounded-lg text-xs font-medium text-zinc-400">
+                      {template.items?.length || 0} item{(template.items?.length || 0) !== 1 ? 's' : ''}
+                    </span>
+                  </div>
+
+                  <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
+                    <button
+                      onClick={() => handleDuplicateTemplate(template)}
+                      className="p-2 rounded-lg text-zinc-500 hover:text-blue-400 hover:bg-blue-500/10 transition-all"
+                      title="Duplicate template"
+                    >
+                      <Copy className="w-4 h-4" />
+                    </button>
+                    <button
+                      onClick={() => {
+                        setSelectedTemplate(template);
+                        setShowEditModal(true);
+                      }}
+                      className="p-2 rounded-lg text-zinc-500 hover:text-violet-400 hover:bg-violet-500/10 transition-all"
+                      title="Edit template"
+                    >
+                      <Pencil className="w-4 h-4" />
+                    </button>
+                    <button
+                      onClick={() => handleDeleteTemplate(template)}
+                      disabled={template.isDefault}
+                      className="p-2 rounded-lg text-zinc-500 hover:text-rose-400 hover:bg-rose-500/10 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+                      title={template.isDefault ? 'Cannot delete default template' : 'Delete template'}
+                    >
+                      <Trash2 className="w-4 h-4" />
+                    </button>
+                  </div>
+                </div>
+
+                {/* Template Items */}
+                {expandedTemplates.has(template.id) && (
+                  <div className="border-t border-zinc-800/30 bg-zinc-900/30">
+                    {!template.items || template.items.length === 0 ? (
+                      <div className="flex items-center gap-3 p-4 pl-16 text-zinc-500">
+                        <span className="text-sm">No items in this template</span>
+                      </div>
+                    ) : (
+                      template.items.map((item, index) => (
+                        <div
+                          key={item.id}
+                          className={`flex items-center gap-4 p-4 pl-16 ${
+                            index !== 0 ? 'border-t border-zinc-800/30' : ''
+                          }`}
+                        >
+                          <div className={`p-2 rounded-lg ${item.isActive ? 'bg-emerald-500/10' : 'bg-zinc-800/50'}`}>
+                            <Tag className={`w-4 h-4 ${item.isActive ? 'text-emerald-400' : 'text-zinc-600'}`} />
+                          </div>
+
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-2">
+                              <span className={`font-medium ${item.isActive ? 'text-white' : 'text-zinc-500'}`}>
+                                {item.name}
+                              </span>
+                              {item.isFree && (
+                                <span className="px-2 py-0.5 bg-emerald-500/20 rounded text-[10px] font-medium text-emerald-400 uppercase border border-emerald-500/30">
+                                  Free
+                                </span>
+                              )}
+                              {!item.isActive && (
+                                <span className="px-2 py-0.5 bg-zinc-800/50 rounded text-[10px] font-medium text-zinc-500 uppercase">
+                                  Inactive
+                                </span>
+                              )}
+                            </div>
+                            {item.description && (
+                              <p className="text-sm text-zinc-500 truncate">{item.description}</p>
+                            )}
+                          </div>
+
+                          <div className="flex items-center gap-2">
+                            {!item.isFree && (
+                              <span className="px-2 py-1 bg-zinc-800/50 text-[10px] font-medium text-zinc-400 rounded">
+                                {item.priceType}
+                              </span>
+                            )}
+                            <span className="text-lg font-semibold text-emerald-400">
+                              {formatPrice(item)}
+                            </span>
+                          </div>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+
+      {/* Create Modal */}
+      {showCreateModal && (
+        <TemplateModal
+          categories={categories}
+          pageTypes={pageTypes}
+          priceTypes={priceTypes}
+          onClose={() => setShowCreateModal(false)}
+          onSuccess={() => {
+            setShowCreateModal(false);
+            loadTemplates();
+          }}
+        />
+      )}
+
+      {/* Edit Modal */}
+      {showEditModal && selectedTemplate && (
+        <TemplateModal
+          template={selectedTemplate}
+          categories={categories}
+          pageTypes={pageTypes}
+          priceTypes={priceTypes}
+          onClose={() => {
+            setShowEditModal(false);
+            setSelectedTemplate(null);
+          }}
+          onSuccess={() => {
+            setShowEditModal(false);
+            setSelectedTemplate(null);
+            loadTemplates();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+// Template Modal Component
+function TemplateModal({
+  template,
+  categories,
+  pageTypes,
+  priceTypes,
+  onClose,
+  onSuccess,
+}: {
+  template?: PricingTemplate;
+  categories: CategoryOption[];
+  pageTypes: PageTypeOption[];
+  priceTypes: PriceTypeOption[];
+  onClose: () => void;
+  onSuccess: () => void;
+}) {
+  const isEdit = !!template;
+  const [name, setName] = useState(template?.name || '');
+  const [slug, setSlug] = useState(template?.slug || '');
+  const [description, setDescription] = useState(template?.description || '');
+  const [category, setCategory] = useState(template?.category || 'CUSTOM');
+  const [pageType, setPageType] = useState(template?.pageType || 'ALL_PAGES');
+  const [isActive, setIsActive] = useState(template?.isActive ?? true);
+  const [items, setItems] = useState<Omit<PricingTemplateItem, 'id'>[]>(
+    template?.items?.map((item) => ({
+      name: item.name,
+      priceType: item.priceType,
+      priceFixed: item.priceFixed,
+      priceMin: item.priceMin,
+      priceMax: item.priceMax,
+      isFree: item.isFree,
+      description: item.description,
+      order: item.order,
+      isActive: item.isActive,
+    })) || []
+  );
+  const [saving, setSaving] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
+
+  useEffect(() => {
+    if (name && !slug && !isEdit) {
+      setSlug(name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''));
+    }
+  }, [name, isEdit, slug]);
+
+  if (!mounted) return null;
+
+  const addItem = () => {
+    setItems([
+      ...items,
+      {
+        name: '',
+        priceType: 'FIXED',
+        priceFixed: 0,
+        priceMin: null,
+        priceMax: null,
+        isFree: false,
+        description: null,
+        order: items.length,
+        isActive: true,
+      },
+    ]);
+  };
+
+  const removeItem = (index: number) => {
+    setItems(items.filter((_, i) => i !== index));
+  };
+
+  const updateItem = (index: number, field: string, value: any) => {
+    setItems(
+      items.map((item, i) => {
+        if (i !== index) return item;
+        return { ...item, [field]: value };
+      })
+    );
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || !slug.trim()) {
+      toast.error('Name and slug are required');
+      return;
+    }
+
+    try {
+      setSaving(true);
+
+      if (isEdit) {
+        // Update template
+        const response = await fetch(`/api/pricing-templates/${template.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: name.trim(),
+            slug: slug.trim(),
+            description: description.trim() || null,
+            category,
+            pageType,
+            isActive,
+          }),
+        });
+
+        if (!response.ok) {
+          const error = await response.json();
+          throw new Error(error.error || 'Failed to update template');
+        }
+
+        // Update items (delete existing and recreate)
+        // Note: For simplicity, we'll need to handle this differently in production
+        // This is a simplified approach
+
+        toast.success('Template updated');
+        onSuccess();
+      } else {
+        // Create template with items
+        const response = await fetch('/api/pricing-templates', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: name.trim(),
+            slug: slug.trim(),
+            description: description.trim() || null,
+            category,
+            pageType,
+            items: items.filter((item) => item.name.trim()),
+          }),
+        });
+
+        if (!response.ok) {
+          const error = await response.json();
+          throw new Error(error.error || 'Failed to create template');
+        }
+
+        toast.success('Template created');
+        onSuccess();
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to save template');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/80 backdrop-blur-sm" onClick={onClose} />
+
+      <div className="relative w-full max-w-2xl max-h-[90vh] bg-zinc-900 border border-zinc-800 rounded-2xl shadow-2xl overflow-hidden flex flex-col animate-fadeIn">
+        <div className="absolute top-0 left-1/2 -translate-x-1/2 w-1/2 h-px bg-gradient-to-r from-transparent via-violet-500 to-transparent" />
+
+        {/* Header */}
+        <div className="flex items-center justify-between p-5 border-b border-zinc-800 flex-shrink-0">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-lg bg-violet-500/10">
+              <FileText className="w-5 h-5 text-violet-400" />
+            </div>
+            <h2 className="text-lg font-medium text-white">
+              {isEdit ? 'Edit Template' : 'Create Template'}
+            </h2>
+          </div>
+          <button onClick={onClose} className="p-2 rounded-lg text-zinc-500 hover:text-white hover:bg-zinc-800 transition-colors">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit} className="flex-1 overflow-y-auto">
+          <div className="p-5 space-y-4">
+            {/* Name & Slug */}
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-zinc-400 mb-2">
+                  Name <span className="text-rose-400">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="e.g. GF Accurate"
+                  className="w-full px-4 py-3 bg-zinc-800/50 border border-zinc-700/50 rounded-xl text-white placeholder-zinc-600 focus:outline-none focus:border-violet-500/50 transition-colors"
+                  required
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-zinc-400 mb-2">
+                  Slug <span className="text-rose-400">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={slug}
+                  onChange={(e) => setSlug(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))}
+                  placeholder="gf-accurate"
+                  className="w-full px-4 py-3 bg-zinc-800/50 border border-zinc-700/50 rounded-xl text-white placeholder-zinc-600 focus:outline-none focus:border-violet-500/50 transition-colors"
+                  required
+                />
+              </div>
+            </div>
+
+            {/* Category & Page Type */}
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-zinc-400 mb-2">Category</label>
+                <select
+                  value={category}
+                  onChange={(e) => setCategory(e.target.value)}
+                  className="w-full px-4 py-3 bg-zinc-800/50 border border-zinc-700/50 rounded-xl text-white focus:outline-none focus:border-violet-500/50 transition-colors"
+                >
+                  {categories.map((cat) => (
+                    <option key={cat.value} value={cat.value}>
+                      {cat.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-zinc-400 mb-2">Page Type</label>
+                <select
+                  value={pageType}
+                  onChange={(e) => setPageType(e.target.value)}
+                  className="w-full px-4 py-3 bg-zinc-800/50 border border-zinc-700/50 rounded-xl text-white focus:outline-none focus:border-violet-500/50 transition-colors"
+                >
+                  {pageTypes.map((pt) => (
+                    <option key={pt.value} value={pt.value}>
+                      {pt.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            {/* Description */}
+            <div>
+              <label className="block text-sm font-medium text-zinc-400 mb-2">Description</label>
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                rows={2}
+                placeholder="Optional description..."
+                className="w-full px-4 py-3 bg-zinc-800/50 border border-zinc-700/50 rounded-xl text-white placeholder-zinc-600 focus:outline-none focus:border-violet-500/50 transition-colors resize-none"
+              />
+            </div>
+
+            {/* Status */}
+            {isEdit && (
+              <div>
+                <label className="block text-sm font-medium text-zinc-400 mb-2">Status</label>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => setIsActive(true)}
+                    className={`flex-1 flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium transition-all ${
+                      isActive
+                        ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/30'
+                        : 'bg-zinc-800/50 border border-zinc-700/50 text-zinc-500 hover:text-zinc-400'
+                    }`}
+                  >
+                    <span className={`w-2 h-2 rounded-full ${isActive ? 'bg-emerald-400' : 'bg-zinc-600'}`} />
+                    Active
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setIsActive(false)}
+                    className={`flex-1 flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg text-sm font-medium transition-all ${
+                      !isActive
+                        ? 'bg-zinc-500/10 text-zinc-400 border border-zinc-500/30'
+                        : 'bg-zinc-800/50 border border-zinc-700/50 text-zinc-500 hover:text-zinc-400'
+                    }`}
+                  >
+                    <span className={`w-2 h-2 rounded-full ${!isActive ? 'bg-zinc-400' : 'bg-zinc-600'}`} />
+                    Inactive
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {/* Items Section */}
+            {!isEdit && (
+              <div>
+                <div className="flex items-center justify-between mb-3">
+                  <label className="block text-sm font-medium text-zinc-400">Pricing Items</label>
+                  <button
+                    type="button"
+                    onClick={addItem}
+                    className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-medium text-violet-400 bg-violet-500/10 hover:bg-violet-500/20 transition-colors"
+                  >
+                    <Plus className="w-3 h-3" />
+                    Add Item
+                  </button>
+                </div>
+
+                <div className="space-y-3">
+                  {items.length === 0 ? (
+                    <div className="text-center py-6 text-zinc-500 text-sm bg-zinc-800/30 rounded-xl border border-dashed border-zinc-700/50">
+                      No items yet. Click "Add Item" to start adding pricing items.
+                    </div>
+                  ) : (
+                    items.map((item, index) => (
+                      <div key={index} className="p-4 bg-zinc-800/30 rounded-xl border border-zinc-700/50 space-y-3">
+                        <div className="flex items-start justify-between">
+                          <span className="text-xs font-medium text-zinc-500">Item {index + 1}</span>
+                          <button
+                            type="button"
+                            onClick={() => removeItem(index)}
+                            className="p-1 rounded text-zinc-500 hover:text-rose-400 hover:bg-rose-500/10 transition-colors"
+                          >
+                            <X className="w-4 h-4" />
+                          </button>
+                        </div>
+
+                        <div className="grid grid-cols-2 gap-3">
+                          <input
+                            type="text"
+                            value={item.name}
+                            onChange={(e) => updateItem(index, 'name', e.target.value)}
+                            placeholder="Item name"
+                            className="px-3 py-2 bg-zinc-800/50 border border-zinc-700/50 rounded-lg text-sm text-white placeholder-zinc-600 focus:outline-none focus:border-violet-500/50"
+                          />
+                          <div className="flex items-center gap-3">
+                            <button
+                              type="button"
+                              onClick={() => updateItem(index, 'isFree', !item.isFree)}
+                              className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-all ${
+                                item.isFree
+                                  ? 'bg-emerald-500/20 text-emerald-400 border border-emerald-500/30'
+                                  : 'bg-zinc-800/50 border border-zinc-700/50 text-zinc-500 hover:text-zinc-400'
+                              }`}
+                            >
+                              <span className={`w-2 h-2 rounded-full ${item.isFree ? 'bg-emerald-400' : 'bg-zinc-600'}`} />
+                              Free
+                            </button>
+                            {!item.isFree && (
+                              <select
+                                value={item.priceType}
+                                onChange={(e) => updateItem(index, 'priceType', e.target.value)}
+                                className="flex-1 px-3 py-2 bg-zinc-800/50 border border-zinc-700/50 rounded-lg text-sm text-white focus:outline-none focus:border-violet-500/50"
+                              >
+                                {priceTypes.map((pt) => (
+                                  <option key={pt.value} value={pt.value}>
+                                    {pt.label}
+                                  </option>
+                                ))}
+                              </select>
+                            )}
+                          </div>
+                        </div>
+
+                        {!item.isFree && item.priceType === 'FIXED' && (
+                          <div className="relative">
+                            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500">$</span>
+                            <input
+                              type="number"
+                              step="0.01"
+                              min="0"
+                              value={item.priceFixed || ''}
+                              onChange={(e) => updateItem(index, 'priceFixed', parseFloat(e.target.value) || 0)}
+                              placeholder="0.00"
+                              className="w-full pl-7 pr-3 py-2 bg-zinc-800/50 border border-zinc-700/50 rounded-lg text-sm text-white placeholder-zinc-600 focus:outline-none focus:border-violet-500/50"
+                            />
+                          </div>
+                        )}
+
+                        {!item.isFree && item.priceType === 'RANGE' && (
+                          <div className="grid grid-cols-2 gap-3">
+                            <div className="relative">
+                              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500">$</span>
+                              <input
+                                type="number"
+                                step="0.01"
+                                min="0"
+                                value={item.priceMin || ''}
+                                onChange={(e) => updateItem(index, 'priceMin', parseFloat(e.target.value) || 0)}
+                                placeholder="Min"
+                                className="w-full pl-7 pr-3 py-2 bg-zinc-800/50 border border-zinc-700/50 rounded-lg text-sm text-white placeholder-zinc-600 focus:outline-none focus:border-violet-500/50"
+                              />
+                            </div>
+                            <div className="relative">
+                              <span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500">$</span>
+                              <input
+                                type="number"
+                                step="0.01"
+                                min="0"
+                                value={item.priceMax || ''}
+                                onChange={(e) => updateItem(index, 'priceMax', parseFloat(e.target.value) || 0)}
+                                placeholder="Max"
+                                className="w-full pl-7 pr-3 py-2 bg-zinc-800/50 border border-zinc-700/50 rounded-lg text-sm text-white placeholder-zinc-600 focus:outline-none focus:border-violet-500/50"
+                              />
+                            </div>
+                          </div>
+                        )}
+
+                        {!item.isFree && item.priceType === 'MINIMUM' && (
+                          <div className="relative">
+                            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-500">$</span>
+                            <input
+                              type="number"
+                              step="0.01"
+                              min="0"
+                              value={item.priceMin || ''}
+                              onChange={(e) => updateItem(index, 'priceMin', parseFloat(e.target.value) || 0)}
+                              placeholder="Starting from"
+                              className="w-full pl-7 pr-3 py-2 bg-zinc-800/50 border border-zinc-700/50 rounded-lg text-sm text-white placeholder-zinc-600 focus:outline-none focus:border-violet-500/50"
+                            />
+                          </div>
+                        )}
+
+                        <input
+                          type="text"
+                          value={item.description || ''}
+                          onChange={(e) => updateItem(index, 'description', e.target.value || null)}
+                          placeholder="Description (optional)"
+                          className="w-full px-3 py-2 bg-zinc-800/50 border border-zinc-700/50 rounded-lg text-sm text-white placeholder-zinc-600 focus:outline-none focus:border-violet-500/50"
+                        />
+                      </div>
+                    ))
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Footer */}
+          <div className="flex gap-3 p-5 border-t border-zinc-800 flex-shrink-0">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 px-4 py-3 bg-zinc-800 border border-zinc-700 text-zinc-300 rounded-xl hover:bg-zinc-700 transition-colors font-medium"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="flex-1 relative px-4 py-3 rounded-xl font-medium text-white overflow-hidden disabled:opacity-50"
+            >
+              <div className="absolute inset-0 bg-gradient-to-r from-violet-600 to-fuchsia-600" />
+              <span className="relative">{saving ? 'Saving...' : isEdit ? 'Save Changes' : 'Create Template'}</span>
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/app/api/of-models/[id]/pricing/[categoryId]/items/[itemId]/history/route.ts
+++ b/app/api/of-models/[id]/pricing/[categoryId]/items/[itemId]/history/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/database";
+
+interface RouteParams {
+  params: Promise<{ id: string; categoryId: string; itemId: string }>;
+}
+
+// GET - Get pricing history for a specific item
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id, categoryId, itemId } = await params;
+    const { searchParams } = new URL(req.url);
+    const limit = parseInt(searchParams.get("limit") || "50");
+    const offset = parseInt(searchParams.get("offset") || "0");
+
+    // Verify model exists
+    const model = await prisma.of_models.findUnique({
+      where: { id },
+    });
+
+    if (!model) {
+      return NextResponse.json(
+        { error: "OF model not found" },
+        { status: 404 }
+      );
+    }
+
+    // Verify item exists
+    const item = await prisma.of_model_pricing_items.findFirst({
+      where: {
+        id: itemId,
+        categoryId,
+      },
+    });
+
+    if (!item) {
+      return NextResponse.json(
+        { error: "Pricing item not found" },
+        { status: 404 }
+      );
+    }
+
+    const [history, total] = await Promise.all([
+      prisma.pricing_history.findMany({
+        where: { pricingItemId: itemId },
+        orderBy: { createdAt: "desc" },
+        take: limit,
+        skip: offset,
+      }),
+      prisma.pricing_history.count({
+        where: { pricingItemId: itemId },
+      }),
+    ]);
+
+    return NextResponse.json({
+      data: history,
+      pagination: {
+        total,
+        limit,
+        offset,
+        hasMore: offset + history.length < total,
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching pricing history:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch pricing history" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/of-models/[id]/pricing/apply-template/route.ts
+++ b/app/api/of-models/[id]/pricing/apply-template/route.ts
@@ -1,0 +1,171 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/database";
+import { z } from "zod";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+// Schema for applying a pricing template
+const applyTemplateSchema = z.object({
+  templateId: z.string().min(1, "Template ID is required"),
+  mode: z.enum(["replace", "merge"]).default("replace"),
+});
+
+// POST - Apply a pricing template to an OF model
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id: modelId } = await params;
+    const body = await req.json();
+    const validatedData = applyTemplateSchema.parse(body);
+
+    // Verify OF model exists
+    const model = await prisma.of_models.findUnique({
+      where: { id: modelId },
+    });
+
+    if (!model) {
+      return NextResponse.json(
+        { error: "OF model not found" },
+        { status: 404 }
+      );
+    }
+
+    // Fetch the template with all its items
+    const template = await prisma.pricing_template.findUnique({
+      where: { id: validatedData.templateId },
+      include: {
+        items: {
+          where: { isActive: true },
+          orderBy: { order: "asc" },
+        },
+      },
+    });
+
+    if (!template) {
+      return NextResponse.json(
+        { error: "Pricing template not found" },
+        { status: 404 }
+      );
+    }
+
+    if (!template.isActive) {
+      return NextResponse.json(
+        { error: "Cannot apply an inactive template" },
+        { status: 400 }
+      );
+    }
+
+    // Group template items by using the template name as the category
+    // The template name becomes the category name
+    const categoryName = template.name;
+    const categorySlug = template.slug;
+
+    await prisma.$transaction(async (tx) => {
+      if (validatedData.mode === "replace") {
+        // Delete all existing pricing categories and items for this model
+        await tx.of_model_pricing_categories.deleteMany({
+          where: { creatorId: modelId },
+        });
+      }
+
+      // Check if category with this slug already exists (for merge mode)
+      let existingCategory = null;
+      if (validatedData.mode === "merge") {
+        existingCategory = await tx.of_model_pricing_categories.findUnique({
+          where: {
+            creatorId_slug: {
+              creatorId: modelId,
+              slug: categorySlug,
+            },
+          },
+        });
+      }
+
+      // Get current max order for categories
+      const maxCategoryOrder = await tx.of_model_pricing_categories.aggregate({
+        where: { creatorId: modelId },
+        _max: { order: true },
+      });
+
+      let category;
+      if (existingCategory) {
+        // Use existing category
+        category = existingCategory;
+      } else {
+        // Create new category
+        category = await tx.of_model_pricing_categories.create({
+          data: {
+            creatorId: modelId,
+            name: categoryName,
+            slug: categorySlug,
+            description: template.description,
+            order: (maxCategoryOrder._max.order ?? -1) + 1,
+          } as any,
+        });
+      }
+
+      // Get current max order for items in this category
+      const maxItemOrder = await tx.of_model_pricing_items.aggregate({
+        where: { categoryId: category.id },
+        _max: { order: true },
+      });
+
+      const startingOrder = (maxItemOrder._max.order ?? -1) + 1;
+
+      // Create pricing items from template
+      if (template.items.length > 0) {
+        await tx.of_model_pricing_items.createMany({
+          data: template.items.map((item, index) => ({
+            categoryId: category.id,
+            name: item.name,
+            // Determine main price based on price type and isFree
+            price: item.isFree ? 0 : (item.priceFixed ?? item.priceMin ?? 0),
+            priceType: item.isFree ? "FIXED" : item.priceType,
+            priceMin: item.isFree ? null : item.priceMin,
+            priceMax: item.isFree ? null : item.priceMax,
+            isFree: item.isFree,
+            description: item.description,
+            order: startingOrder + index,
+            isActive: item.isActive,
+            updatedAt: new Date(),
+          })),
+        });
+      }
+    });
+
+    // Fetch updated pricing data
+    const updatedCategories = await prisma.of_model_pricing_categories.findMany({
+      where: { creatorId: modelId },
+      orderBy: { order: "asc" },
+      include: {
+        of_model_pricing_items: {
+          orderBy: { order: "asc" },
+        },
+      },
+    });
+
+    return NextResponse.json({
+      data: updatedCategories,
+      message: `Template "${template.name}" applied successfully (${validatedData.mode} mode)`,
+    });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: "Validation error", details: error.errors },
+        { status: 400 }
+      );
+    }
+    console.error("Error applying pricing template:", error);
+    return NextResponse.json(
+      { error: "Failed to apply pricing template" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/of-models/[id]/route.ts
+++ b/app/api/of-models/[id]/route.ts
@@ -131,14 +131,14 @@ export async function PATCH(req: NextRequest, { params }: RouteParams) {
     const model = await prisma.of_models.update({
       where: { id },
       data: updateData,
-      include: ({
+      include: {
         _count: {
           select: {
-            assets: true,
-            pricingCategories: true,
+            of_model_assets: true,
+            of_model_pricing_categories: true,
           },
         },
-      } as any),
+      },
     });
 
     return NextResponse.json({ data: model });

--- a/app/api/pricing-templates/[id]/items/route.ts
+++ b/app/api/pricing-templates/[id]/items/route.ts
@@ -1,0 +1,282 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/database";
+import { z } from "zod";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+// Schema for creating a pricing template item
+const createItemSchema = z.object({
+  name: z.string().min(1, "Item name is required"),
+  priceType: z.enum(["FIXED", "RANGE", "MINIMUM"]).default("FIXED"),
+  priceFixed: z.number().optional().nullable(),
+  priceMin: z.number().optional().nullable(),
+  priceMax: z.number().optional().nullable(),
+  description: z.string().optional().nullable(),
+  order: z.number().optional(),
+  isActive: z.boolean().default(true),
+});
+
+// Schema for updating a pricing template item
+const updateItemSchema = z.object({
+  itemId: z.string().min(1, "Item ID is required"),
+  name: z.string().min(1, "Item name is required").optional(),
+  priceType: z.enum(["FIXED", "RANGE", "MINIMUM"]).optional(),
+  priceFixed: z.number().optional().nullable(),
+  priceMin: z.number().optional().nullable(),
+  priceMax: z.number().optional().nullable(),
+  description: z.string().optional().nullable(),
+  order: z.number().optional(),
+  isActive: z.boolean().optional(),
+});
+
+// Schema for bulk reorder
+const reorderSchema = z.object({
+  items: z.array(z.object({
+    id: z.string(),
+    order: z.number(),
+  })),
+});
+
+// GET - List all items in a pricing template
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id: templateId } = await params;
+
+    // Verify template exists
+    const template = await prisma.pricing_template.findUnique({
+      where: { id: templateId },
+    });
+
+    if (!template) {
+      return NextResponse.json(
+        { error: "Pricing template not found" },
+        { status: 404 }
+      );
+    }
+
+    const { searchParams } = new URL(req.url);
+    const activeOnly = searchParams.get("activeOnly") !== "false";
+
+    const items = await prisma.pricing_template_item.findMany({
+      where: {
+        templateId,
+        ...(activeOnly ? { isActive: true } : {}),
+      },
+      orderBy: { order: "asc" },
+    });
+
+    return NextResponse.json({ data: items });
+  } catch (error) {
+    console.error("Error fetching pricing template items:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch pricing template items" },
+      { status: 500 }
+    );
+  }
+}
+
+// POST - Add an item to a pricing template
+export async function POST(req: NextRequest, { params }: RouteParams) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id: templateId } = await params;
+    const body = await req.json();
+    const validatedData = createItemSchema.parse(body);
+
+    // Verify template exists
+    const template = await prisma.pricing_template.findUnique({
+      where: { id: templateId },
+    });
+
+    if (!template) {
+      return NextResponse.json(
+        { error: "Pricing template not found" },
+        { status: 404 }
+      );
+    }
+
+    // Get the max order in this template
+    const maxOrder = await prisma.pricing_template_item.aggregate({
+      where: { templateId },
+      _max: { order: true },
+    });
+
+    const item = await prisma.pricing_template_item.create({
+      data: {
+        templateId,
+        name: validatedData.name,
+        priceType: validatedData.priceType,
+        priceFixed: validatedData.priceFixed,
+        priceMin: validatedData.priceMin,
+        priceMax: validatedData.priceMax,
+        description: validatedData.description,
+        order: validatedData.order ?? (maxOrder._max.order ?? 0) + 1,
+        isActive: validatedData.isActive,
+      },
+    });
+
+    return NextResponse.json({ data: item }, { status: 201 });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: "Validation error", details: error.errors },
+        { status: 400 }
+      );
+    }
+    console.error("Error creating pricing template item:", error);
+    return NextResponse.json(
+      { error: "Failed to create pricing template item" },
+      { status: 500 }
+    );
+  }
+}
+
+// PATCH - Update an item or bulk reorder items
+export async function PATCH(req: NextRequest, { params }: RouteParams) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id: templateId } = await params;
+    const body = await req.json();
+
+    // Verify template exists
+    const template = await prisma.pricing_template.findUnique({
+      where: { id: templateId },
+    });
+
+    if (!template) {
+      return NextResponse.json(
+        { error: "Pricing template not found" },
+        { status: 404 }
+      );
+    }
+
+    // Check if this is a bulk reorder operation
+    if (body.items && Array.isArray(body.items)) {
+      const validatedData = reorderSchema.parse(body);
+
+      await prisma.$transaction(
+        validatedData.items.map((item) =>
+          prisma.pricing_template_item.update({
+            where: { id: item.id },
+            data: { order: item.order },
+          })
+        )
+      );
+
+      const items = await prisma.pricing_template_item.findMany({
+        where: { templateId },
+        orderBy: { order: "asc" },
+      });
+
+      return NextResponse.json({ data: items });
+    }
+
+    // Single item update
+    const validatedData = updateItemSchema.parse(body);
+
+    // Verify item exists and belongs to this template
+    const existingItem = await prisma.pricing_template_item.findUnique({
+      where: { id: validatedData.itemId },
+    });
+
+    if (!existingItem || existingItem.templateId !== templateId) {
+      return NextResponse.json(
+        { error: "Item not found in this template" },
+        { status: 404 }
+      );
+    }
+
+    const { itemId, ...updateData } = validatedData;
+    const item = await prisma.pricing_template_item.update({
+      where: { id: itemId },
+      data: updateData,
+    });
+
+    return NextResponse.json({ data: item });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: "Validation error", details: error.errors },
+        { status: 400 }
+      );
+    }
+    console.error("Error updating pricing template item:", error);
+    return NextResponse.json(
+      { error: "Failed to update pricing template item" },
+      { status: 500 }
+    );
+  }
+}
+
+// DELETE - Remove an item from a pricing template
+export async function DELETE(req: NextRequest, { params }: RouteParams) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id: templateId } = await params;
+    const { searchParams } = new URL(req.url);
+    const itemId = searchParams.get("itemId");
+
+    if (!itemId) {
+      return NextResponse.json(
+        { error: "Item ID is required" },
+        { status: 400 }
+      );
+    }
+
+    // Verify template exists
+    const template = await prisma.pricing_template.findUnique({
+      where: { id: templateId },
+    });
+
+    if (!template) {
+      return NextResponse.json(
+        { error: "Pricing template not found" },
+        { status: 404 }
+      );
+    }
+
+    // Verify item exists and belongs to this template
+    const existingItem = await prisma.pricing_template_item.findUnique({
+      where: { id: itemId },
+    });
+
+    if (!existingItem || existingItem.templateId !== templateId) {
+      return NextResponse.json(
+        { error: "Item not found in this template" },
+        { status: 404 }
+      );
+    }
+
+    await prisma.pricing_template_item.delete({
+      where: { id: itemId },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error deleting pricing template item:", error);
+    return NextResponse.json(
+      { error: "Failed to delete pricing template item" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/pricing-templates/[id]/route.ts
+++ b/app/api/pricing-templates/[id]/route.ts
@@ -1,0 +1,174 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/database";
+import { z } from "zod";
+
+interface RouteParams {
+  params: Promise<{ id: string }>;
+}
+
+// Schema for updating a pricing template
+const updateTemplateSchema = z.object({
+  name: z.string().min(1, "Name is required").optional(),
+  slug: z.string().min(1, "Slug is required").regex(/^[a-z0-9-]+$/, "Slug must be lowercase with hyphens only").optional(),
+  description: z.string().optional().nullable(),
+  category: z.enum(["PORN_ACCURATE", "PORN_SCAM", "GF_ACCURATE", "GF_SCAM", "BUNDLE_BASED", "CUSTOM"]).optional(),
+  pageType: z.enum(["ALL_PAGES", "FREE", "PAID", "VIP"]).optional(),
+  isDefault: z.boolean().optional(),
+  isActive: z.boolean().optional(),
+});
+
+// GET - Get a single pricing template by ID
+export async function GET(req: NextRequest, { params }: RouteParams) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id } = await params;
+
+    const template = await prisma.pricing_template.findUnique({
+      where: { id },
+      include: {
+        items: {
+          orderBy: { order: "asc" },
+        },
+      },
+    });
+
+    if (!template) {
+      return NextResponse.json(
+        { error: "Pricing template not found" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ data: template });
+  } catch (error) {
+    console.error("Error fetching pricing template:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch pricing template" },
+      { status: 500 }
+    );
+  }
+}
+
+// PATCH - Update a pricing template
+export async function PATCH(req: NextRequest, { params }: RouteParams) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id } = await params;
+    const body = await req.json();
+    const validatedData = updateTemplateSchema.parse(body);
+
+    // Check if template exists
+    const existingTemplate = await prisma.pricing_template.findUnique({
+      where: { id },
+    });
+
+    if (!existingTemplate) {
+      return NextResponse.json(
+        { error: "Pricing template not found" },
+        { status: 404 }
+      );
+    }
+
+    // If slug is being updated, check for conflicts
+    if (validatedData.slug && validatedData.slug !== existingTemplate.slug) {
+      const slugExists = await prisma.pricing_template.findUnique({
+        where: { slug: validatedData.slug },
+      });
+
+      if (slugExists) {
+        return NextResponse.json(
+          { error: "A template with this slug already exists" },
+          { status: 409 }
+        );
+      }
+    }
+
+    const template = await prisma.pricing_template.update({
+      where: { id },
+      data: validatedData,
+      include: {
+        items: {
+          orderBy: { order: "asc" },
+        },
+      },
+    });
+
+    return NextResponse.json({ data: template });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: "Validation error", details: error.errors },
+        { status: 400 }
+      );
+    }
+    console.error("Error updating pricing template:", error);
+    return NextResponse.json(
+      { error: "Failed to update pricing template" },
+      { status: 500 }
+    );
+  }
+}
+
+// DELETE - Delete a pricing template (soft delete via isActive)
+export async function DELETE(req: NextRequest, { params }: RouteParams) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { id } = await params;
+    const { searchParams } = new URL(req.url);
+    const hardDelete = searchParams.get("hard") === "true";
+
+    // Check if template exists
+    const existingTemplate = await prisma.pricing_template.findUnique({
+      where: { id },
+    });
+
+    if (!existingTemplate) {
+      return NextResponse.json(
+        { error: "Pricing template not found" },
+        { status: 404 }
+      );
+    }
+
+    // Prevent deleting system default templates
+    if (existingTemplate.isDefault) {
+      return NextResponse.json(
+        { error: "Cannot delete system default templates" },
+        { status: 403 }
+      );
+    }
+
+    if (hardDelete) {
+      // Hard delete - removes the template and all items
+      await prisma.pricing_template.delete({
+        where: { id },
+      });
+    } else {
+      // Soft delete - set isActive to false
+      await prisma.pricing_template.update({
+        where: { id },
+        data: { isActive: false },
+      });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Error deleting pricing template:", error);
+    return NextResponse.json(
+      { error: "Failed to delete pricing template" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/pricing-templates/categories/route.ts
+++ b/app/api/pricing-templates/categories/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+
+// GET - Get available categories and page types
+export async function GET(req: NextRequest) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const categories = [
+      { value: "PORN_ACCURATE", label: "Porn Accurate", description: "Explicit content, straightforward pricing" },
+      { value: "PORN_SCAM", label: "Porn Scam", description: "Explicit teasers, heavy paywalls" },
+      { value: "GF_ACCURATE", label: "GF Accurate", description: "Girlfriend experience, authentic" },
+      { value: "GF_SCAM", label: "GF Scam", description: "GF vibe with aggressive upselling" },
+      { value: "BUNDLE_BASED", label: "Bundle Based", description: "Focus on content bundles" },
+      { value: "CUSTOM", label: "Custom", description: "User-defined pricing category" },
+    ];
+
+    const pageTypes = [
+      { value: "ALL_PAGES", label: "All Pages", description: "Applies to all page tiers" },
+      { value: "FREE", label: "Free", description: "Free/freemium pages" },
+      { value: "PAID", label: "Paid", description: "Standard paid subscription" },
+      { value: "VIP", label: "VIP", description: "Premium/exclusive tier" },
+    ];
+
+    const priceTypes = [
+      { value: "FIXED", label: "Fixed", description: "Single fixed price" },
+      { value: "RANGE", label: "Range", description: "Price range (min to max)" },
+      { value: "MINIMUM", label: "Minimum", description: "Starting from price" },
+    ];
+
+    return NextResponse.json({
+      data: {
+        categories,
+        pageTypes,
+        priceTypes,
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching categories:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch categories" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/pricing-templates/route.ts
+++ b/app/api/pricing-templates/route.ts
@@ -1,0 +1,159 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/database";
+import { z } from "zod";
+
+// Schema for creating a pricing template
+const createTemplateSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  slug: z.string().min(1, "Slug is required").regex(/^[a-z0-9-]+$/, "Slug must be lowercase with hyphens only"),
+  description: z.string().optional().nullable(),
+  category: z.enum(["PORN_ACCURATE", "PORN_SCAM", "GF_ACCURATE", "GF_SCAM", "BUNDLE_BASED", "CUSTOM"]),
+  pageType: z.enum(["ALL_PAGES", "FREE", "PAID", "VIP"]).default("ALL_PAGES"),
+  isDefault: z.boolean().default(false),
+  items: z.array(z.object({
+    name: z.string().min(1, "Item name is required"),
+    priceType: z.enum(["FIXED", "RANGE", "MINIMUM"]).default("FIXED"),
+    priceFixed: z.number().optional().nullable(),
+    priceMin: z.number().optional().nullable(),
+    priceMax: z.number().optional().nullable(),
+    isFree: z.boolean().default(false),
+    description: z.string().optional().nullable(),
+    order: z.number().default(0),
+    isActive: z.boolean().default(true),
+  })).optional(),
+});
+
+// GET - List all pricing templates
+export async function GET(req: NextRequest) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    const category = searchParams.get("category");
+    const pageType = searchParams.get("pageType");
+    const includeItems = searchParams.get("includeItems") === "true";
+    const activeOnly = searchParams.get("activeOnly") !== "false"; // Default to true
+
+    const where: any = {};
+
+    if (category) {
+      where.category = category;
+    }
+
+    if (pageType) {
+      where.pageType = pageType;
+    }
+
+    if (activeOnly) {
+      where.isActive = true;
+    }
+
+    const templates = await prisma.pricing_template.findMany({
+      where,
+      include: includeItems ? {
+        items: {
+          where: activeOnly ? { isActive: true } : undefined,
+          orderBy: { order: "asc" },
+        },
+      } : undefined,
+      orderBy: [
+        { isDefault: "desc" },
+        { name: "asc" },
+      ],
+    });
+
+    return NextResponse.json({ data: templates });
+  } catch (error) {
+    console.error("Error fetching pricing templates:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch pricing templates" },
+      { status: 500 }
+    );
+  }
+}
+
+// POST - Create a new pricing template
+export async function POST(req: NextRequest) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const validatedData = createTemplateSchema.parse(body);
+
+    // Check if slug already exists
+    const existingTemplate = await prisma.pricing_template.findUnique({
+      where: { slug: validatedData.slug },
+    });
+
+    if (existingTemplate) {
+      return NextResponse.json(
+        { error: "A template with this slug already exists" },
+        { status: 409 }
+      );
+    }
+
+    // Create template with items in a transaction
+    const template = await prisma.$transaction(async (tx) => {
+      const newTemplate = await tx.pricing_template.create({
+        data: {
+          name: validatedData.name,
+          slug: validatedData.slug,
+          description: validatedData.description,
+          category: validatedData.category,
+          pageType: validatedData.pageType,
+          isDefault: validatedData.isDefault,
+          createdBy: userId,
+        },
+      });
+
+      // Create items if provided
+      if (validatedData.items && validatedData.items.length > 0) {
+        await tx.pricing_template_item.createMany({
+          data: validatedData.items.map((item, index) => ({
+            templateId: newTemplate.id,
+            name: item.name,
+            priceType: item.isFree ? "FIXED" : item.priceType,
+            priceFixed: item.isFree ? null : item.priceFixed,
+            priceMin: item.isFree ? null : item.priceMin,
+            priceMax: item.isFree ? null : item.priceMax,
+            isFree: item.isFree ?? false,
+            description: item.description,
+            order: item.order ?? index,
+            isActive: item.isActive ?? true,
+          })),
+        });
+      }
+
+      // Return template with items
+      return tx.pricing_template.findUnique({
+        where: { id: newTemplate.id },
+        include: {
+          items: {
+            orderBy: { order: "asc" },
+          },
+        },
+      });
+    });
+
+    return NextResponse.json({ data: template }, { status: 201 });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json(
+        { error: "Validation error", details: error.errors },
+        { status: 400 }
+      );
+    }
+    console.error("Error creating pricing template:", error);
+    return NextResponse.json(
+      { error: "Failed to create pricing template" },
+      { status: 500 }
+    );
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1274,7 +1274,7 @@ model reference_folders {
 }
 
 model of_model_assets {
-  id           String           @id
+  id           String           @id @default(cuid())
   creatorId    String
   type         OfModelAssetType
   name         String
@@ -1292,7 +1292,7 @@ model of_model_assets {
 }
 
 model of_model_details {
-  id                   String    @id
+  id                   String    @id @default(cuid())
   creatorId            String    @unique
   fullName             String?
   age                  Int?
@@ -1320,38 +1320,47 @@ model of_model_details {
 }
 
 model of_model_pricing_categories {
-  id                     String                   @id
-  creatorId              String
+  id                     String                   @id @default(cuid())
+  creatorId              String?                  // Nullable for global categories
   name                   String
   slug                   String
   description            String?
   order                  Int                      @default(0)
+  isGlobal               Boolean                  @default(false) // True for global pricing that applies to all models
   createdAt              DateTime                 @default(now())
   updatedAt              DateTime
-  of_models              of_models                @relation(fields: [creatorId], references: [id], onDelete: Cascade)
+  of_models              of_models?               @relation(fields: [creatorId], references: [id], onDelete: Cascade)
   of_model_pricing_items of_model_pricing_items[]
 
   @@unique([creatorId, slug])
   @@index([creatorId])
+  @@index([isGlobal])
 }
 
 model of_model_pricing_items {
-  id                          String                      @id
+  id                          String                      @id @default(cuid())
   categoryId                  String
   name                        String
-  price                       Float
+  price                       Float                       // Main price (for FIXED) or display price
+  priceType                   PricingItemType             @default(FIXED) // FIXED, RANGE, MINIMUM
+  priceMin                    Float?                      // For RANGE/MINIMUM types
+  priceMax                    Float?                      // For RANGE type
+  isFree                      Boolean                     @default(false) // Mark as free content
   description                 String?
   order                       Int                         @default(0)
   isActive                    Boolean                     @default(true)
   createdAt                   DateTime                    @default(now())
   updatedAt                   DateTime
   of_model_pricing_categories of_model_pricing_categories @relation(fields: [categoryId], references: [id], onDelete: Cascade)
+  pricing_history             pricing_history[]
 
   @@index([categoryId])
+  @@index([isFree])
+  @@index([priceType])
 }
 
 model of_models {
-  id                          String                        @id
+  id                          String                        @id @default(cuid())
   name                        String
   displayName                 String
   slug                        String                        @unique
@@ -1635,4 +1644,116 @@ enum OfModelStatus {
   INACTIVE
   DROPPED
   PENDING
+}
+
+// Pricing Templates
+model pricing_template {
+  id          String   @id @default(cuid())
+  name        String                          // e.g., "GF Accurate", "Porn Scam"
+  slug        String   @unique
+  description String?
+  category    PricingTemplateCategory         // PORN_ACCURATE, PORN_SCAM, GF_ACCURATE, GF_SCAM, BUNDLE_BASED, CUSTOM
+  pageType    PricingTemplatePageType @default(ALL_PAGES)  // ALL_PAGES, FREE, PAID, VIP
+  isDefault   Boolean  @default(false)        // System default templates
+  isActive    Boolean  @default(true)
+  createdBy   String?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  items       pricing_template_item[]
+
+  @@index([category])
+  @@index([pageType])
+  @@index([isActive])
+}
+
+model pricing_template_item {
+  id          String   @id @default(cuid())
+  templateId  String
+  name        String                          // e.g., "Dick Rating", "Custom Video"
+  priceType   PricingItemType @default(FIXED) // FIXED, RANGE, MINIMUM
+  priceFixed  Float?
+  priceMin    Float?
+  priceMax    Float?
+  isFree      Boolean  @default(false)        // Mark as free content
+  description String?
+  order       Int      @default(0)
+  isActive    Boolean  @default(true)
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  template    pricing_template @relation(fields: [templateId], references: [id], onDelete: Cascade)
+
+  @@index([templateId])
+  @@index([order])
+  @@index([isFree])
+}
+
+// Pricing History for audit trail
+model pricing_history {
+  id              String   @id @default(cuid())
+  pricingItemId   String
+  changeType      PricingChangeType           // CREATED, UPDATED, DELETED, ACTIVATED, DEACTIVATED
+
+  // Old values
+  oldName         String?
+  oldPriceType    PricingItemType?
+  oldPrice        Float?
+  oldPriceMin     Float?
+  oldPriceMax     Float?
+  oldIsFree       Boolean?
+  oldIsActive     Boolean?
+
+  // New values
+  newName         String?
+  newPriceType    PricingItemType?
+  newPrice        Float?
+  newPriceMin     Float?
+  newPriceMax     Float?
+  newIsFree       Boolean?
+  newIsActive     Boolean?
+
+  // Audit info
+  changedById     String?
+  changedByName   String?
+  reason          String?
+  createdAt       DateTime @default(now())
+
+  pricingItem     of_model_pricing_items @relation(fields: [pricingItemId], references: [id], onDelete: Cascade)
+
+  @@index([pricingItemId])
+  @@index([createdAt])
+  @@index([changeType])
+  @@index([changedById])
+}
+
+enum PricingChangeType {
+  CREATED
+  UPDATED
+  DELETED
+  ACTIVATED
+  DEACTIVATED
+  PRICE_CHANGE
+}
+
+enum PricingTemplateCategory {
+  PORN_ACCURATE
+  PORN_SCAM
+  GF_ACCURATE
+  GF_SCAM
+  BUNDLE_BASED
+  CUSTOM
+}
+
+enum PricingTemplatePageType {
+  ALL_PAGES
+  FREE
+  PAID
+  VIP
+}
+
+enum PricingItemType {
+  FIXED
+  RANGE
+  MINIMUM
 }


### PR DESCRIPTION
- Add pricing templates page with CRUD operations for reusable pricing configs
- Implement pricing categories and items with history tracking
- Add apply-template endpoint to bulk apply templates to models
- Enhance OF model pricing page with category-based pricing UI
- Update Prisma schema with PricingTemplate, PricingCategory, and PricingItem models
- Fix modelSlug parameter naming consistency across OF model pages