### PR TITLE
feat: add content type options with pricing and content tags dropdowns

### DIFF
--- a/app/api/content-type-options/route.ts
+++ b/app/api/content-type-options/route.ts
@@ -1,0 +1,201 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+import { prisma } from '@/lib/database';
+
+export async function GET(req: NextRequest) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { searchParams } = new URL(req.url);
+    const category = searchParams.get('category');
+    const modelId = searchParams.get('modelId');
+    const modelName = searchParams.get('modelName');
+    const pageType = searchParams.get('pageType');
+    const fetchAll = searchParams.get('fetchAll');
+
+    // Build where clause
+    const whereClause: any = {
+      isActive: true,
+    };
+
+    if (category) {
+      whereClause.category = category;
+    }
+
+    const andConditions: any[] = [];
+
+    // Page type filtering
+    if (pageType && pageType !== 'ALL_PAGES') {
+      andConditions.push({
+        OR: [{ pageType }, { pageType: 'ALL_PAGES' }],
+      });
+    }
+
+    // Model filtering
+    let resolvedModelId = modelId;
+    if (modelName && !resolvedModelId) {
+      const model = await prisma.of_models.findFirst({
+        where: { name: modelName },
+        select: { id: true },
+      });
+      if (model) resolvedModelId = model.id;
+    }
+
+    if (fetchAll === 'true') {
+      // No model filter - get everything
+    } else if (resolvedModelId) {
+      andConditions.push({
+        OR: [{ modelId: resolvedModelId }, { modelId: null }],
+      });
+    } else {
+      whereClause.modelId = null;
+    }
+
+    if (andConditions.length > 0) {
+      whereClause.AND = andConditions;
+    }
+
+    const contentTypeOptions = await prisma.contentTypeOption.findMany({
+      where: whereClause,
+      include: {
+        model: {
+          select: {
+            id: true,
+            name: true,
+            displayName: true,
+          },
+        },
+      },
+      orderBy: { order: 'asc' },
+    });
+
+    return NextResponse.json({
+      success: true,
+      contentTypeOptions,
+      category,
+      modelId: resolvedModelId,
+      pageType,
+    });
+  } catch (error) {
+    console.error('Error fetching content type options:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to fetch content type options' },
+      { status: 500 }
+    );
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const {
+      value,
+      label,
+      category,
+      pageType,
+      priceType,
+      priceFixed,
+      priceMin,
+      priceMax,
+      description,
+      order,
+      isFree,
+      modelId,
+    } = body;
+
+    if (!value || !label || !category) {
+      return NextResponse.json(
+        { success: false, error: 'Value, label, and category are required' },
+        { status: 400 }
+      );
+    }
+
+    if (modelId) {
+      const modelExists = await prisma.of_models.findUnique({
+        where: { id: modelId },
+      });
+      if (!modelExists) {
+        return NextResponse.json(
+          { success: false, error: 'Invalid modelId - model not found' },
+          { status: 400 }
+        );
+      }
+    }
+
+    // Validate pricing
+    if (!isFree && priceType) {
+      if (priceType === 'FIXED' && !priceFixed && priceFixed !== 0) {
+        return NextResponse.json(
+          { success: false, error: 'Fixed price required for FIXED type' },
+          { status: 400 }
+        );
+      }
+      if (priceType === 'RANGE' && ((!priceMin && priceMin !== 0) || (!priceMax && priceMax !== 0))) {
+        return NextResponse.json(
+          { success: false, error: 'Min and max prices required for RANGE type' },
+          { status: 400 }
+        );
+      }
+      if (priceType === 'MINIMUM' && !priceMin && priceMin !== 0) {
+        return NextResponse.json(
+          { success: false, error: 'Minimum price required for MINIMUM type' },
+          { status: 400 }
+        );
+      }
+    }
+
+    const contentTypeOption = await prisma.contentTypeOption.create({
+      data: {
+        value,
+        label,
+        category,
+        pageType: pageType || 'ALL_PAGES',
+        priceType: isFree ? null : priceType,
+        priceFixed: isFree ? null : priceFixed,
+        priceMin: isFree ? null : priceMin,
+        priceMax: isFree ? null : priceMax,
+        description,
+        order: order || 0,
+        isFree: isFree || false,
+        modelId: modelId || null,
+      },
+    });
+
+    await prisma.contentTypePricingHistory.create({
+      data: {
+        contentTypeOptionId: contentTypeOption.id,
+        changeType: 'CREATED',
+        newPriceType: isFree ? null : priceType,
+        newPriceFixed: isFree ? null : (priceFixed ?? null),
+        newPriceMin: isFree ? null : (priceMin ?? null),
+        newPriceMax: isFree ? null : (priceMax ?? null),
+        newLabel: label,
+        newIsFree: isFree || false,
+        changedById: userId,
+        reason: 'Initial creation',
+      },
+    });
+
+    return NextResponse.json({ success: true, contentTypeOption });
+  } catch (error: any) {
+    console.error('Error creating content type option:', error);
+    if (error.code === 'P2002') {
+      return NextResponse.json(
+        { success: false, error: 'A content type option with this value already exists' },
+        { status: 409 }
+      );
+    }
+    return NextResponse.json(
+      { success: false, error: 'Failed to create content type option' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/instagram-profiles/[id]/route.ts
+++ b/app/api/instagram-profiles/[id]/route.ts
@@ -161,6 +161,7 @@ export async function PATCH(
       isDefault,
       shareWithOrganization,
       modelBible,
+      metadata,
       tags,
       isFavorite,
       pageStrategy,
@@ -249,6 +250,11 @@ export async function PATCH(
     // Handle modelBible as JSON field
     if (modelBible !== undefined) {
       updateData.modelBible = modelBible;
+    }
+
+    // Handle metadata as JSON field
+    if (metadata !== undefined) {
+      updateData.metadata = metadata;
     }
 
     const updatedProfile = await prisma.instagramProfile.update({

--- a/app/api/instagram-profiles/list/route.ts
+++ b/app/api/instagram-profiles/list/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/database";
+
+// GET - Lightweight list of profiles (id, name, type) for dropdowns
+export async function GET() {
+  try {
+    const { userId } = await auth();
+
+    if (!userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Get user's current organization
+    const user = await prisma.user.findUnique({
+      where: { clerkId: userId },
+      select: { currentOrganizationId: true },
+    });
+
+    // Fetch own profiles + org-shared profiles (lightweight)
+    const profiles = await prisma.instagramProfile.findMany({
+      where: {
+        OR: [
+          { clerkId: userId },
+          ...(user?.currentOrganizationId
+            ? [{ organizationId: user.currentOrganizationId }]
+            : []),
+        ],
+      },
+      select: {
+        id: true,
+        name: true,
+        type: true,
+      },
+      orderBy: { name: "asc" },
+    });
+
+    return NextResponse.json(profiles);
+  } catch (error) {
+    console.error("Error fetching profiles list:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch profiles" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/instagram-profiles/route.ts
+++ b/app/api/instagram-profiles/route.ts
@@ -260,8 +260,9 @@ export async function POST(request: NextRequest) {
       isDefault,
       shareWithOrganization,
       modelBible,
+      metadata,
       tags,
-      type, // "real" or "ai"
+      type, // "real", "ai", or "of_model"
     } = body;
 
     if (!name || typeof name !== "string" || name.trim().length === 0) {
@@ -308,6 +309,7 @@ export async function POST(request: NextRequest) {
         isDefault: isDefault || existingProfileCount === 0,
         organizationId,
         modelBible: modelBible || undefined,
+        metadata: metadata || undefined,
         tags: tags || [],
         type: type || "real", // Default to "real" if not specified
         status: "pending", // All new profiles start as pending

--- a/components/content-submission/ContentDetailsFields.tsx
+++ b/components/content-submission/ContentDetailsFields.tsx
@@ -1,22 +1,696 @@
 'use client';
 
-import { X } from 'lucide-react';
+import { useEffect, useState, useRef, useCallback, useMemo } from 'react';
+import { X, Search, ChevronDown, Check, User, Users, Loader2, RefreshCw } from 'lucide-react';
 import type { UseFormRegister, UseFormSetValue, UseFormWatch, FieldErrors } from 'react-hook-form';
 import type { CreateSubmissionWithComponents } from '@/lib/validations/content-submission';
 import { PricingTierSelector } from './PricingTierSelector';
+import { CONTENT_TAGS } from '@/lib/constants/contentTags';
+import {
+  useContentTypeOptions,
+  formatContentTypePrice,
+  formatPageType,
+  type ContentTypeOption,
+} from '@/lib/hooks/useContentTypeOptions.query';
 
-const CONTENT_TYPES = [
-  { value: 'photo', label: 'Photo' },
-  { value: 'video', label: 'Video' },
-  { value: 'photo_set', label: 'Photo Set' },
-  { value: 'video_set', label: 'Video Set' },
-  { value: 'mixed', label: 'Mixed (Photos + Videos)' },
-  { value: 'gif', label: 'GIF' },
-  { value: 'livestream', label: 'Livestream' },
-  { value: 'audio', label: 'Audio' },
-  { value: 'text', label: 'Text Only' },
-] as const;
+interface ProfileItem {
+  id: string;
+  name: string;
+  type: string;
+}
 
+// --- Searchable Single-Select Dropdown ---
+function SearchableSelect({
+  items,
+  value,
+  onChange,
+  placeholder = 'Select...',
+  loading = false,
+  icon: Icon,
+}: {
+  items: ProfileItem[];
+  value: string;
+  onChange: (id: string, name: string) => void;
+  placeholder?: string;
+  loading?: boolean;
+  icon?: React.ElementType;
+}) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const ref = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const selectedItem = items.find((i) => i.id === value);
+
+  const filtered = useMemo(
+    () =>
+      search
+        ? items.filter((i) => i.name.toLowerCase().includes(search.toLowerCase()))
+        : items,
+    [items, search]
+  );
+
+  const handleClickOutside = useCallback((e: MouseEvent) => {
+    if (ref.current && !ref.current.contains(e.target as Node)) {
+      setOpen(false);
+      setSearch('');
+    }
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [handleClickOutside]);
+
+  useEffect(() => {
+    if (open && inputRef.current) inputRef.current.focus();
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className={`w-full flex items-center gap-3 px-4 py-3 border rounded-xl bg-zinc-800/50 text-left transition-all ${
+          open
+            ? 'border-brand-light-pink ring-2 ring-brand-light-pink/20'
+            : 'border-zinc-700/50 hover:border-zinc-600'
+        }`}
+      >
+        {Icon && (
+          <div className="flex-shrink-0 w-8 h-8 rounded-lg bg-brand-light-pink/10 flex items-center justify-center">
+            <Icon className="w-4 h-4 text-brand-light-pink" />
+          </div>
+        )}
+        <span className={`flex-1 text-sm truncate ${selectedItem ? 'text-white' : 'text-zinc-500'}`}>
+          {selectedItem ? selectedItem.name : placeholder}
+        </span>
+        <ChevronDown
+          className={`w-4 h-4 text-zinc-500 transition-transform ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {open && (
+        <div className="absolute z-50 mt-2 w-full bg-zinc-900 border border-zinc-700/50 rounded-xl shadow-2xl shadow-black/40 overflow-hidden animate-in fade-in slide-in-from-top-1 duration-150">
+          {/* Search */}
+          <div className="p-2 border-b border-zinc-800">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-zinc-500" />
+              <input
+                ref={inputRef}
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search models..."
+                className="w-full pl-9 pr-4 py-2.5 text-sm bg-zinc-800/80 border border-zinc-700/50 rounded-lg text-white placeholder-zinc-500 focus:outline-none focus:border-brand-light-pink/50 focus:ring-1 focus:ring-brand-light-pink/20"
+              />
+            </div>
+          </div>
+
+          {/* Options */}
+          <div className="max-h-56 overflow-y-auto overscroll-contain custom-scrollbar">
+            {loading ? (
+              <div className="flex items-center justify-center gap-2 py-8 text-zinc-500">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                <span className="text-sm">Loading models...</span>
+              </div>
+            ) : filtered.length === 0 ? (
+              <div className="py-8 text-center text-sm text-zinc-500">
+                No models found
+              </div>
+            ) : (
+              <div className="p-1">
+                {/* Clear selection option */}
+                {value && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onChange('', '');
+                      setOpen(false);
+                      setSearch('');
+                    }}
+                    className="w-full flex items-center gap-3 px-3 py-2 text-sm text-zinc-400 hover:bg-zinc-800 rounded-lg transition-colors"
+                  >
+                    <X className="w-4 h-4" />
+                    Clear selection
+                  </button>
+                )}
+                {filtered.map((item) => {
+                  const isSelected = item.id === value;
+                  return (
+                    <button
+                      key={item.id}
+                      type="button"
+                      onClick={() => {
+                        onChange(item.id, item.name);
+                        setOpen(false);
+                        setSearch('');
+                      }}
+                      className={`w-full flex items-center gap-3 px-3 py-2.5 text-sm rounded-lg transition-colors ${
+                        isSelected
+                          ? 'bg-brand-light-pink/15 text-brand-light-pink'
+                          : 'text-zinc-300 hover:bg-zinc-800 hover:text-white'
+                      }`}
+                    >
+                      <div
+                        className={`flex-shrink-0 w-7 h-7 rounded-full flex items-center justify-center text-xs font-semibold ${
+                          isSelected
+                            ? 'bg-brand-light-pink/20 text-brand-light-pink'
+                            : 'bg-zinc-800 text-zinc-400'
+                        }`}
+                      >
+                        {item.name.charAt(0).toUpperCase()}
+                      </div>
+                      <span className="flex-1 text-left truncate">{item.name}</span>
+                      {item.type !== 'of_model' && (
+                        <span className="flex-shrink-0 text-[10px] px-1.5 py-0.5 rounded bg-zinc-800 text-zinc-500 uppercase tracking-wider">
+                          {item.type}
+                        </span>
+                      )}
+                      {isSelected && <Check className="w-4 h-4 flex-shrink-0 text-brand-light-pink" />}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+
+          {/* Footer count */}
+          <div className="px-3 py-2 border-t border-zinc-800 text-[11px] text-zinc-600">
+            {filtered.length} model{filtered.length !== 1 ? 's' : ''} available
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// --- Searchable Multi-Select Dropdown ---
+function SearchableMultiSelect({
+  items,
+  selectedValues,
+  onAdd,
+  onRemove,
+  placeholder = 'Select...',
+  loading = false,
+}: {
+  items: ProfileItem[];
+  selectedValues: string[];
+  onAdd: (name: string) => void;
+  onRemove: (name: string) => void;
+  placeholder?: string;
+  loading?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const ref = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const availableItems = useMemo(
+    () => items.filter((i) => !selectedValues.includes(i.name)),
+    [items, selectedValues]
+  );
+
+  const filtered = useMemo(
+    () =>
+      search
+        ? availableItems.filter((i) =>
+            i.name.toLowerCase().includes(search.toLowerCase())
+          )
+        : availableItems,
+    [availableItems, search]
+  );
+
+  const handleClickOutside = useCallback((e: MouseEvent) => {
+    if (ref.current && !ref.current.contains(e.target as Node)) {
+      setOpen(false);
+      setSearch('');
+    }
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [handleClickOutside]);
+
+  useEffect(() => {
+    if (open && inputRef.current) inputRef.current.focus();
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative">
+      {/* Trigger */}
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className={`w-full flex items-center gap-3 px-4 py-3 border rounded-xl bg-zinc-800/50 text-left transition-all ${
+          open
+            ? 'border-brand-light-pink ring-2 ring-brand-light-pink/20'
+            : 'border-zinc-700/50 hover:border-zinc-600'
+        }`}
+      >
+        <div className="flex-shrink-0 w-8 h-8 rounded-lg bg-brand-light-pink/10 flex items-center justify-center">
+          <Users className="w-4 h-4 text-brand-light-pink" />
+        </div>
+        <span className="flex-1 text-sm text-zinc-500 truncate">
+          {selectedValues.length > 0
+            ? `${selectedValues.length} model${selectedValues.length !== 1 ? 's' : ''} selected`
+            : placeholder}
+        </span>
+        <ChevronDown
+          className={`w-4 h-4 text-zinc-500 transition-transform ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {/* Selected chips */}
+      {selectedValues.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mt-2.5">
+          {selectedValues.map((tag) => (
+            <button
+              key={tag}
+              type="button"
+              onClick={() => onRemove(tag)}
+              className="group inline-flex items-center gap-1.5 px-2.5 py-1 bg-brand-light-pink/10 border border-brand-light-pink/20 text-brand-light-pink rounded-lg text-xs font-medium hover:bg-brand-light-pink/20 hover:border-brand-light-pink/40 transition-all"
+            >
+              <span className="w-4 h-4 rounded-full bg-brand-light-pink/20 flex items-center justify-center text-[9px] font-bold">
+                {tag.charAt(0).toUpperCase()}
+              </span>
+              {tag}
+              <X className="w-3 h-3 opacity-60 group-hover:opacity-100 transition-opacity" />
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Dropdown - opens upward to avoid clipping */}
+      {open && (
+        <div className="absolute z-50 bottom-full mb-2 w-full bg-zinc-900 border border-zinc-700/50 rounded-xl shadow-2xl shadow-black/40 overflow-hidden animate-in fade-in slide-in-from-bottom-1 duration-150">
+          {/* Footer */}
+          <div className="px-3 py-2 border-b border-zinc-800 flex items-center justify-between text-[11px] text-zinc-600">
+            <span>
+              {filtered.length} available
+            </span>
+            {selectedValues.length > 0 && (
+              <button
+                type="button"
+                onClick={() => {
+                  selectedValues.forEach((v) => onRemove(v));
+                  setSearch('');
+                }}
+                className="text-zinc-500 hover:text-zinc-300 transition-colors"
+              >
+                Clear all
+              </button>
+            )}
+          </div>
+
+          {/* Options */}
+          <div className="max-h-56 overflow-y-auto overscroll-contain custom-scrollbar">
+            {loading ? (
+              <div className="flex items-center justify-center gap-2 py-8 text-zinc-500">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                <span className="text-sm">Loading models...</span>
+              </div>
+            ) : filtered.length === 0 ? (
+              <div className="py-8 text-center text-sm text-zinc-500">
+                {availableItems.length === 0 ? 'All models selected' : 'No models found'}
+              </div>
+            ) : (
+              <div className="p-1">
+                {filtered.map((item) => (
+                  <button
+                    key={item.id}
+                    type="button"
+                    onClick={() => {
+                      onAdd(item.name);
+                      setSearch('');
+                    }}
+                    className="w-full flex items-center gap-3 px-3 py-2.5 text-sm text-zinc-300 hover:bg-zinc-800 hover:text-white rounded-lg transition-colors"
+                  >
+                    <div className="flex-shrink-0 w-7 h-7 rounded-full bg-zinc-800 flex items-center justify-center text-xs font-semibold text-zinc-400">
+                      {item.name.charAt(0).toUpperCase()}
+                    </div>
+                    <span className="flex-1 text-left truncate">{item.name}</span>
+                    <div className="flex-shrink-0 w-5 h-5 rounded border border-zinc-700 flex items-center justify-center">
+                      {/* empty checkbox */}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Search at bottom for upward dropdown */}
+          <div className="p-2 border-t border-zinc-800">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-zinc-500" />
+              <input
+                ref={inputRef}
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search models..."
+                className="w-full pl-9 pr-4 py-2.5 text-sm bg-zinc-800/80 border border-zinc-700/50 rounded-lg text-white placeholder-zinc-500 focus:outline-none focus:border-brand-light-pink/50 focus:ring-1 focus:ring-brand-light-pink/20"
+              />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// --- Content Tags Multi-Select (checkbox style with search and Select All) ---
+function ContentTagsSelect({
+  selectedTags,
+  onChange,
+}: {
+  selectedTags: string[];
+  onChange: (tags: string[]) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const ref = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const filtered = useMemo(
+    () =>
+      search
+        ? CONTENT_TAGS.filter((tag) =>
+            tag.toLowerCase().includes(search.toLowerCase())
+          )
+        : [...CONTENT_TAGS],
+    [search]
+  );
+
+  const allSelected = selectedTags.length === CONTENT_TAGS.length;
+
+  const handleClickOutside = useCallback((e: MouseEvent) => {
+    if (ref.current && !ref.current.contains(e.target as Node)) {
+      setOpen(false);
+      setSearch('');
+    }
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [handleClickOutside]);
+
+  useEffect(() => {
+    if (open && inputRef.current) inputRef.current.focus();
+  }, [open]);
+
+  const toggleTag = useCallback(
+    (tag: string) => {
+      if (selectedTags.includes(tag)) {
+        onChange(selectedTags.filter((t) => t !== tag));
+      } else {
+        onChange([...selectedTags, tag]);
+      }
+    },
+    [selectedTags, onChange]
+  );
+
+  const toggleAll = useCallback(() => {
+    if (allSelected) {
+      onChange([]);
+    } else {
+      onChange([...CONTENT_TAGS]);
+    }
+  }, [allSelected, onChange]);
+
+  return (
+    <div ref={ref} className="relative">
+      {/* Trigger */}
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className={`w-full flex items-center gap-3 px-4 py-3 border rounded-xl bg-zinc-800/50 text-left transition-all ${
+          open
+            ? 'border-brand-light-pink ring-2 ring-brand-light-pink/20'
+            : 'border-zinc-700/50 hover:border-zinc-600'
+        }`}
+      >
+        <span className={`flex-1 text-sm truncate ${selectedTags.length > 0 ? 'text-white' : 'text-zinc-500'}`}>
+          {selectedTags.length > 0
+            ? selectedTags.length <= 3
+              ? selectedTags.join(', ')
+              : `${selectedTags.slice(0, 3).join(', ')} +${selectedTags.length - 3} more`
+            : 'Select content tags...'}
+        </span>
+        <ChevronDown
+          className={`w-4 h-4 text-zinc-500 transition-transform ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {/* Selected chips */}
+      {selectedTags.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mt-2">
+          {selectedTags.map((tag) => (
+            <button
+              key={tag}
+              type="button"
+              onClick={() => toggleTag(tag)}
+              className="group inline-flex items-center gap-1 px-2 py-0.5 bg-brand-mid-pink/10 border border-brand-mid-pink/20 text-brand-mid-pink rounded-md text-xs font-medium hover:bg-brand-mid-pink/20 hover:border-brand-mid-pink/40 transition-all"
+            >
+              {tag}
+              <X className="w-3 h-3 opacity-60 group-hover:opacity-100 transition-opacity" />
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Dropdown */}
+      {open && (
+        <div className="absolute z-50 mt-2 w-full bg-zinc-900 border border-zinc-700/50 rounded-xl shadow-2xl shadow-black/40 overflow-hidden animate-in fade-in slide-in-from-top-1 duration-150">
+          {/* Search */}
+          <div className="p-2 border-b border-zinc-800">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-zinc-500" />
+              <input
+                ref={inputRef}
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="Search..."
+                className="w-full pl-9 pr-4 py-2.5 text-sm bg-zinc-800/80 border border-zinc-700/50 rounded-lg text-white placeholder-zinc-500 focus:outline-none focus:border-brand-light-pink/50 focus:ring-1 focus:ring-brand-light-pink/20"
+              />
+            </div>
+          </div>
+
+          {/* Options */}
+          <div className="max-h-56 overflow-y-auto overscroll-contain custom-scrollbar">
+            <div className="p-1">
+              {/* Select All */}
+              {!search && (
+                <button
+                  type="button"
+                  onClick={toggleAll}
+                  className={`w-full flex items-center gap-3 px-3 py-2.5 text-sm rounded-lg transition-colors ${
+                    allSelected
+                      ? 'bg-brand-light-pink/15 text-brand-light-pink'
+                      : 'text-zinc-300 hover:bg-zinc-800 hover:text-white'
+                  }`}
+                >
+                  <div
+                    className={`flex-shrink-0 w-5 h-5 rounded border flex items-center justify-center transition-colors ${
+                      allSelected
+                        ? 'bg-brand-light-pink border-brand-light-pink'
+                        : 'border-zinc-600'
+                    }`}
+                  >
+                    {allSelected && <Check className="w-3 h-3 text-white" />}
+                  </div>
+                  <span className="font-medium">(Select All)</span>
+                </button>
+              )}
+
+              {filtered.map((tag) => {
+                const isSelected = selectedTags.includes(tag);
+                return (
+                  <button
+                    key={tag}
+                    type="button"
+                    onClick={() => toggleTag(tag)}
+                    className={`w-full flex items-center gap-3 px-3 py-2.5 text-sm rounded-lg transition-colors ${
+                      isSelected
+                        ? 'bg-brand-light-pink/10 text-brand-light-pink'
+                        : 'text-zinc-300 hover:bg-zinc-800 hover:text-white'
+                    }`}
+                  >
+                    <div
+                      className={`flex-shrink-0 w-5 h-5 rounded border flex items-center justify-center transition-colors ${
+                        isSelected
+                          ? 'bg-brand-light-pink border-brand-light-pink'
+                          : 'border-zinc-600'
+                      }`}
+                    >
+                      {isSelected && <Check className="w-3 h-3 text-white" />}
+                    </div>
+                    <span>{tag}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="px-3 py-2 border-t border-zinc-800 flex items-center justify-between text-[11px] text-zinc-600">
+            <span>{selectedTags.length} of {CONTENT_TAGS.length} selected</span>
+            {selectedTags.length > 0 && (
+              <button
+                type="button"
+                onClick={() => onChange([])}
+                className="text-zinc-500 hover:text-zinc-300 transition-colors"
+              >
+                Clear all
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// --- Content Type Select (with pricing info from API) ---
+function ContentTypeSelect({
+  value,
+  onChange,
+  options,
+  loading,
+  onRefresh,
+}: {
+  value: string;
+  onChange: (option: ContentTypeOption | null) => void;
+  options: ContentTypeOption[];
+  loading: boolean;
+  onRefresh: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const selectedOption = useMemo(
+    () => options.find((opt) => opt.id === value) || null,
+    [options, value]
+  );
+
+  const handleClickOutside = useCallback((e: MouseEvent) => {
+    if (ref.current && !ref.current.contains(e.target as Node)) {
+      setOpen(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [handleClickOutside]);
+
+  const displayText = useMemo(() => {
+    if (!selectedOption) return null;
+    const pageDisplay = formatPageType(selectedOption.pageType);
+    const priceDisplay = formatContentTypePrice(selectedOption);
+    return `${selectedOption.label} ${pageDisplay} - ${priceDisplay}`;
+  }, [selectedOption]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className={`w-full flex items-center gap-3 px-4 py-3 border rounded-xl bg-zinc-800/50 text-left transition-all ${
+          open
+            ? 'border-brand-light-pink ring-2 ring-brand-light-pink/20'
+            : 'border-zinc-700/50 hover:border-zinc-600'
+        }`}
+      >
+        <span className={`flex-1 text-sm truncate ${selectedOption ? 'text-white' : 'text-zinc-500'}`}>
+          {displayText || 'Select content type...'}
+        </span>
+        <ChevronDown
+          className={`w-4 h-4 text-zinc-500 transition-transform ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {open && (
+        <div className="absolute z-50 mt-2 w-full bg-zinc-900 border border-zinc-700/50 rounded-xl shadow-2xl shadow-black/40 overflow-hidden animate-in fade-in slide-in-from-top-1 duration-150">
+          <div className="max-h-72 overflow-y-auto overscroll-contain custom-scrollbar">
+            {loading ? (
+              <div className="flex items-center justify-center gap-2 py-8 text-zinc-500">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                <span className="text-sm">Loading content types...</span>
+              </div>
+            ) : options.length === 0 ? (
+              <div className="py-8 text-center text-sm text-zinc-500">
+                No content types available
+              </div>
+            ) : (
+              <div className="p-1">
+                {/* Clear selection */}
+                {value && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onChange(null);
+                      setOpen(false);
+                    }}
+                    className="w-full flex items-center gap-3 px-3 py-2 text-sm text-zinc-400 hover:bg-zinc-800 rounded-lg transition-colors"
+                  >
+                    <X className="w-4 h-4" />
+                    Clear selection
+                  </button>
+                )}
+                {options.map((option) => {
+                  const isSelected = option.id === value;
+                  const pageDisplay = formatPageType(option.pageType);
+                  const priceDisplay = formatContentTypePrice(option);
+                  const modelDisplay = option.model
+                    ? ` [${option.model.displayName || option.model.name}]`
+                    : '';
+
+                  return (
+                    <button
+                      key={option.id}
+                      type="button"
+                      onClick={() => {
+                        onChange(option);
+                        setOpen(false);
+                      }}
+                      className={`w-full text-left px-3 py-3 text-sm rounded-lg transition-colors ${
+                        isSelected
+                          ? 'bg-brand-light-pink/15 text-brand-light-pink'
+                          : 'text-zinc-300 hover:bg-zinc-800 hover:text-white'
+                      }`}
+                    >
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="font-medium truncate">
+                          {option.label} {pageDisplay}
+                        </span>
+                        <span className={`flex-shrink-0 text-xs font-semibold ${
+                          option.isFree ? 'text-green-400' : 'text-brand-mid-pink'
+                        }`}>
+                          {priceDisplay}
+                        </span>
+                      </div>
+                      {(option.description || modelDisplay) && (
+                        <p className="text-xs text-zinc-500 mt-0.5 truncate">
+                          {option.description}{modelDisplay}
+                        </p>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// --- Main Component ---
 interface ContentDetailsFieldsProps {
   register: UseFormRegister<CreateSubmissionWithComponents>;
   setValue: UseFormSetValue<CreateSubmissionWithComponents>;
@@ -33,52 +707,138 @@ export function ContentDetailsFields({
   const internalModelTags = watch('internalModelTags') || [];
   const externalCreatorTags = watch('externalCreatorTags') || '';
   const pricingCategory = watch('pricingCategory') || 'PORN_ACCURATE';
+  const modelId = watch('modelId') || '';
+  const contentTags = watch('contentTags') || [];
 
-  // Parse @ mentions from external tags
+  const [profiles, setProfiles] = useState<ProfileItem[]>([]);
+  const [loadingProfiles, setLoadingProfiles] = useState(true);
+  const [selectedContentTypeOptionId, setSelectedContentTypeOptionId] = useState('');
+
+  // Fetch content type options from API
+  const {
+    data: contentTypeOptions = [],
+    isLoading: loadingContentTypes,
+    refetch: refetchContentTypes,
+  } = useContentTypeOptions({
+    category: pricingCategory,
+    modelId: modelId || undefined,
+    fetchAll: !modelId,
+  });
+
+  useEffect(() => {
+    async function fetchProfiles() {
+      try {
+        const response = await fetch('/api/instagram-profiles/list');
+        if (response.ok) {
+          const data = await response.json();
+          setProfiles(data);
+        }
+      } catch (error) {
+        console.error('Failed to fetch profiles:', error);
+      } finally {
+        setLoadingProfiles(false);
+      }
+    }
+    fetchProfiles();
+  }, []);
+
+  const allProfiles = profiles;
+  const ofModelProfiles = useMemo(
+    () => profiles.filter((p) => p.type === 'of_model'),
+    [profiles]
+  );
+
   const parsedExternalTags = externalCreatorTags
     .match(/@\w+/g)
     ?.map((tag) => tag.substring(1)) || [];
 
-  // For demo, using static model list. In production, fetch from API
-  const availableModels = [
-    { id: '1', name: 'Model Alpha' },
-    { id: '2', name: 'Model Beta' },
-    { id: '3', name: 'Model Gamma' },
-    { id: '4', name: 'Model Delta' },
-  ];
+  const addInternalTag = useCallback(
+    (modelName: string) => {
+      if (!internalModelTags.includes(modelName)) {
+        setValue('internalModelTags', [...internalModelTags, modelName]);
+      }
+    },
+    [internalModelTags, setValue]
+  );
 
-  const addInternalTag = (modelName: string) => {
-    if (!internalModelTags.includes(modelName)) {
-      setValue('internalModelTags', [...internalModelTags, modelName]);
-    }
-  };
+  const removeInternalTag = useCallback(
+    (modelName: string) => {
+      setValue(
+        'internalModelTags',
+        internalModelTags.filter((tag) => tag !== modelName)
+      );
+    },
+    [internalModelTags, setValue]
+  );
 
-  const removeInternalTag = (modelName: string) => {
-    setValue(
-      'internalModelTags',
-      internalModelTags.filter((tag) => tag !== modelName)
-    );
-  };
+  const handleContentTypeChange = useCallback(
+    (option: ContentTypeOption | null) => {
+      if (option) {
+        setValue('contentType', option.value as any);
+        setSelectedContentTypeOptionId(option.id);
+      } else {
+        setValue('contentType', undefined);
+        setSelectedContentTypeOptionId('');
+      }
+    },
+    [setValue]
+  );
+
+  const handleContentTagsChange = useCallback(
+    (tags: string[]) => {
+      setValue('contentTags', tags);
+    },
+    [setValue]
+  );
 
   return (
     <div className="space-y-6">
-      {/* Content Type */}
+      {/* Model Dropdown - All profiles */}
       <div>
         <label className="block text-sm font-medium text-zinc-300 mb-2">
-          Content Type
+          Model
           <span className="text-zinc-500 text-xs ml-1">(Optional)</span>
         </label>
-        <select
-          {...register('contentType')}
-          className="w-full px-4 py-3 border border-zinc-700/50 rounded-xl bg-zinc-800/50 text-white focus:ring-2 focus:ring-brand-light-pink focus:border-transparent transition-all"
-        >
-          <option value="">Select content type...</option>
-          {CONTENT_TYPES.map((type) => (
-            <option key={type.value} value={type.value}>
-              {type.label}
-            </option>
-          ))}
-        </select>
+        <SearchableSelect
+          items={allProfiles}
+          value={modelId}
+          onChange={(id, name) => {
+            setValue('modelId', id || undefined);
+            setValue('modelName', name || undefined);
+          }}
+          placeholder="Search and select a model..."
+          loading={loadingProfiles}
+          icon={User}
+        />
+        <p className="text-xs text-zinc-500 mt-1.5">Select the model/influencer for this submission</p>
+        {errors.modelName && (
+          <p className="text-sm text-red-400 mt-1">{errors.modelName.message}</p>
+        )}
+      </div>
+
+      {/* Content Type - Pricing-based from API */}
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <label className="block text-sm font-medium text-zinc-300">
+            Content Type
+            <span className="text-zinc-500 text-xs ml-1">(Optional)</span>
+          </label>
+          <button
+            type="button"
+            onClick={() => refetchContentTypes()}
+            className="p-1 text-zinc-500 hover:text-zinc-300 transition-colors"
+            title="Refresh content types"
+          >
+            <RefreshCw className={`w-3.5 h-3.5 ${loadingContentTypes ? 'animate-spin' : ''}`} />
+          </button>
+        </div>
+        <ContentTypeSelect
+          value={selectedContentTypeOptionId}
+          onChange={handleContentTypeChange}
+          options={contentTypeOptions}
+          loading={loadingContentTypes}
+          onRefresh={() => refetchContentTypes()}
+        />
         {errors.contentType && (
           <p className="text-sm text-red-400 mt-1">{errors.contentType.message}</p>
         )}
@@ -89,6 +849,18 @@ export function ContentDetailsFields({
         value={pricingCategory}
         onChange={(value) => setValue('pricingCategory', value as any)}
       />
+
+      {/* Content Tags - Multi-select with checkboxes */}
+      <div>
+        <label className="block text-sm font-medium text-zinc-300 mb-2">
+          Content Tags
+          <span className="text-zinc-500 text-xs ml-1">(Optional)</span>
+        </label>
+        <ContentTagsSelect
+          selectedTags={contentTags}
+          onChange={handleContentTagsChange}
+        />
+      </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
         {/* Content Length */}
@@ -144,7 +916,6 @@ export function ContentDetailsFields({
           Tag external collaborators with @ (e.g., @creator1 @creator2)
         </p>
 
-        {/* Display parsed tags */}
         {parsedExternalTags.length > 0 && (
           <div className="flex flex-wrap gap-2 mt-2">
             {parsedExternalTags.map((tag) => (
@@ -165,54 +936,23 @@ export function ContentDetailsFields({
         )}
       </div>
 
-      {/* Internal Model Tags */}
+      {/* Internal Model Tags - OF Model profiles only, multi-select */}
       <div>
         <label className="block text-sm font-medium text-zinc-300 mb-2">
           Internal Model Tags
           <span className="text-zinc-500 text-xs ml-1">(Optional)</span>
         </label>
-
-        {/* Simple dropdown for demo - can be upgraded to Combobox */}
-        <select
-          onChange={(e) => {
-            if (e.target.value) {
-              addInternalTag(e.target.value);
-              e.target.value = '';
-            }
-          }}
-          className="w-full px-4 py-3 border border-zinc-700/50 rounded-xl bg-zinc-800/50 text-white focus:ring-2 focus:ring-brand-light-pink focus:border-transparent transition-all"
-        >
-          <option value="">Select models to tag...</option>
-          {availableModels
-            .filter((model) => !internalModelTags.includes(model.name))
-            .map((model) => (
-              <option key={model.id} value={model.name}>
-                {model.name}
-              </option>
-            ))}
-        </select>
-
-        <p className="text-xs text-zinc-500 mt-1">
-          Tag related internal models for cross-promotion
+        <SearchableMultiSelect
+          items={ofModelProfiles}
+          selectedValues={internalModelTags}
+          onAdd={addInternalTag}
+          onRemove={removeInternalTag}
+          placeholder="Search and tag models..."
+          loading={loadingProfiles}
+        />
+        <p className="text-xs text-zinc-500 mt-1.5">
+          Tag related OF models for cross-promotion
         </p>
-
-        {/* Selected Tags */}
-        {internalModelTags.length > 0 && (
-          <div className="flex flex-wrap gap-2 mt-3">
-            {internalModelTags.map((tag) => (
-              <button
-                key={tag}
-                type="button"
-                onClick={() => removeInternalTag(tag)}
-                className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-brand-light-pink/20 border border-brand-light-pink/30 text-brand-light-pink rounded-lg text-sm font-medium hover:bg-brand-light-pink/30 transition-colors"
-              >
-                {tag}
-                <X className="w-3.5 h-3.5" />
-              </button>
-            ))}
-          </div>
-        )}
-
         {errors.internalModelTags && (
           <p className="text-sm text-red-400 mt-1">
             {errors.internalModelTags.message}

--- a/components/content-submission/SubmissionForm.tsx
+++ b/components/content-submission/SubmissionForm.tsx
@@ -381,7 +381,84 @@ export const SubmissionForm = memo(function SubmissionForm({
                   </StepContent>
                 )}
 
-                {/* Add other step renderings as needed */}
+                {/* File Upload Step */}
+                {currentStepInfo?.id === 'files' && (
+                  <StepContent title="Upload Files" subtitle="Upload images, videos, or other files for this submission">
+                    {submissionId ? (
+                      <FileUploadZone submissionId={submissionId} />
+                    ) : (
+                      <div className="bg-amber-500/10 border border-amber-500/20 rounded-xl p-6">
+                        <p className="text-sm text-amber-200/80 font-light">
+                          Save the submission first to upload files
+                        </p>
+                      </div>
+                    )}
+                  </StepContent>
+                )}
+
+                {/* Review & Submit Step */}
+                {currentStepInfo?.id === 'review' && (
+                  <StepContent title="Review & Submit" subtitle="Review your submission details before finalizing">
+                    <div className="space-y-4">
+                      <div className="bg-zinc-800/30 rounded-xl p-6 border border-zinc-700/30">
+                        <h3 className="text-sm font-medium text-zinc-400 mb-3">Submission Overview</h3>
+                        <div className="grid grid-cols-2 gap-4">
+                          <div>
+                            <p className="text-xs text-zinc-500 mb-1">Type</p>
+                            <p className="text-white font-medium">{submissionType === 'otp' ? 'One-Time Post (OTP)' : 'Pay-to-Release (PTR)'}</p>
+                          </div>
+                          <div>
+                            <p className="text-xs text-zinc-500 mb-1">Content Style</p>
+                            <p className="text-white font-medium capitalize">{contentStyle}</p>
+                          </div>
+                          <div>
+                            <p className="text-xs text-zinc-500 mb-1">Platform</p>
+                            <p className="text-white font-medium capitalize">{platform}</p>
+                          </div>
+                          {watch('modelName') && (
+                            <div>
+                              <p className="text-xs text-zinc-500 mb-1">Model</p>
+                              <p className="text-white font-medium">{watch('modelName')}</p>
+                            </div>
+                          )}
+                        </div>
+                      </div>
+
+                      {watch('caption') && (
+                        <div className="bg-zinc-800/30 rounded-xl p-6 border border-zinc-700/30">
+                          <h3 className="text-sm font-medium text-zinc-400 mb-3">Caption</h3>
+                          <p className="text-white text-sm line-clamp-3">{watch('caption')}</p>
+                        </div>
+                      )}
+
+                      {isPTR && watch('releaseSchedule.releaseDate') && (
+                        <div className="bg-zinc-800/30 rounded-xl p-6 border border-zinc-700/30">
+                          <h3 className="text-sm font-medium text-zinc-400 mb-3">Release Schedule</h3>
+                          <div className="grid grid-cols-2 gap-4">
+                            <div>
+                              <p className="text-xs text-zinc-500 mb-1">Release Date</p>
+                              <p className="text-white">{watch('releaseSchedule.releaseDate')?.toString()}</p>
+                            </div>
+                            {watch('releaseSchedule.releaseTime') && (
+                              <div>
+                                <p className="text-xs text-zinc-500 mb-1">Release Time</p>
+                                <p className="text-white">{watch('releaseSchedule.releaseTime')?.toString()}</p>
+                              </div>
+                            )}
+                          </div>
+                        </div>
+                      )}
+
+                      <div className="bg-gradient-to-r from-brand-light-pink/10 to-brand-dark-pink/10 border border-brand-light-pink/20 rounded-xl p-6">
+                        <p className="text-white font-medium mb-1">Ready to submit?</p>
+                        <p className="text-sm text-zinc-400">
+                          Click Submit below to create your {submissionType === 'otp' ? 'OTP' : 'PTR'} submission.
+                          {!submissionId && ' Files can be uploaded after creation.'}
+                        </p>
+                      </div>
+                    </div>
+                  </StepContent>
+                )}
               </div>
             </motion.div>
           </AnimatePresence>
@@ -457,9 +534,11 @@ export const SubmissionForm = memo(function SubmissionForm({
 // Helper Components
 const StepContent = memo(function StepContent({
   title,
+  subtitle,
   children,
 }: {
   title: string;
+  subtitle?: string;
   children: React.ReactNode;
 }) {
   return (
@@ -468,6 +547,9 @@ const StepContent = memo(function StepContent({
         <h2 className="text-3xl sm:text-4xl font-light text-white tracking-tight">
           {title}
         </h2>
+        {subtitle && (
+          <p className="text-lg text-zinc-400 font-light">{subtitle}</p>
+        )}
       </div>
       {children}
     </div>

--- a/lib/constants/contentTags.ts
+++ b/lib/constants/contentTags.ts
@@ -1,0 +1,31 @@
+/**
+ * Content Tags for content submissions
+ * Used for categorizing content in the QA review process
+ */
+
+export const CONTENT_TAGS = [
+  'Dildo',
+  'Fingering',
+  'Vibrator',
+  'Squirting',
+  'Blowjob',
+  'Handjob',
+  'Pussy Eating',
+  'Rim Job',
+  'Double Penetration',
+  'Cream Pie',
+  'POV',
+  'Creaming',
+  'Rough',
+  'Toys',
+  'Anal',
+  'BBC',
+  'Drooling',
+  'Footjob',
+  'Doggy',
+  'Missionary',
+  'Cowgirl',
+  'Reversed Cowgirl',
+] as const;
+
+export type ContentTag = (typeof CONTENT_TAGS)[number];

--- a/lib/hooks/useContentTypeOptions.query.ts
+++ b/lib/hooks/useContentTypeOptions.query.ts
@@ -1,0 +1,113 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+export interface ContentTypeOption {
+  id: string;
+  value: string;
+  label: string;
+  priceType: string | null;
+  priceFixed: number | null;
+  priceMin: number | null;
+  priceMax: number | null;
+  description: string | null;
+  isActive: boolean;
+  order: number;
+  category: string;
+  isFree: boolean;
+  modelId: string | null;
+  pageType: string | null;
+  model?: {
+    id: string;
+    name: string;
+    displayName: string;
+  } | null;
+}
+
+interface ContentTypeOptionsResponse {
+  success: boolean;
+  contentTypeOptions: ContentTypeOption[];
+  category: string | null;
+  modelId: string | null;
+  pageType: string | null;
+}
+
+async function fetchContentTypeOptions(params: {
+  category?: string;
+  modelId?: string;
+  modelName?: string;
+  pageType?: string;
+  fetchAll?: boolean;
+}): Promise<ContentTypeOption[]> {
+  const searchParams = new URLSearchParams();
+  if (params.category) searchParams.append('category', params.category);
+  if (params.modelId) searchParams.append('modelId', params.modelId);
+  if (params.modelName) searchParams.append('modelName', params.modelName);
+  if (params.pageType) searchParams.append('pageType', params.pageType);
+  if (params.fetchAll) searchParams.append('fetchAll', 'true');
+
+  const response = await fetch(`/api/content-type-options?${searchParams.toString()}`);
+  if (!response.ok) {
+    throw new Error('Failed to fetch content type options');
+  }
+
+  const data: ContentTypeOptionsResponse = await response.json();
+  if (!data.success) {
+    throw new Error('Failed to fetch content type options');
+  }
+
+  return data.contentTypeOptions;
+}
+
+export function useContentTypeOptions(params: {
+  category?: string;
+  modelId?: string;
+  modelName?: string;
+  pageType?: string;
+  fetchAll?: boolean;
+  enabled?: boolean;
+} = {}) {
+  const { enabled = true, ...queryParams } = params;
+
+  return useQuery({
+    queryKey: ['contentTypeOptions', queryParams],
+    queryFn: () => fetchContentTypeOptions(queryParams),
+    enabled,
+    staleTime: 1000 * 60 * 2,
+    gcTime: 1000 * 60 * 5,
+    refetchOnWindowFocus: false,
+  });
+}
+
+export function formatContentTypePrice(option: ContentTypeOption): string {
+  if (option.isFree) return 'Free';
+  if (!option.priceType) return '$--.--';
+
+  switch (option.priceType) {
+    case 'FIXED':
+      return option.priceFixed != null ? `$${option.priceFixed.toFixed(2)}` : '$--.--';
+    case 'RANGE':
+      return option.priceMin != null && option.priceMax != null
+        ? `$${option.priceMin.toFixed(2)}-${option.priceMax.toFixed(2)}`
+        : '$--.--';
+    case 'MINIMUM':
+      return option.priceMin != null ? `$${option.priceMin.toFixed(2)}+` : '$--.--';
+    default:
+      return '$--.--';
+  }
+}
+
+export function formatPageType(pageType: string | null): string {
+  switch (pageType) {
+    case 'ALL_PAGES':
+      return '(All Pages)';
+    case 'FREE':
+      return '(Free)';
+    case 'PAID':
+      return '(Paid)';
+    case 'VIP':
+      return '(VIP)';
+    default:
+      return '(All Pages)';
+  }
+}

--- a/lib/validations/content-submission.ts
+++ b/lib/validations/content-submission.ts
@@ -9,18 +9,8 @@ export const contentStyleSchema = z.enum(['normal', 'poll', 'game', 'ppv', 'bund
 // Priority enum
 export const prioritySchema = z.enum(['low', 'normal', 'high', 'urgent']);
 
-// Content type enum - expanded for detailed tracking
-export const contentTypeSchema = z.enum([
-  'photo',
-  'video',
-  'photo_set',
-  'video_set',
-  'mixed', // Photos + Videos
-  'gif',
-  'livestream',
-  'audio',
-  'text',
-]);
+// Content type - accepts any string value (dynamic from ContentTypeOption database)
+export const contentTypeSchema = z.string();
 
 // Component module enum
 export const componentModuleSchema = z.enum(['pricing', 'release', 'upload']);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -516,6 +516,7 @@ model InstagramProfile {
   selectedContentTypes   String[]              @default([])
   status                 String                @default("active")
   type                   String                @default("real")
+  metadata               Json?
   captions               Caption[]
   bookmarks              FeedPostBookmark[]    @relation("ProfileBookmarks")
   commentLikes           FeedPostCommentLike[] @relation("ProfileCommentLikes")
@@ -1542,6 +1543,7 @@ model of_models {
   of_model_assets             of_model_assets[]
   of_model_details            of_model_details?
   of_model_pricing_categories of_model_pricing_categories[]
+  contentTypeOptions          ContentTypeOption[]           @relation("ModelContentTypes")
 
   @@index([slug])
   @@index([status])
@@ -1764,6 +1766,7 @@ model content_submissions {
   caption                              String?
   driveLink                            String?
   contentType                          String?
+  contentTypeOptionId                  String?
   contentCount                         String?
   contentLength                        String?
   contentTags                          String[]                              @default([])
@@ -1778,6 +1781,7 @@ model content_submissions {
   content_submission_files             content_submission_files[]
   content_submission_pricing           content_submission_pricing?
   content_submission_release_schedules content_submission_release_schedules?
+  contentTypeOption                    ContentTypeOption?                    @relation("SubmissionContentType", fields: [contentTypeOptionId], references: [id])
   users                                User                                  @relation(fields: [clerkId], references: [clerkId], onDelete: Cascade)
   organizations                        Organization                          @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
@@ -1790,6 +1794,61 @@ model content_submissions {
   @@index([pricingCategory])
   @@index([status])
   @@index([submissionType])
+}
+
+model ContentTypeOption {
+  id             String                      @id @default(cuid())
+  value          String
+  label          String
+  priceType      String?
+  priceFixed     Float?
+  priceMin       Float?
+  priceMax       Float?
+  description    String?
+  isActive       Boolean                     @default(true)
+  order          Int                         @default(0)
+  createdAt      DateTime                    @default(now())
+  updatedAt      DateTime                    @updatedAt
+  category       String
+  isFree         Boolean                     @default(false)
+  modelId        String?
+  pageType       String?                     @default("ALL_PAGES")
+  model          of_models?                  @relation("ModelContentTypes", fields: [modelId], references: [id], onDelete: Cascade)
+  pricingHistory ContentTypePricingHistory[] @relation("ContentTypePricingHistory")
+  submissions    content_submissions[]       @relation("SubmissionContentType")
+
+  @@index([isActive])
+  @@index([order])
+  @@index([category])
+  @@index([isFree])
+  @@index([modelId])
+  @@index([pageType])
+  @@index([value, category, modelId, pageType])
+}
+
+model ContentTypePricingHistory {
+  id                  String            @id @default(cuid())
+  contentTypeOptionId String
+  changeType          String
+  oldPriceType        String?
+  oldPriceFixed       Float?
+  oldPriceMin         Float?
+  oldPriceMax         Float?
+  oldLabel            String?
+  oldIsFree           Boolean?
+  newPriceType        String?
+  newPriceFixed       Float?
+  newPriceMin         Float?
+  newPriceMax         Float?
+  newLabel            String?
+  newIsFree           Boolean?
+  changedById         String?
+  reason              String?
+  createdAt           DateTime          @default(now())
+  contentTypeOption   ContentTypeOption @relation("ContentTypePricingHistory", fields: [contentTypeOptionId], references: [id], onDelete: Cascade)
+
+  @@index([contentTypeOptionId])
+  @@index([createdAt])
 }
 
 enum SyncStatus {


### PR DESCRIPTION
- Add ContentTypeOption and ContentTypePricingHistory database models
- Create /api/content-type-options endpoint with category/model/pageType filtering
- Add useContentTypeOptions TanStack Query hook with price formatting helpers
- Port CONTENT_TAGS constant (22 tags) from legacy platform
- Replace static content type select with dynamic pricing-based dropdown
- Add content tags multi-select with search, checkboxes, and Select All
- Extend influencer profiles with OF Model business fields, pricing categories, and migration tracking
- Add lightweight /api/instagram-profiles/list endpoint for dropdowns
- Filter of_model profiles from influencer page during transition
- Add metadata JSON field to InstagramProfile schema