### PR TITLE
feat: add Sexting Sets and Wall Post templates with task detail modals

### DIFF
--- a/app/[tenant]/(dashboard)/spaces/SpaceCard.tsx
+++ b/app/[tenant]/(dashboard)/spaces/SpaceCard.tsx
@@ -1,27 +1,40 @@
 'use client';
 
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { Layers, Lock, Globe } from 'lucide-react';
 import type { Space } from '@/lib/hooks/useSpaces.query';
 
-interface SpaceCardProps {
-  space: Space;
-  onClick?: () => void;
-}
+const TEMPLATE_LABELS: Record<string, string> = {
+  KANBAN: 'Kanban',
+  WALL_POST: 'Wall Post',
+  SEXTING_SETS: 'Sexting Sets',
+  OTP_PTR: 'OTP/PTR',
+};
 
-export function SpaceCard({ space, onClick }: SpaceCardProps) {
+const TEMPLATE_COLORS: Record<string, string> = {
+  KANBAN: 'bg-brand-blue/10 text-brand-blue',
+  WALL_POST: 'bg-brand-light-pink/10 text-brand-light-pink',
+  SEXTING_SETS: 'bg-purple-500/10 text-purple-500',
+  OTP_PTR: 'bg-amber-500/10 text-amber-500',
+};
+
+export function SpaceCard({ space }: { space: Space }) {
+  const params = useParams<{ tenant: string }>();
+
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="w-full text-left rounded-2xl border border-gray-200 dark:border-brand-mid-pink/20 bg-white/80 dark:bg-gray-900/70 px-4 py-3 sm:px-5 sm:py-4 shadow-sm hover:shadow-md transition-all hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-light-pink"
+    <Link
+      href={`/${params.tenant}/spaces/${space.slug}`}
+      className="group block w-full rounded-2xl border border-gray-200 dark:border-brand-mid-pink/20 bg-white/80 dark:bg-gray-900/70 px-4 py-3 sm:px-5 sm:py-4 shadow-sm hover:shadow-md transition-all hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-light-pink"
     >
       <div className="flex items-start justify-between gap-3">
-        <div>
-          <div className="inline-flex items-center gap-2 mb-1.5">
-            <h3 className="text-sm sm:text-base font-semibold text-gray-900 dark:text-brand-off-white">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 mb-1.5">
+            <h3 className="text-sm sm:text-base font-semibold text-gray-900 dark:text-brand-off-white truncate group-hover:text-brand-light-pink transition-colors">
               {space.name}
             </h3>
-            <span className="inline-flex items-center rounded-full bg-brand-light-pink/10 text-[10px] sm:text-xs font-medium text-brand-light-pink px-2 py-0.5">
-              {space.templateType === 'KANBAN' ? 'Kanban board' : space.templateType}
+            <span className={`inline-flex items-center rounded-full text-[10px] sm:text-xs font-medium px-2 py-0.5 ${TEMPLATE_COLORS[space.templateType] ?? 'bg-gray-100 text-gray-500'}`}>
+              {TEMPLATE_LABELS[space.templateType] ?? space.templateType}
             </span>
           </div>
           {space.description && (
@@ -29,17 +42,32 @@ export function SpaceCard({ space, onClick }: SpaceCardProps) {
               {space.description}
             </p>
           )}
+          <div className="flex items-center gap-3 mt-2">
+            {space.key && (
+              <span className="text-[10px] font-mono text-gray-400 dark:text-gray-500 bg-gray-100 dark:bg-gray-800 rounded px-1.5 py-0.5">
+                {space.key}
+              </span>
+            )}
+            {space.access === 'PRIVATE' ? (
+              <span className="flex items-center gap-1 text-[10px] text-gray-400 dark:text-gray-500">
+                <Lock className="h-2.5 w-2.5" /> Private
+              </span>
+            ) : (
+              <span className="flex items-center gap-1 text-[10px] text-gray-400 dark:text-gray-500">
+                <Globe className="h-2.5 w-2.5" /> Open
+              </span>
+            )}
+          </div>
         </div>
         <div className="flex flex-col items-end gap-1">
-          <span className="inline-flex h-8 w-8 items-center justify-center rounded-xl bg-brand-light-pink/10 text-brand-light-pink text-xs font-semibold">
-            {space.name.charAt(0).toUpperCase()}
+          <span className="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-brand-light-pink/10 text-brand-light-pink">
+            <Layers className="h-4 w-4" />
           </span>
           <span className="text-[10px] text-gray-400 dark:text-gray-500">
-            Created {new Date(space.createdAt).toLocaleDateString()}
+            {new Date(space.createdAt).toLocaleDateString()}
           </span>
         </div>
       </div>
-    </button>
+    </Link>
   );
 }
-

--- a/app/[tenant]/(dashboard)/spaces/SpacesDropdown.tsx
+++ b/app/[tenant]/(dashboard)/spaces/SpacesDropdown.tsx
@@ -5,35 +5,18 @@ import { Plus, Layers, ChevronUp, ChevronDown } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { CreateSpaceModal } from './CreateSpaceModal';
+import { useSpaces } from '@/lib/hooks/useSpaces.query';
 
 interface SpacesDropdownProps {
   tenant: string;
   sidebarOpen: boolean;
 }
 
-// Static placeholder spaces for the dropdown
-const STATIC_SPACES = [
-  {
-    id: 'space-1',
-    name: 'Content Production',
-    href: '/spaces/content-production',
-  },
-  {
-    id: 'space-2',
-    name: 'Influencer Ops',
-    href: '/spaces/influencer-ops',
-  },
-  {
-    id: 'space-3',
-    name: 'Campaign Planning',
-    href: '/spaces/campaign-planning',
-  },
-];
-
 export function SpacesDropdown({ tenant, sidebarOpen }: SpacesDropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const pathname = usePathname();
+  const { data, isLoading } = useSpaces();
 
   const handleCreateClick = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -41,6 +24,7 @@ export function SpacesDropdown({ tenant, sidebarOpen }: SpacesDropdownProps) {
     setIsCreateModalOpen(true);
   };
 
+  const spaces = data?.spaces ?? [];
   const isActive = pathname?.startsWith(`/${tenant}/spaces`);
 
   if (!sidebarOpen) {
@@ -113,32 +97,42 @@ export function SpacesDropdown({ tenant, sidebarOpen }: SpacesDropdownProps) {
 
         {isOpen && (
           <div className="space-y-1 animate-fadeIn pl-6 xs:pl-7 sm:pl-8">
-            {STATIC_SPACES.map((space) => {
-              const spaceHref = `/${tenant}${space.href}`;
-              const isSpaceActive = pathname === spaceHref;
+            {isLoading ? (
+              <div className="px-2.5 xs:px-3 py-2 xs:py-2.5 text-xs xs:text-sm text-gray-500 dark:text-gray-400">
+                Loading spaces...
+              </div>
+            ) : spaces.length === 0 ? (
+              <div className="px-2.5 xs:px-3 py-2 xs:py-2.5 text-xs xs:text-sm text-gray-500 dark:text-gray-400">
+                No spaces yet. Create one!
+              </div>
+            ) : (
+              spaces.map((space) => {
+                const spaceHref = `/${tenant}/spaces/${space.slug}`;
+                const isSpaceActive = pathname === spaceHref;
 
-              return (
-                <Link
-                  key={space.id}
-                  href={spaceHref}
-                  className={`group flex items-center px-2.5 xs:px-3 py-2 xs:py-2.5 text-xs xs:text-sm font-medium rounded-xl transition-all duration-300 active:scale-95 ${
-                    isSpaceActive
-                      ? 'bg-gradient-to-r from-brand-mid-pink to-brand-light-pink text-white shadow-lg shadow-brand-mid-pink/25 scale-[1.02] border-2 border-brand-mid-pink/30'
-                      : 'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground hover:scale-[1.02] hover:shadow-md hover:border-brand-mid-pink/20 border-2 border-transparent'
-                  }`}
-                >
-                  <Layers
-                    className={`h-4 w-4 shrink-0 mr-2 xs:mr-2.5 sm:mr-3 transition-all duration-300 ${
+                return (
+                  <Link
+                    key={space.id}
+                    href={spaceHref}
+                    className={`group flex items-center px-2.5 xs:px-3 py-2 xs:py-2.5 text-xs xs:text-sm font-medium rounded-xl transition-all duration-300 active:scale-95 ${
                       isSpaceActive
-                        ? 'text-white'
-                        : 'text-brand-blue group-hover:text-brand-mid-pink'
-                    } ${isSpaceActive ? 'scale-110' : 'group-hover:scale-110'}`}
-                    aria-hidden="true"
-                  />
-                  <span className="truncate">{space.name}</span>
-                </Link>
-              );
-            })}
+                        ? 'bg-gradient-to-r from-brand-mid-pink to-brand-light-pink text-white shadow-lg shadow-brand-mid-pink/25 scale-[1.02] border-2 border-brand-mid-pink/30'
+                        : 'text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-foreground hover:scale-[1.02] hover:shadow-md hover:border-brand-mid-pink/20 border-2 border-transparent'
+                    }`}
+                  >
+                    <Layers
+                      className={`h-4 w-4 shrink-0 mr-2 xs:mr-2.5 sm:mr-3 transition-all duration-300 ${
+                        isSpaceActive
+                          ? 'text-white'
+                          : 'text-brand-blue group-hover:text-brand-mid-pink'
+                      } ${isSpaceActive ? 'scale-110' : 'group-hover:scale-110'}`}
+                      aria-hidden="true"
+                    />
+                    <span className="truncate">{space.name}</span>
+                  </Link>
+                );
+              })
+            )}
           </div>
         )}
       </div>

--- a/app/[tenant]/(dashboard)/spaces/SpacesList.tsx
+++ b/app/[tenant]/(dashboard)/spaces/SpacesList.tsx
@@ -6,18 +6,16 @@ import { SpaceCard } from './SpaceCard';
 interface SpacesListProps {
   spaces: Space[];
   isLoading?: boolean;
-  onSelectSpace?: (space: Space) => void;
 }
 
-export function SpacesList({ spaces, isLoading, onSelectSpace }: SpacesListProps) {
+export function SpacesList({ spaces, isLoading }: SpacesListProps) {
   if (isLoading) {
     return (
       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
         {Array.from({ length: 3 }).map((_, index) => (
           <div
-            // eslint-disable-next-line react/no-array-index-key
             key={index}
-            className="h-24 rounded-2xl bg-gray-100/70 dark:bg-gray-900/60 border border-gray-200/80 dark:border-brand-mid-pink/10 animate-pulse"
+            className="h-28 rounded-2xl bg-gray-100/70 dark:bg-gray-900/60 border border-gray-200/80 dark:border-brand-mid-pink/10 animate-pulse"
           />
         ))}
       </div>
@@ -37,13 +35,8 @@ export function SpacesList({ spaces, isLoading, onSelectSpace }: SpacesListProps
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
       {spaces.map((space) => (
-        <SpaceCard
-          key={space.id}
-          space={space}
-          onClick={onSelectSpace ? () => onSelectSpace(space) : undefined}
-        />
+        <SpaceCard key={space.id} space={space} />
       ))}
     </div>
   );
 }
-

--- a/app/[tenant]/(dashboard)/spaces/SpacesTab.tsx
+++ b/app/[tenant]/(dashboard)/spaces/SpacesTab.tsx
@@ -1,30 +1,45 @@
 'use client';
 
 import { useState } from 'react';
-import { useOrganization } from '@/lib/hooks/useOrganization.query';
+import { Plus } from 'lucide-react';
 import { useSpaces } from '@/lib/hooks/useSpaces.query';
 import { SpacesList } from './SpacesList';
-import { KanbanBoard } from './KanbanBoard';
+import { CreateSpaceModal } from './CreateSpaceModal';
 
 export function SpacesTab() {
-  const [selectedSpaceId, setSelectedSpaceId] = useState<string | null>(null);
-
-  const { currentOrganization } = useOrganization();
-  const { data, isLoading } = useSpaces(!!currentOrganization);
-
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const { data, isLoading } = useSpaces();
   const spaces = data?.spaces ?? [];
-  const selectedSpace =
-    spaces.find((s) => s.id === selectedSpaceId) ?? spaces[0] ?? null;
 
   return (
     <div className="space-y-6">
-      <SpacesList
-        spaces={spaces}
-        isLoading={isLoading}
-        onSelectSpace={(space) => setSelectedSpaceId(space.id)}
-      />
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-brand-off-white">
+            Spaces
+          </h1>
+          <p className="text-xs sm:text-sm text-gray-500 dark:text-gray-400 mt-0.5">
+            Manage all your workspaces. Click a space to open its board.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setIsCreateOpen(true)}
+          className="inline-flex items-center gap-1.5 rounded-xl bg-linear-to-r from-brand-light-pink to-brand-mid-pink text-white px-4 py-2 text-sm font-medium shadow-sm hover:shadow-md transition-all hover:scale-[1.02] active:scale-95"
+        >
+          <Plus className="h-4 w-4" />
+          New Space
+        </button>
+      </div>
 
-      <KanbanBoard spaceName={selectedSpace?.name} />
+      {/* Space cards grid */}
+      <SpacesList spaces={spaces} isLoading={isLoading} />
+
+      <CreateSpaceModal
+        isOpen={isCreateOpen}
+        onClose={() => setIsCreateOpen(false)}
+      />
     </div>
   );
 }

--- a/app/[tenant]/(dashboard)/spaces/[slug]/SpaceBoardView.tsx
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/SpaceBoardView.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useSpaceBySlug } from '@/lib/hooks/useSpaces.query';
+import { Loader2 } from 'lucide-react';
+import {
+  KanbanTemplate,
+  WallPostTemplate,
+  SextingSetsTemplate,
+  OtpPtrTemplate,
+} from './templates';
+import type { SpaceWithBoards } from '@/lib/hooks/useSpaces.query';
+import type { ComponentType } from 'react';
+import type { TemplateProps } from './templates';
+
+/* ------------------------------------------------------------------ */
+/*  Template registry — maps templateType → component                  */
+/* ------------------------------------------------------------------ */
+
+const TEMPLATE_COMPONENTS: Record<string, ComponentType<TemplateProps>> = {
+  KANBAN: KanbanTemplate,
+  WALL_POST: WallPostTemplate,
+  SEXTING_SETS: SextingSetsTemplate,
+  OTP_PTR: OtpPtrTemplate,
+};
+
+/* ------------------------------------------------------------------ */
+/*  Props                                                              */
+/* ------------------------------------------------------------------ */
+
+interface SpaceBoardViewProps {
+  slug: string;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Component                                                          */
+/* ------------------------------------------------------------------ */
+
+export function SpaceBoardView({ slug }: SpaceBoardViewProps) {
+  const { data: space, isLoading } = useSpaceBySlug(slug);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 className="h-6 w-6 animate-spin text-brand-light-pink" />
+        <span className="ml-2 text-sm text-gray-500 dark:text-gray-400">
+          Loading space...
+        </span>
+      </div>
+    );
+  }
+
+  if (!space) {
+    return (
+      <div className="rounded-2xl border border-dashed border-gray-300 dark:border-brand-mid-pink/30 bg-gray-50/70 dark:bg-gray-900/50 px-4 py-12 text-center">
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Space not found.
+        </p>
+      </div>
+    );
+  }
+
+  const Template = TEMPLATE_COMPONENTS[space.templateType];
+
+  if (!Template) {
+    return (
+      <div className="rounded-2xl border border-dashed border-gray-300 dark:border-brand-mid-pink/30 bg-gray-50/70 dark:bg-gray-900/50 px-4 py-12 text-center">
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          Unknown template type: <strong>{space.templateType}</strong>
+        </p>
+      </div>
+    );
+  }
+
+  return <Template space={space} />;
+}

--- a/app/[tenant]/(dashboard)/spaces/[slug]/page.tsx
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/page.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import { SpaceBoardView } from './SpaceBoardView';
+
+export default function SpaceSlugPage() {
+  const params = useParams<{ slug: string }>();
+
+  return <SpaceBoardView slug={params.slug} />;
+}

--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/KanbanTaskDetailModal.tsx
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/KanbanTaskDetailModal.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  X,
+  Pencil,
+  User,
+  UserCircle,
+  Flag,
+  CalendarDays,
+  CalendarClock,
+  ListTodo,
+  Hash,
+  Tag,
+} from 'lucide-react';
+import type { BoardTask } from '../../board/BoardTaskCard';
+import { EditableField } from '../../board/EditableField';
+import { SelectField } from '../../board/SelectField';
+import { ActivityFeed, type TaskComment, type TaskHistoryEntry } from '../../board/ActivityFeed';
+
+interface Props {
+  task: BoardTask;
+  columnTitle: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onUpdate: (updated: BoardTask) => void;
+}
+
+const PRIORITY_OPTIONS: BoardTask['priority'][] = ['Low', 'Medium', 'High'];
+const PRIORITY_DOT: Record<string, string> = {
+  High: 'bg-red-500',
+  Medium: 'bg-amber-500',
+  Low: 'bg-emerald-500',
+};
+
+const PLACEHOLDER_HISTORY: TaskHistoryEntry[] = [
+  { id: 'h1', field: 'priority', oldValue: 'Low', newValue: 'High', changedBy: 'Alex', changedAt: new Date(Date.now() - 86400000).toISOString() },
+  { id: 'h2', field: 'assignee', oldValue: '', newValue: 'Alex', changedBy: 'System', changedAt: new Date(Date.now() - 172800000).toISOString() },
+];
+
+function SidebarLabel({ icon: Icon, label }: { icon: React.ComponentType<{ className?: string }>; label: string }) {
+  return (
+    <div className="flex items-center gap-1.5 mb-1.5">
+      <Icon className="h-3.5 w-3.5 text-gray-400" />
+      <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">{label}</span>
+    </div>
+  );
+}
+
+/**
+ * Kanban task detail — classic Jira-style two-column layout.
+ * Left: title, description, story points / labels inline, activity feed.
+ * Right: status, assignee, reporter, priority, dates, tags.
+ */
+export function KanbanTaskDetailModal({ task, columnTitle, isOpen, onClose, onUpdate }: Props) {
+  const [mounted, setMounted] = useState(false);
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [editingDesc, setEditingDesc] = useState(false);
+  const [titleDraft, setTitleDraft] = useState(task.title);
+  const [descDraft, setDescDraft] = useState(task.description ?? '');
+  const [comments, setComments] = useState<TaskComment[]>([
+    { id: 'c1', author: 'Jordan', content: 'Let me know if you need help breaking this down into subtasks.', createdAt: new Date(Date.now() - 43200000).toISOString() },
+  ]);
+  const titleRef = useRef<HTMLInputElement>(null);
+  const descRef = useRef<HTMLTextAreaElement>(null);
+
+  const meta = task.metadata ?? {};
+  const storyPoints = (meta.storyPoints as number) ?? 0;
+  const labels = Array.isArray(meta.labels) ? (meta.labels as string[]) : [];
+
+  useEffect(() => setMounted(true), []);
+  useEffect(() => { setTitleDraft(task.title); setDescDraft(task.description ?? ''); }, [task]);
+  useEffect(() => { if (editingTitle) titleRef.current?.focus(); }, [editingTitle]);
+  useEffect(() => { if (editingDesc) descRef.current?.focus(); }, [editingDesc]);
+
+  if (!mounted || !isOpen) return null;
+
+  const saveTitle = () => { setEditingTitle(false); if (titleDraft.trim() && titleDraft !== task.title) onUpdate({ ...task, title: titleDraft.trim() }); else setTitleDraft(task.title); };
+  const saveDesc = () => { setEditingDesc(false); if (descDraft !== (task.description ?? '')) onUpdate({ ...task, description: descDraft }); };
+  const updateMeta = (partial: Record<string, unknown>) => onUpdate({ ...task, metadata: { ...meta, ...partial } });
+
+  return createPortal(
+    <div className="fixed inset-0 z-9999 flex items-start justify-center bg-black/50 backdrop-blur-sm overflow-y-auto py-8 px-3" onClick={onClose}>
+      <div className="relative w-full max-w-5xl bg-white dark:bg-gray-950 rounded-2xl shadow-2xl border border-gray-200 dark:border-brand-mid-pink/20 overflow-hidden" onClick={(e) => e.stopPropagation()}>
+
+        {/* ── Header ─────────────────────────────────────────── */}
+        <div className="px-6 sm:px-8 pt-6 pb-4 flex items-start justify-between gap-4">
+          <div className="flex-1 min-w-0">
+            <span className="inline-flex items-center rounded-md bg-brand-blue/10 text-brand-blue px-2 py-0.5 text-[11px] font-bold tracking-wide mb-2">{task.taskKey}</span>
+            <div className="group/title">
+              {editingTitle ? (
+                <input ref={titleRef} value={titleDraft} onChange={(e) => setTitleDraft(e.target.value)} onBlur={saveTitle}
+                  onKeyDown={(e) => { if (e.key === 'Enter') saveTitle(); if (e.key === 'Escape') { setTitleDraft(task.title); setEditingTitle(false); } }}
+                  className="w-full text-xl sm:text-2xl font-bold text-gray-900 dark:text-brand-off-white bg-transparent border-b-2 border-brand-light-pink/60 focus-visible:outline-none pb-1" />
+              ) : (
+                <button type="button" onClick={() => setEditingTitle(true)} className="flex items-center gap-2 w-full text-left">
+                  <h2 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-brand-off-white">{task.title}</h2>
+                  <Pencil className="h-4 w-4 text-gray-400 opacity-0 group-hover/title:opacity-100 transition-opacity shrink-0" />
+                </button>
+              )}
+            </div>
+          </div>
+          <button type="button" onClick={onClose} className="shrink-0 inline-flex h-8 w-8 items-center justify-center rounded-full border border-gray-200 dark:border-brand-mid-pink/30 bg-white/80 dark:bg-gray-900/80 text-gray-500 hover:text-gray-900 dark:hover:text-brand-off-white hover:border-brand-light-pink/60 transition-colors">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="border-b border-gray-200 dark:border-brand-mid-pink/15" />
+
+        {/* ── Two-column body ─────────────────────────────────── */}
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr_320px]">
+
+          {/* Left — description, story points, labels, activity */}
+          <div className="px-6 sm:px-8 py-6 border-r-0 lg:border-r border-gray-200 dark:border-brand-mid-pink/15 min-h-[50vh]">
+
+            {/* Description */}
+            <div className="mb-6">
+              <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2">Description</h3>
+              <div className="group/desc">
+                {editingDesc ? (
+                  <div>
+                    <textarea ref={descRef} value={descDraft} onChange={(e) => setDescDraft(e.target.value)} rows={5} placeholder="Add a description..."
+                      className="w-full rounded-xl border border-brand-light-pink/40 bg-white/80 dark:bg-gray-900/80 px-3 py-2.5 text-sm text-gray-800 dark:text-brand-off-white placeholder:text-gray-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-light-pink/60 resize-none" />
+                    <div className="flex items-center gap-2 mt-2">
+                      <button type="button" onClick={saveDesc} className="px-3 py-1.5 rounded-lg bg-brand-light-pink text-white text-xs font-medium hover:bg-brand-mid-pink">Save</button>
+                      <button type="button" onClick={() => { setDescDraft(task.description ?? ''); setEditingDesc(false); }} className="px-3 py-1.5 rounded-lg text-gray-500 text-xs font-medium hover:bg-gray-100 dark:hover:bg-gray-800">Cancel</button>
+                    </div>
+                  </div>
+                ) : (
+                  <button type="button" onClick={() => setEditingDesc(true)} className="flex items-start gap-2 w-full text-left">
+                    <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap flex-1">{task.description || <span className="text-gray-400 italic">Click to add a description...</span>}</p>
+                    <Pencil className="h-3.5 w-3.5 text-gray-400 opacity-0 group-hover/desc:opacity-100 transition-opacity shrink-0 mt-0.5" />
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* Story Points + Labels (inline, Kanban-specific) */}
+            <div className="mb-6 flex flex-wrap gap-4">
+              <div className="flex items-center gap-2">
+                <Hash className="h-3.5 w-3.5 text-gray-400" />
+                <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Story Points</span>
+                <span className="inline-flex items-center justify-center rounded-md bg-brand-blue/10 text-brand-blue px-2 py-0.5 text-xs font-bold min-w-[28px] text-center">{storyPoints}</span>
+              </div>
+              {labels.length > 0 && (
+                <div className="flex items-center gap-1.5 flex-wrap">
+                  <Tag className="h-3.5 w-3.5 text-gray-400" />
+                  {labels.map((l) => (
+                    <span key={l} className="inline-flex items-center rounded-full bg-violet-500/10 text-violet-500 px-2 py-0.5 text-[10px] font-medium">{l}</span>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <ActivityFeed comments={comments} history={PLACEHOLDER_HISTORY} onAddComment={(c) => setComments((p) => [{ id: `c-${Date.now()}`, author: 'You', content: c, createdAt: new Date().toISOString() }, ...p])} />
+          </div>
+
+          {/* Right — classic Jira sidebar */}
+          <div className="px-6 py-6 bg-gray-50/70 dark:bg-gray-950/60 space-y-5">
+            <div>
+              <SidebarLabel icon={ListTodo} label="Status" />
+              <span className="inline-flex items-center rounded-lg bg-brand-blue/10 text-brand-blue px-2.5 py-1 text-xs font-medium">{columnTitle}</span>
+            </div>
+            <div>
+              <SidebarLabel icon={User} label="Assignee" />
+              <EditableField value={task.assignee ?? ''} placeholder="Unassigned" onSave={(v) => onUpdate({ ...task, assignee: v || undefined })} />
+            </div>
+            <div>
+              <SidebarLabel icon={UserCircle} label="Reporter" />
+              <EditableField value={task.reporter ?? ''} placeholder="None" onSave={(v) => onUpdate({ ...task, reporter: v || undefined })} />
+            </div>
+            <div>
+              <SidebarLabel icon={Flag} label="Priority" />
+              <SelectField value={task.priority ?? ''} options={PRIORITY_OPTIONS.filter(Boolean) as string[]} onSave={(v) => onUpdate({ ...task, priority: v as BoardTask['priority'] })}
+                renderOption={(v) => (<span className="flex items-center gap-2 text-sm text-gray-800 dark:text-brand-off-white"><span className={`h-2 w-2 rounded-full ${PRIORITY_DOT[v] ?? 'bg-gray-400'}`} />{v || <span className="text-gray-400 italic">None</span>}</span>)} />
+            </div>
+            <div>
+              <SidebarLabel icon={CalendarClock} label="Start date" />
+              <EditableField value={task.startDate ?? ''} type="date" placeholder="Not set" onSave={(v) => onUpdate({ ...task, startDate: v || undefined })} />
+            </div>
+            <div>
+              <SidebarLabel icon={CalendarDays} label="Due date" />
+              <EditableField value={task.dueDate ?? ''} type="date" placeholder="Not set" onSave={(v) => onUpdate({ ...task, dueDate: v || undefined })} />
+            </div>
+            <div>
+              <SidebarLabel icon={Hash} label="Story Points" />
+              <EditableField value={String(storyPoints)} placeholder="0" onSave={(v) => updateMeta({ storyPoints: Number(v) || 0 })} />
+            </div>
+            <div>
+              <SidebarLabel icon={Tag} label="Tags" />
+              {task.tags && task.tags.length > 0 ? (
+                <div className="flex items-center gap-1.5 flex-wrap">{task.tags.map((t) => (<span key={t} className="inline-flex items-center rounded-full bg-brand-light-pink/10 text-brand-light-pink px-2 py-0.5 text-[10px] font-medium">{t}</span>))}</div>
+              ) : (<span className="text-xs text-gray-400 italic">No tags</span>)}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/KanbanTemplate.tsx
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/KanbanTemplate.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { DragDropContext } from '@hello-pangea/dnd';
+import {
+  BoardLayout,
+  BoardColumn,
+  type BoardTab,
+} from '../../board';
+import { useSpaceBoard, defaultItemToTask } from '../useSpaceBoard';
+import { KanbanTaskDetailModal } from './KanbanTaskDetailModal';
+import { Loader2 } from 'lucide-react';
+import type { TemplateProps } from './types';
+
+const TABS: BoardTab[] = [
+  { id: 'summary', label: 'Summary' },
+  { id: 'board', label: 'Board' },
+  { id: 'timeline', label: 'Timeline' },
+];
+
+export function KanbanTemplate({ space }: TemplateProps) {
+  const {
+    itemsLoading,
+    effectiveColumns,
+    effectiveTasks,
+    effectiveColumnOrder,
+    selectedTask,
+    selectedColumnTitle,
+    handleDragEnd,
+    handleAddTask,
+    handleTaskClick,
+    handleTaskUpdate,
+    handleTitleUpdate,
+    closeTaskModal,
+  } = useSpaceBoard({ space, itemToTask: defaultItemToTask });
+
+  return (
+    <>
+      <BoardLayout
+        spaceName={space.name}
+        templateLabel="Kanban"
+        tabs={TABS}
+        defaultTab="board"
+      >
+        {(activeTab, searchQuery) => {
+          if (activeTab === 'summary') {
+            return (
+              <div className="rounded-2xl border border-dashed border-gray-200 dark:border-brand-mid-pink/20 bg-white/50 dark:bg-gray-900/40 px-6 py-10 text-center">
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  Summary view coming soon &mdash; overview metrics, recent
+                  activity, and key insights will appear here.
+                </p>
+              </div>
+            );
+          }
+
+          if (activeTab === 'timeline') {
+            return (
+              <div className="rounded-2xl border border-dashed border-gray-200 dark:border-brand-mid-pink/20 bg-white/50 dark:bg-gray-900/40 px-6 py-10 text-center">
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  Timeline view coming soon &mdash; visualize tasks across time.
+                </p>
+              </div>
+            );
+          }
+
+          if (itemsLoading) {
+            return (
+              <div className="flex items-center justify-center py-16">
+                <Loader2 className="h-5 w-5 animate-spin text-brand-light-pink" />
+                <span className="ml-2 text-sm text-gray-500 dark:text-gray-400">
+                  Loading board...
+                </span>
+              </div>
+            );
+          }
+
+          const query = searchQuery.toLowerCase();
+
+          return (
+            <div className="rounded-2xl border border-gray-200 dark:border-brand-mid-pink/15 bg-gray-100/50 dark:bg-gray-950/40 p-3 sm:p-4 overflow-x-auto">
+              <DragDropContext onDragEnd={handleDragEnd}>
+                <div className="flex gap-3 sm:gap-4 min-w-max">
+                  {effectiveColumnOrder.map((colId) => {
+                    const col = effectiveColumns[colId];
+                    if (!col) return null;
+
+                    const colTasks = col.taskIds
+                      .map((id) => effectiveTasks[id])
+                      .filter(Boolean)
+                      .filter(
+                        (t) =>
+                          !query ||
+                          t.title.toLowerCase().includes(query) ||
+                          t.taskKey.toLowerCase().includes(query) ||
+                          t.assignee?.toLowerCase().includes(query) ||
+                          t.tags?.some((tag) =>
+                            tag.toLowerCase().includes(query),
+                          ),
+                      );
+
+                    return (
+                      <BoardColumn
+                        key={col.id}
+                        column={col}
+                        tasks={colTasks}
+                        onAddTask={handleAddTask}
+                        onTaskClick={handleTaskClick}
+                        onTaskTitleUpdate={handleTitleUpdate}
+                      />
+                    );
+                  })}
+                </div>
+              </DragDropContext>
+            </div>
+          );
+        }}
+      </BoardLayout>
+
+      {selectedTask && (
+        <KanbanTaskDetailModal
+          task={selectedTask}
+          columnTitle={selectedColumnTitle}
+          isOpen={!!selectedTask}
+          onClose={closeTaskModal}
+          onUpdate={handleTaskUpdate}
+        />
+      )}
+    </>
+  );
+}

--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/OtpPtrTaskDetailModal.tsx
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/OtpPtrTaskDetailModal.tsx
@@ -1,0 +1,263 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  X,
+  Pencil,
+  DollarSign,
+  User,
+  CalendarDays,
+  Package,
+  ShieldCheck,
+  ClipboardList,
+  FileText,
+  Tag,
+} from 'lucide-react';
+import type { BoardTask } from '../../board/BoardTaskCard';
+import { EditableField } from '../../board/EditableField';
+import { SelectField } from '../../board/SelectField';
+import { ActivityFeed, type TaskComment, type TaskHistoryEntry } from '../../board/ActivityFeed';
+
+interface Props {
+  task: BoardTask;
+  columnTitle: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onUpdate: (updated: BoardTask) => void;
+}
+
+const REQUEST_TYPE_OPTIONS = ['OTP', 'PTR', 'CUSTOM'];
+const TYPE_COLORS: Record<string, string> = {
+  OTP: 'bg-brand-blue/10 text-brand-blue',
+  PTR: 'bg-brand-light-pink/10 text-brand-light-pink',
+  CUSTOM: 'bg-amber-500/10 text-amber-600',
+};
+
+const PLACEHOLDER_HISTORY: TaskHistoryEntry[] = [
+  { id: 'h1', field: 'isPaid', oldValue: 'false', newValue: 'true', changedBy: 'Alex', changedAt: new Date(Date.now() - 86400000).toISOString() },
+];
+
+/**
+ * OTP/PTR detail — order/request management layout.
+ * Header: title + type badge (OTP/PTR/CUSTOM) + prominent paid/unpaid + price.
+ * Top bar: buyer, model, deadline — key info at a glance.
+ * Left: fulfillment notes, deliverables checklist, activity.
+ * Right: all editable fields (request type, price, buyer, model, deadline, paid toggle, deliverables).
+ */
+export function OtpPtrTaskDetailModal({ task, columnTitle, isOpen, onClose, onUpdate }: Props) {
+  const [mounted, setMounted] = useState(false);
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [editingNotes, setEditingNotes] = useState(false);
+  const [titleDraft, setTitleDraft] = useState(task.title);
+  const [comments, setComments] = useState<TaskComment[]>([]);
+  const titleRef = useRef<HTMLInputElement>(null);
+  const notesRef = useRef<HTMLTextAreaElement>(null);
+
+  const meta = task.metadata ?? {};
+  const requestType = (meta.requestType as string) ?? 'OTP';
+  const price = (meta.price as number) ?? 0;
+  const buyer = (meta.buyer as string) ?? '';
+  const model = (meta.model as string) ?? '';
+  const deliverables = Array.isArray(meta.deliverables) ? (meta.deliverables as string[]) : [];
+  const deadline = (meta.deadline as string) ?? '';
+  const isPaid = (meta.isPaid as boolean) ?? false;
+  const fulfillmentNotes = (meta.fulfillmentNotes as string) ?? '';
+
+  const [notesDraft, setNotesDraft] = useState(fulfillmentNotes);
+
+  useEffect(() => setMounted(true), []);
+  useEffect(() => { setTitleDraft(task.title); setNotesDraft(fulfillmentNotes); }, [task, fulfillmentNotes]);
+  useEffect(() => { if (editingTitle) titleRef.current?.focus(); }, [editingTitle]);
+  useEffect(() => { if (editingNotes) notesRef.current?.focus(); }, [editingNotes]);
+
+  if (!mounted || !isOpen) return null;
+
+  const updateMeta = (partial: Record<string, unknown>) => onUpdate({ ...task, metadata: { ...meta, ...partial } });
+  const saveTitle = () => { setEditingTitle(false); if (titleDraft.trim() && titleDraft !== task.title) onUpdate({ ...task, title: titleDraft.trim() }); else setTitleDraft(task.title); };
+  const saveNotes = () => { setEditingNotes(false); if (notesDraft !== fulfillmentNotes) updateMeta({ fulfillmentNotes: notesDraft }); };
+
+  const typeStyle = TYPE_COLORS[requestType] ?? 'bg-gray-100 text-gray-500';
+
+  return createPortal(
+    <div className="fixed inset-0 z-9999 flex items-start justify-center bg-black/50 backdrop-blur-sm overflow-y-auto py-8 px-3" onClick={onClose}>
+      <div className="relative w-full max-w-5xl bg-white dark:bg-gray-950 rounded-2xl shadow-2xl border border-gray-200 dark:border-brand-mid-pink/20 overflow-hidden" onClick={(e) => e.stopPropagation()}>
+
+        {/* ── Header: title + type + paid status + price ────── */}
+        <div className="px-6 sm:px-8 pt-6 pb-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2 mb-2 flex-wrap">
+                <span className="inline-flex items-center rounded-md bg-brand-blue/10 text-brand-blue px-2 py-0.5 text-[11px] font-bold tracking-wide">{task.taskKey}</span>
+                <span className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-[11px] font-bold ${typeStyle}`}>
+                  <ClipboardList className="h-3 w-3" />{requestType}
+                </span>
+                <button type="button" onClick={() => updateMeta({ isPaid: !isPaid })}
+                  className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-0.5 text-[11px] font-bold transition-colors ${isPaid ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'bg-red-500/10 text-red-600 dark:text-red-400'}`}>
+                  <span className={`h-2 w-2 rounded-full ${isPaid ? 'bg-emerald-500' : 'bg-red-500'}`} />
+                  {isPaid ? 'PAID' : 'UNPAID'}
+                </button>
+                <span className="inline-flex items-center rounded-lg bg-brand-blue/10 text-brand-blue px-2 py-0.5 text-[10px] font-medium">{columnTitle}</span>
+              </div>
+              <div className="group/title">
+                {editingTitle ? (
+                  <input ref={titleRef} value={titleDraft} onChange={(e) => setTitleDraft(e.target.value)} onBlur={saveTitle}
+                    onKeyDown={(e) => { if (e.key === 'Enter') saveTitle(); if (e.key === 'Escape') { setTitleDraft(task.title); setEditingTitle(false); } }}
+                    className="w-full text-xl sm:text-2xl font-bold text-gray-900 dark:text-brand-off-white bg-transparent border-b-2 border-brand-light-pink/60 focus-visible:outline-none pb-1" />
+                ) : (
+                  <button type="button" onClick={() => setEditingTitle(true)} className="flex items-center gap-2 w-full text-left">
+                    <h2 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-brand-off-white">{task.title}</h2>
+                    <Pencil className="h-4 w-4 text-gray-400 opacity-0 group-hover/title:opacity-100 transition-opacity shrink-0" />
+                  </button>
+                )}
+              </div>
+            </div>
+            <div className="flex items-center gap-3 shrink-0">
+              <div className="text-right">
+                <p className="text-[10px] uppercase tracking-wider text-gray-400 mb-0.5">Price</p>
+                <p className="text-2xl font-bold text-gray-900 dark:text-brand-off-white">${price.toFixed(2)}</p>
+              </div>
+              <button type="button" onClick={onClose} className="shrink-0 inline-flex h-8 w-8 items-center justify-center rounded-full border border-gray-200 dark:border-brand-mid-pink/30 bg-white/80 dark:bg-gray-900/80 text-gray-500 hover:text-gray-900 dark:hover:text-brand-off-white hover:border-brand-light-pink/60 transition-colors">
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+
+          {/* Quick-info bar */}
+          <div className="mt-4 flex flex-wrap items-center gap-x-6 gap-y-2 rounded-xl bg-gray-50 dark:bg-gray-900/50 border border-gray-200 dark:border-brand-mid-pink/15 px-4 py-2.5 text-xs">
+            {buyer && (
+              <div className="flex items-center gap-1.5">
+                <Tag className="h-3 w-3 text-gray-400" />
+                <span className="text-gray-500 dark:text-gray-400">Buyer:</span>
+                <span className="font-semibold text-gray-800 dark:text-brand-off-white">@{buyer}</span>
+              </div>
+            )}
+            {model && (
+              <div className="flex items-center gap-1.5">
+                <User className="h-3 w-3 text-gray-400" />
+                <span className="text-gray-500 dark:text-gray-400">Model:</span>
+                <span className="font-semibold text-gray-800 dark:text-brand-off-white">{model}</span>
+              </div>
+            )}
+            {deadline && (
+              <div className="flex items-center gap-1.5">
+                <CalendarDays className="h-3 w-3 text-gray-400" />
+                <span className="text-gray-500 dark:text-gray-400">Deadline:</span>
+                <span className="font-semibold text-gray-800 dark:text-brand-off-white">{deadline}</span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="border-b border-gray-200 dark:border-brand-mid-pink/15" />
+
+        {/* ── Body ────────────────────────────────────────────── */}
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr_300px]">
+
+          {/* Left — fulfillment notes, deliverables, activity */}
+          <div className="px-6 sm:px-8 py-6 border-r-0 lg:border-r border-gray-200 dark:border-brand-mid-pink/15 min-h-[45vh]">
+
+            {/* Fulfillment Notes */}
+            <div className="mb-6">
+              <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2">Fulfillment Notes</h3>
+              <div className="group/notes">
+                {editingNotes ? (
+                  <div>
+                    <textarea ref={notesRef} value={notesDraft} onChange={(e) => setNotesDraft(e.target.value)} rows={5} placeholder="Delivery instructions, special requests..."
+                      className="w-full rounded-xl border border-brand-light-pink/40 bg-white/80 dark:bg-gray-900/80 px-3 py-2.5 text-sm text-gray-800 dark:text-brand-off-white placeholder:text-gray-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-light-pink/60 resize-none" />
+                    <div className="flex items-center gap-2 mt-2">
+                      <button type="button" onClick={saveNotes} className="px-3 py-1.5 rounded-lg bg-brand-light-pink text-white text-xs font-medium hover:bg-brand-mid-pink">Save</button>
+                      <button type="button" onClick={() => { setNotesDraft(fulfillmentNotes); setEditingNotes(false); }} className="px-3 py-1.5 rounded-lg text-gray-500 text-xs font-medium hover:bg-gray-100 dark:hover:bg-gray-800">Cancel</button>
+                    </div>
+                  </div>
+                ) : (
+                  <button type="button" onClick={() => setEditingNotes(true)} className="flex items-start gap-2 w-full text-left">
+                    <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap flex-1">{fulfillmentNotes || <span className="text-gray-400 italic">Click to add fulfillment notes...</span>}</p>
+                    <Pencil className="h-3.5 w-3.5 text-gray-400 opacity-0 group-hover/notes:opacity-100 transition-opacity shrink-0 mt-0.5" />
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* Deliverables */}
+            <div className="mb-6">
+              <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2">Deliverables</h3>
+              {deliverables.length > 0 ? (
+                <div className="space-y-1.5">
+                  {deliverables.map((d, i) => (
+                    <div key={i} className="flex items-center gap-2 rounded-lg bg-gray-50 dark:bg-gray-900/40 border border-gray-200 dark:border-brand-mid-pink/15 px-3 py-2">
+                      <Package className="h-3.5 w-3.5 text-brand-blue shrink-0" />
+                      <span className="text-sm text-gray-700 dark:text-gray-300">{d}</span>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-xs text-gray-400 italic">No deliverables specified</p>
+              )}
+            </div>
+
+            {/* Description (secondary) */}
+            <div className="mb-6">
+              <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2">Description</h3>
+              <EditableField value={task.description ?? ''} placeholder="Additional details..." onSave={(v) => onUpdate({ ...task, description: v || undefined })} />
+            </div>
+
+            <ActivityFeed comments={comments} history={PLACEHOLDER_HISTORY} onAddComment={(c) => setComments((p) => [{ id: `c-${Date.now()}`, author: 'You', content: c, createdAt: new Date().toISOString() }, ...p])} />
+          </div>
+
+          {/* Right — order details */}
+          <div className="px-5 py-6 bg-gray-50/70 dark:bg-gray-950/60 space-y-5">
+
+            <div>
+              <div className="flex items-center gap-1.5 mb-1.5"><ClipboardList className="h-3.5 w-3.5 text-gray-400" /><span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Request Type</span></div>
+              <SelectField value={requestType} options={REQUEST_TYPE_OPTIONS} onSave={(v) => updateMeta({ requestType: v })}
+                renderOption={(v) => (<span className="flex items-center gap-2 text-sm text-gray-800 dark:text-brand-off-white"><span className={`h-2 w-2 rounded-full ${v === 'OTP' ? 'bg-brand-blue' : v === 'PTR' ? 'bg-brand-light-pink' : 'bg-amber-500'}`} />{v}</span>)} />
+            </div>
+
+            <div>
+              <div className="flex items-center gap-1.5 mb-1.5"><DollarSign className="h-3.5 w-3.5 text-gray-400" /><span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Price</span></div>
+              <EditableField value={String(price)} placeholder="0.00" onSave={(v) => updateMeta({ price: Number(v) || 0 })} />
+            </div>
+
+            <div>
+              <div className="flex items-center gap-1.5 mb-1.5"><Tag className="h-3.5 w-3.5 text-gray-400" /><span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Buyer</span></div>
+              <EditableField value={buyer} placeholder="@username" onSave={(v) => updateMeta({ buyer: v })} />
+            </div>
+
+            <div>
+              <div className="flex items-center gap-1.5 mb-1.5"><User className="h-3.5 w-3.5 text-gray-400" /><span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Model</span></div>
+              <EditableField value={model} placeholder="Model name" onSave={(v) => updateMeta({ model: v })} />
+            </div>
+
+            <div>
+              <div className="flex items-center gap-1.5 mb-1.5"><CalendarDays className="h-3.5 w-3.5 text-gray-400" /><span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Deadline</span></div>
+              <EditableField value={deadline} type="date" placeholder="Not set" onSave={(v) => updateMeta({ deadline: v })} />
+            </div>
+
+            <div>
+              <div className="flex items-center gap-1.5 mb-1.5"><ShieldCheck className="h-3.5 w-3.5 text-gray-400" /><span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Payment Status</span></div>
+              <button type="button" onClick={() => updateMeta({ isPaid: !isPaid })}
+                className={`inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs font-medium transition-colors ${isPaid ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'bg-red-500/10 text-red-600 dark:text-red-400'}`}>
+                <span className={`h-2 w-2 rounded-full ${isPaid ? 'bg-emerald-500' : 'bg-red-500'}`} />
+                {isPaid ? 'Paid' : 'Unpaid'}
+              </button>
+            </div>
+
+            <div>
+              <div className="flex items-center gap-1.5 mb-1.5"><Package className="h-3.5 w-3.5 text-gray-400" /><span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Deliverables</span></div>
+              {deliverables.length > 0 ? (
+                <div className="flex items-center gap-1.5 flex-wrap">{deliverables.map((d) => (<span key={d} className="inline-flex items-center rounded-full bg-brand-blue/10 text-brand-blue px-2 py-0.5 text-[10px] font-medium">{d}</span>))}</div>
+              ) : (<span className="text-xs text-gray-400 italic">None</span>)}
+            </div>
+
+            <div>
+              <div className="flex items-center gap-1.5 mb-1.5"><FileText className="h-3.5 w-3.5 text-gray-400" /><span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Notes Preview</span></div>
+              <p className="text-xs text-gray-600 dark:text-gray-300 line-clamp-3">{fulfillmentNotes || <span className="text-gray-400 italic">No notes</span>}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/OtpPtrTemplate.tsx
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/OtpPtrTemplate.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { DragDropContext } from '@hello-pangea/dnd';
+import {
+  BoardLayout,
+  BoardColumn,
+  type BoardTask,
+  type BoardTab,
+} from '../../board';
+import { useSpaceBoard } from '../useSpaceBoard';
+import { OtpPtrTaskDetailModal } from './OtpPtrTaskDetailModal';
+import type { BoardItem } from '@/lib/hooks/useBoardItems.query';
+import { Loader2, DollarSign } from 'lucide-react';
+import type { TemplateProps } from './types';
+
+const TABS: BoardTab[] = [
+  { id: 'summary', label: 'Summary' },
+  { id: 'board', label: 'Board' },
+  { id: 'financials', label: 'Financials' },
+];
+
+function otpPtrItemToTask(item: BoardItem, spaceKey: string): BoardTask {
+  const meta = (item.metadata ?? {}) as Record<string, unknown>;
+  const priceTag = meta.price ? `$${meta.price}` : undefined;
+  return {
+    id: item.id,
+    taskKey: spaceKey
+      ? `${spaceKey}-${item.position + 1}`
+      : item.id.slice(-6).toUpperCase(),
+    title: item.title,
+    description: (item.description as string) ?? undefined,
+    assignee: (meta.model as string) ?? (item.assigneeId as string) ?? undefined,
+    priority: meta.isPaid ? ('Low' as const) : ('High' as const),
+    tags: [
+      ...(meta.requestType ? [meta.requestType as string] : []),
+      ...(priceTag ? [priceTag] : []),
+      ...(meta.buyer ? [`@${meta.buyer}`] : []),
+    ],
+    startDate: undefined,
+    dueDate: (meta.deadline as string) ?? item.dueDate ?? undefined,
+    reporter: undefined,
+    metadata: meta,
+  };
+}
+
+export function OtpPtrTemplate({ space }: TemplateProps) {
+  const {
+    itemsLoading,
+    effectiveColumns,
+    effectiveTasks,
+    effectiveColumnOrder,
+    selectedTask,
+    selectedColumnTitle,
+    handleDragEnd,
+    handleAddTask,
+    handleTaskClick,
+    handleTaskUpdate,
+    handleTitleUpdate,
+    closeTaskModal,
+  } = useSpaceBoard({ space, itemToTask: otpPtrItemToTask });
+
+  return (
+    <>
+      <BoardLayout
+        spaceName={space.name}
+        templateLabel="OTP / PTR"
+        tabs={TABS}
+        defaultTab="board"
+      >
+        {(activeTab, searchQuery) => {
+          if (activeTab === 'summary') {
+            return (
+              <div className="rounded-2xl border border-dashed border-gray-200 dark:border-brand-mid-pink/20 bg-white/50 dark:bg-gray-900/40 px-6 py-10 text-center">
+                <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-brand-light-pink/10">
+                  <DollarSign className="h-5 w-5 text-brand-light-pink" />
+                </div>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  OTP/PTR summary &mdash; revenue tracking, fulfillment rates,
+                  and pending requests will appear here.
+                </p>
+              </div>
+            );
+          }
+
+          if (activeTab === 'financials') {
+            return (
+              <div className="rounded-2xl border border-dashed border-gray-200 dark:border-brand-mid-pink/20 bg-white/50 dark:bg-gray-900/40 px-6 py-10 text-center">
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  Financials view coming soon &mdash; earnings breakdown, payout
+                  tracking, and invoice management.
+                </p>
+              </div>
+            );
+          }
+
+          if (itemsLoading) {
+            return (
+              <div className="flex items-center justify-center py-16">
+                <Loader2 className="h-5 w-5 animate-spin text-brand-light-pink" />
+                <span className="ml-2 text-sm text-gray-500 dark:text-gray-400">
+                  Loading board...
+                </span>
+              </div>
+            );
+          }
+
+          const query = searchQuery.toLowerCase();
+
+          return (
+            <div className="rounded-2xl border border-gray-200 dark:border-brand-mid-pink/15 bg-gray-100/50 dark:bg-gray-950/40 p-3 sm:p-4 overflow-x-auto">
+              <DragDropContext onDragEnd={handleDragEnd}>
+                <div className="flex gap-3 sm:gap-4 min-w-max">
+                  {effectiveColumnOrder.map((colId) => {
+                    const col = effectiveColumns[colId];
+                    if (!col) return null;
+
+                    const colTasks = col.taskIds
+                      .map((id) => effectiveTasks[id])
+                      .filter(Boolean)
+                      .filter(
+                        (t) =>
+                          !query ||
+                          t.title.toLowerCase().includes(query) ||
+                          t.taskKey.toLowerCase().includes(query) ||
+                          t.assignee?.toLowerCase().includes(query) ||
+                          t.tags?.some((tag) =>
+                            tag.toLowerCase().includes(query),
+                          ),
+                      );
+
+                    return (
+                      <BoardColumn
+                        key={col.id}
+                        column={col}
+                        tasks={colTasks}
+                        onAddTask={handleAddTask}
+                        onTaskClick={handleTaskClick}
+                        onTaskTitleUpdate={handleTitleUpdate}
+                      />
+                    );
+                  })}
+                </div>
+              </DragDropContext>
+            </div>
+          );
+        }}
+      </BoardLayout>
+
+      {selectedTask && (
+        <OtpPtrTaskDetailModal
+          task={selectedTask}
+          columnTitle={selectedColumnTitle}
+          isOpen={!!selectedTask}
+          onClose={closeTaskModal}
+          onUpdate={handleTaskUpdate}
+        />
+      )}
+    </>
+  );
+}

--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/SextingSetsTaskDetailModal.tsx
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/SextingSetsTaskDetailModal.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  X,
+  Pencil,
+  Layers,
+  User,
+  Image as ImageIcon,
+  ShieldCheck,
+  Tag,
+  Upload,
+  Sparkles,
+} from 'lucide-react';
+import type { BoardTask } from '../../board/BoardTaskCard';
+import { EditableField } from '../../board/EditableField';
+import { SelectField } from '../../board/SelectField';
+import { ActivityFeed, type TaskComment, type TaskHistoryEntry } from '../../board/ActivityFeed';
+
+interface Props {
+  task: BoardTask;
+  columnTitle: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onUpdate: (updated: BoardTask) => void;
+}
+
+const CATEGORY_OPTIONS = ['bedroom', 'outdoor', 'studio', 'selfie', 'cosplay', 'lingerie', 'other'];
+const QUALITY_OPTIONS = ['SD', 'HD', '4K'];
+const QUALITY_COLORS: Record<string, string> = { SD: 'bg-gray-200 text-gray-600', HD: 'bg-brand-blue/10 text-brand-blue', '4K': 'bg-brand-light-pink/10 text-brand-light-pink' };
+
+const PLACEHOLDER_HISTORY: TaskHistoryEntry[] = [
+  { id: 'h1', field: 'quality', oldValue: 'SD', newValue: 'HD', changedBy: 'Alex', changedAt: new Date(Date.now() - 86400000).toISOString() },
+];
+
+/**
+ * Sexting Sets detail — media-set management card.
+ * Top: title + category badge + quality badge + watermark indicator.
+ * Left (wider): description, gallery/media zone.
+ * Right (narrow): set details (category, set size, model, quality, watermark, tags), activity.
+ */
+export function SextingSetsTaskDetailModal({ task, columnTitle, isOpen, onClose, onUpdate }: Props) {
+  const [mounted, setMounted] = useState(false);
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [editingDesc, setEditingDesc] = useState(false);
+  const [titleDraft, setTitleDraft] = useState(task.title);
+  const [descDraft, setDescDraft] = useState(task.description ?? '');
+  const [comments, setComments] = useState<TaskComment[]>([]);
+  const titleRef = useRef<HTMLInputElement>(null);
+  const descRef = useRef<HTMLTextAreaElement>(null);
+
+  const meta = task.metadata ?? {};
+  const category = (meta.category as string) ?? '';
+  const setSize = (meta.setSize as number) ?? 0;
+  const model = (meta.model as string) ?? '';
+  const quality = (meta.quality as string) ?? 'HD';
+  const watermarked = (meta.watermarked as boolean) ?? false;
+  const tags = Array.isArray(meta.tags) ? (meta.tags as string[]) : [];
+
+  useEffect(() => setMounted(true), []);
+  useEffect(() => { setTitleDraft(task.title); setDescDraft(task.description ?? ''); }, [task]);
+  useEffect(() => { if (editingTitle) titleRef.current?.focus(); }, [editingTitle]);
+  useEffect(() => { if (editingDesc) descRef.current?.focus(); }, [editingDesc]);
+
+  if (!mounted || !isOpen) return null;
+
+  const updateMeta = (partial: Record<string, unknown>) => onUpdate({ ...task, metadata: { ...meta, ...partial } });
+  const saveTitle = () => { setEditingTitle(false); if (titleDraft.trim() && titleDraft !== task.title) onUpdate({ ...task, title: titleDraft.trim() }); else setTitleDraft(task.title); };
+  const saveDesc = () => { setEditingDesc(false); if (descDraft !== (task.description ?? '')) onUpdate({ ...task, description: descDraft }); };
+
+  const qualityStyle = QUALITY_COLORS[quality] ?? 'bg-gray-100 text-gray-500';
+
+  return createPortal(
+    <div className="fixed inset-0 z-9999 flex items-start justify-center bg-black/50 backdrop-blur-sm overflow-y-auto py-8 px-3" onClick={onClose}>
+      <div className="relative w-full max-w-5xl bg-white dark:bg-gray-950 rounded-2xl shadow-2xl border border-gray-200 dark:border-brand-mid-pink/20 overflow-hidden" onClick={(e) => e.stopPropagation()}>
+
+        {/* ── Header: title + badges ─────────────────────────── */}
+        <div className="px-6 sm:px-8 pt-6 pb-4 flex items-start justify-between gap-4">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-2 flex-wrap">
+              <span className="inline-flex items-center rounded-md bg-brand-blue/10 text-brand-blue px-2 py-0.5 text-[11px] font-bold tracking-wide">{task.taskKey}</span>
+              {category && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-violet-500/10 text-violet-600 dark:text-violet-400 px-2.5 py-0.5 text-[11px] font-semibold capitalize">
+                  <Layers className="h-3 w-3" />{category}
+                </span>
+              )}
+              <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-[11px] font-bold ${qualityStyle}`}>{quality}</span>
+              {watermarked && (
+                <span className="inline-flex items-center gap-1 rounded-full bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 px-2 py-0.5 text-[10px] font-medium">
+                  <ShieldCheck className="h-3 w-3" />Watermarked
+                </span>
+              )}
+              <span className="inline-flex items-center rounded-lg bg-brand-blue/10 text-brand-blue px-2 py-0.5 text-[10px] font-medium">{columnTitle}</span>
+            </div>
+            <div className="group/title">
+              {editingTitle ? (
+                <input ref={titleRef} value={titleDraft} onChange={(e) => setTitleDraft(e.target.value)} onBlur={saveTitle}
+                  onKeyDown={(e) => { if (e.key === 'Enter') saveTitle(); if (e.key === 'Escape') { setTitleDraft(task.title); setEditingTitle(false); } }}
+                  className="w-full text-xl sm:text-2xl font-bold text-gray-900 dark:text-brand-off-white bg-transparent border-b-2 border-brand-light-pink/60 focus-visible:outline-none pb-1" />
+              ) : (
+                <button type="button" onClick={() => setEditingTitle(true)} className="flex items-center gap-2 w-full text-left">
+                  <h2 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-brand-off-white">{task.title}</h2>
+                  <Pencil className="h-4 w-4 text-gray-400 opacity-0 group-hover/title:opacity-100 transition-opacity shrink-0" />
+                </button>
+              )}
+            </div>
+          </div>
+          <button type="button" onClick={onClose} className="shrink-0 inline-flex h-8 w-8 items-center justify-center rounded-full border border-gray-200 dark:border-brand-mid-pink/30 bg-white/80 dark:bg-gray-900/80 text-gray-500 hover:text-gray-900 dark:hover:text-brand-off-white hover:border-brand-light-pink/60 transition-colors">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="border-b border-gray-200 dark:border-brand-mid-pink/15" />
+
+        {/* ── Body ────────────────────────────────────────────── */}
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr_280px]">
+
+          {/* Left — description + gallery zone */}
+          <div className="px-6 sm:px-8 py-6 border-r-0 lg:border-r border-gray-200 dark:border-brand-mid-pink/15 min-h-[50vh]">
+
+            {/* Description */}
+            <div className="mb-6">
+              <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2">Description</h3>
+              <div className="group/desc">
+                {editingDesc ? (
+                  <div>
+                    <textarea ref={descRef} value={descDraft} onChange={(e) => setDescDraft(e.target.value)} rows={3} placeholder="Describe this set..."
+                      className="w-full rounded-xl border border-brand-light-pink/40 bg-white/80 dark:bg-gray-900/80 px-3 py-2.5 text-sm text-gray-800 dark:text-brand-off-white placeholder:text-gray-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-light-pink/60 resize-none" />
+                    <div className="flex items-center gap-2 mt-2">
+                      <button type="button" onClick={saveDesc} className="px-3 py-1.5 rounded-lg bg-brand-light-pink text-white text-xs font-medium hover:bg-brand-mid-pink">Save</button>
+                      <button type="button" onClick={() => { setDescDraft(task.description ?? ''); setEditingDesc(false); }} className="px-3 py-1.5 rounded-lg text-gray-500 text-xs font-medium hover:bg-gray-100 dark:hover:bg-gray-800">Cancel</button>
+                    </div>
+                  </div>
+                ) : (
+                  <button type="button" onClick={() => setEditingDesc(true)} className="flex items-start gap-2 w-full text-left">
+                    <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap flex-1">{task.description || <span className="text-gray-400 italic">Click to add a description...</span>}</p>
+                    <Pencil className="h-3.5 w-3.5 text-gray-400 opacity-0 group-hover/desc:opacity-100 transition-opacity shrink-0 mt-0.5" />
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* Gallery grid placeholder */}
+            <div className="mb-6">
+              <div className="flex items-center justify-between mb-2">
+                <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Gallery</h3>
+                <span className="text-[10px] text-gray-400">{setSize} image{setSize !== 1 ? 's' : ''} in set</span>
+              </div>
+              {setSize > 0 ? (
+                <div className="grid grid-cols-3 gap-2">
+                  {Array.from({ length: Math.min(setSize, 6) }).map((_, i) => (
+                    <div key={i} className="aspect-square rounded-xl bg-gray-100 dark:bg-gray-900/60 border border-gray-200 dark:border-brand-mid-pink/15 flex items-center justify-center">
+                      <Sparkles className="h-5 w-5 text-gray-300 dark:text-gray-600" />
+                    </div>
+                  ))}
+                  {setSize > 6 && (
+                    <div className="aspect-square rounded-xl bg-gray-100 dark:bg-gray-900/60 border border-gray-200 dark:border-brand-mid-pink/15 flex items-center justify-center">
+                      <span className="text-xs font-bold text-gray-400">+{setSize - 6}</span>
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div className="rounded-2xl border-2 border-dashed border-gray-300 dark:border-brand-mid-pink/25 bg-gray-50/50 dark:bg-gray-900/30 p-8 flex flex-col items-center justify-center gap-3 text-center">
+                  <div className="h-12 w-12 rounded-full bg-brand-light-pink/10 flex items-center justify-center">
+                    <Upload className="h-5 w-5 text-brand-light-pink" />
+                  </div>
+                  <p className="text-sm text-gray-500 dark:text-gray-400">Upload images for this set</p>
+                </div>
+              )}
+            </div>
+
+            <ActivityFeed comments={comments} history={PLACEHOLDER_HISTORY} onAddComment={(c) => setComments((p) => [{ id: `c-${Date.now()}`, author: 'You', content: c, createdAt: new Date().toISOString() }, ...p])} />
+          </div>
+
+          {/* Right — set metadata */}
+          <div className="px-5 py-6 bg-gray-50/70 dark:bg-gray-950/60 space-y-5">
+
+            <div>
+              <div className="flex items-center gap-1.5 mb-1.5"><Layers className="h-3.5 w-3.5 text-gray-400" /><span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Category</span></div>
+              <SelectField value={category} options={CATEGORY_OPTIONS} onSave={(v) => updateMeta({ category: v })} />
+            </div>
+
+            <div>
+              <div className="flex items-center gap-1.5 mb-1.5"><ImageIcon className="h-3.5 w-3.5 text-gray-400" /><span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Set Size</span></div>
+              <EditableField value={String(setSize)} placeholder="Number of images" onSave={(v) => updateMeta({ setSize: Number(v) || 0 })} />
+            </div>
+
+            <div>
+              <div className="flex items-center gap-1.5 mb-1.5"><User className="h-3.5 w-3.5 text-gray-400" /><span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Model</span></div>
+              <EditableField value={model} placeholder="Model name" onSave={(v) => updateMeta({ model: v })} />
+            </div>
+
+            <div>
+              <div className="flex items-center gap-1.5 mb-1.5"><ImageIcon className="h-3.5 w-3.5 text-gray-400" /><span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Quality</span></div>
+              <SelectField value={quality} options={QUALITY_OPTIONS} onSave={(v) => updateMeta({ quality: v })} />
+            </div>
+
+            <div>
+              <div className="flex items-center gap-1.5 mb-1.5"><ShieldCheck className="h-3.5 w-3.5 text-gray-400" /><span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Watermarked</span></div>
+              <button type="button" onClick={() => updateMeta({ watermarked: !watermarked })}
+                className={`inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs font-medium transition-colors ${watermarked ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400'}`}>
+                <span className={`h-2 w-2 rounded-full ${watermarked ? 'bg-emerald-500' : 'bg-gray-400'}`} />
+                {watermarked ? 'Yes' : 'No'}
+              </button>
+            </div>
+
+            <div>
+              <div className="flex items-center gap-1.5 mb-1.5"><Tag className="h-3.5 w-3.5 text-gray-400" /><span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Tags</span></div>
+              {tags.length > 0 ? (
+                <div className="flex items-center gap-1.5 flex-wrap">{tags.map((t) => (<span key={t} className="inline-flex items-center rounded-full bg-brand-light-pink/10 text-brand-light-pink px-2 py-0.5 text-[10px] font-medium">{t}</span>))}</div>
+              ) : (<span className="text-xs text-gray-400 italic">No tags</span>)}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/SextingSetsTemplate.tsx
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/SextingSetsTemplate.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { DragDropContext } from '@hello-pangea/dnd';
+import {
+  BoardLayout,
+  BoardColumn,
+  type BoardTask,
+  type BoardTab,
+} from '../../board';
+import { useSpaceBoard } from '../useSpaceBoard';
+import { SextingSetsTaskDetailModal } from './SextingSetsTaskDetailModal';
+import type { BoardItem } from '@/lib/hooks/useBoardItems.query';
+import { Loader2, Layers } from 'lucide-react';
+import type { TemplateProps } from './types';
+
+const TABS: BoardTab[] = [
+  { id: 'summary', label: 'Summary' },
+  { id: 'board', label: 'Board' },
+  { id: 'gallery', label: 'Gallery' },
+];
+
+function sextingSetsItemToTask(item: BoardItem, spaceKey: string): BoardTask {
+  const meta = (item.metadata ?? {}) as Record<string, unknown>;
+  return {
+    id: item.id,
+    taskKey: spaceKey
+      ? `${spaceKey}-${item.position + 1}`
+      : item.id.slice(-6).toUpperCase(),
+    title: item.title,
+    description: (item.description as string) ?? undefined,
+    assignee: (meta.model as string) ?? (item.assigneeId as string) ?? undefined,
+    priority: undefined,
+    tags: [
+      ...(meta.category ? [meta.category as string] : []),
+      ...(meta.quality ? [meta.quality as string] : []),
+      ...(Array.isArray(meta.tags) ? (meta.tags as string[]) : []),
+    ],
+    startDate: undefined,
+    dueDate: item.dueDate ?? undefined,
+    reporter: undefined,
+    metadata: meta,
+  };
+}
+
+export function SextingSetsTemplate({ space }: TemplateProps) {
+  const {
+    itemsLoading,
+    effectiveColumns,
+    effectiveTasks,
+    effectiveColumnOrder,
+    selectedTask,
+    selectedColumnTitle,
+    handleDragEnd,
+    handleAddTask,
+    handleTaskClick,
+    handleTaskUpdate,
+    handleTitleUpdate,
+    closeTaskModal,
+  } = useSpaceBoard({ space, itemToTask: sextingSetsItemToTask });
+
+  return (
+    <>
+      <BoardLayout
+        spaceName={space.name}
+        templateLabel="Sexting Sets"
+        tabs={TABS}
+        defaultTab="board"
+      >
+        {(activeTab, searchQuery) => {
+          if (activeTab === 'summary') {
+            return (
+              <div className="rounded-2xl border border-dashed border-gray-200 dark:border-brand-mid-pink/20 bg-white/50 dark:bg-gray-900/40 px-6 py-10 text-center">
+                <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-brand-light-pink/10">
+                  <Layers className="h-5 w-5 text-brand-light-pink" />
+                </div>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  Sexting Sets summary &mdash; set counts, model distribution,
+                  and recent uploads will appear here.
+                </p>
+              </div>
+            );
+          }
+
+          if (activeTab === 'gallery') {
+            return (
+              <div className="rounded-2xl border border-dashed border-gray-200 dark:border-brand-mid-pink/20 bg-white/50 dark:bg-gray-900/40 px-6 py-10 text-center">
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  Gallery view coming soon &mdash; browse sets in a visual grid
+                  layout.
+                </p>
+              </div>
+            );
+          }
+
+          if (itemsLoading) {
+            return (
+              <div className="flex items-center justify-center py-16">
+                <Loader2 className="h-5 w-5 animate-spin text-brand-light-pink" />
+                <span className="ml-2 text-sm text-gray-500 dark:text-gray-400">
+                  Loading board...
+                </span>
+              </div>
+            );
+          }
+
+          const query = searchQuery.toLowerCase();
+
+          return (
+            <div className="rounded-2xl border border-gray-200 dark:border-brand-mid-pink/15 bg-gray-100/50 dark:bg-gray-950/40 p-3 sm:p-4 overflow-x-auto">
+              <DragDropContext onDragEnd={handleDragEnd}>
+                <div className="flex gap-3 sm:gap-4 min-w-max">
+                  {effectiveColumnOrder.map((colId) => {
+                    const col = effectiveColumns[colId];
+                    if (!col) return null;
+
+                    const colTasks = col.taskIds
+                      .map((id) => effectiveTasks[id])
+                      .filter(Boolean)
+                      .filter(
+                        (t) =>
+                          !query ||
+                          t.title.toLowerCase().includes(query) ||
+                          t.taskKey.toLowerCase().includes(query) ||
+                          t.assignee?.toLowerCase().includes(query) ||
+                          t.tags?.some((tag) =>
+                            tag.toLowerCase().includes(query),
+                          ),
+                      );
+
+                    return (
+                      <BoardColumn
+                        key={col.id}
+                        column={col}
+                        tasks={colTasks}
+                        onAddTask={handleAddTask}
+                        onTaskClick={handleTaskClick}
+                        onTaskTitleUpdate={handleTitleUpdate}
+                      />
+                    );
+                  })}
+                </div>
+              </DragDropContext>
+            </div>
+          );
+        }}
+      </BoardLayout>
+
+      {selectedTask && (
+        <SextingSetsTaskDetailModal
+          task={selectedTask}
+          columnTitle={selectedColumnTitle}
+          isOpen={!!selectedTask}
+          onClose={closeTaskModal}
+          onUpdate={handleTaskUpdate}
+        />
+      )}
+    </>
+  );
+}

--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/WallPostTaskDetailModal.tsx
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/WallPostTaskDetailModal.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import {
+  X,
+  Pencil,
+  Image as ImageIcon,
+  CalendarDays,
+  User,
+  AtSign,
+  Hash,
+  Upload,
+} from 'lucide-react';
+import type { BoardTask } from '../../board/BoardTaskCard';
+import { EditableField } from '../../board/EditableField';
+import { SelectField } from '../../board/SelectField';
+import { ActivityFeed, type TaskComment, type TaskHistoryEntry } from '../../board/ActivityFeed';
+
+interface Props {
+  task: BoardTask;
+  columnTitle: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onUpdate: (updated: BoardTask) => void;
+}
+
+const PLATFORM_OPTIONS = ['onlyfans', 'fansly', 'instagram', 'twitter', 'reddit'];
+const PLATFORM_COLORS: Record<string, string> = {
+  onlyfans: 'bg-sky-500/10 text-sky-600',
+  fansly: 'bg-brand-light-pink/10 text-brand-light-pink',
+  instagram: 'bg-purple-500/10 text-purple-600',
+  twitter: 'bg-blue-500/10 text-blue-500',
+  reddit: 'bg-orange-500/10 text-orange-600',
+};
+
+const PLACEHOLDER_HISTORY: TaskHistoryEntry[] = [
+  { id: 'h1', field: 'platform', oldValue: 'instagram', newValue: 'onlyfans', changedBy: 'Alex', changedAt: new Date(Date.now() - 86400000).toISOString() },
+];
+
+/**
+ * Wall Post detail — content-editor style.
+ * Top: title + platform badge.
+ * Left (wider): large caption editor, media upload area.
+ * Right (narrow): scheduling, model, hashtags, media count, activity.
+ */
+export function WallPostTaskDetailModal({ task, columnTitle, isOpen, onClose, onUpdate }: Props) {
+  const [mounted, setMounted] = useState(false);
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [editingCaption, setEditingCaption] = useState(false);
+  const [titleDraft, setTitleDraft] = useState(task.title);
+  const [comments, setComments] = useState<TaskComment[]>([]);
+  const titleRef = useRef<HTMLInputElement>(null);
+  const captionRef = useRef<HTMLTextAreaElement>(null);
+
+  const meta = task.metadata ?? {};
+  const caption = (meta.caption as string) ?? '';
+  const platform = (meta.platform as string) ?? '';
+  const hashtags = Array.isArray(meta.hashtags) ? (meta.hashtags as string[]) : [];
+  const scheduledDate = (meta.scheduledDate as string) ?? '';
+  const model = (meta.model as string) ?? '';
+  const mediaCount = (meta.mediaCount as number) ?? 0;
+
+  const [captionDraft, setCaptionDraft] = useState(caption);
+
+  useEffect(() => setMounted(true), []);
+  useEffect(() => { setTitleDraft(task.title); setCaptionDraft(caption); }, [task, caption]);
+  useEffect(() => { if (editingTitle) titleRef.current?.focus(); }, [editingTitle]);
+  useEffect(() => { if (editingCaption) captionRef.current?.focus(); }, [editingCaption]);
+
+  if (!mounted || !isOpen) return null;
+
+  const updateMeta = (partial: Record<string, unknown>) => onUpdate({ ...task, metadata: { ...meta, ...partial } });
+  const saveTitle = () => { setEditingTitle(false); if (titleDraft.trim() && titleDraft !== task.title) onUpdate({ ...task, title: titleDraft.trim() }); else setTitleDraft(task.title); };
+  const saveCaption = () => { setEditingCaption(false); if (captionDraft !== caption) updateMeta({ caption: captionDraft }); };
+
+  const platformStyle = PLATFORM_COLORS[platform] ?? 'bg-gray-100 dark:bg-gray-800 text-gray-500';
+
+  return createPortal(
+    <div className="fixed inset-0 z-9999 flex items-start justify-center bg-black/50 backdrop-blur-sm overflow-y-auto py-8 px-3" onClick={onClose}>
+      <div className="relative w-full max-w-5xl bg-white dark:bg-gray-950 rounded-2xl shadow-2xl border border-gray-200 dark:border-brand-mid-pink/20 overflow-hidden" onClick={(e) => e.stopPropagation()}>
+
+        {/* ── Header: title + platform badge + status ──────── */}
+        <div className="px-6 sm:px-8 pt-6 pb-4 flex items-start justify-between gap-4">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 mb-2 flex-wrap">
+              <span className="inline-flex items-center rounded-md bg-brand-blue/10 text-brand-blue px-2 py-0.5 text-[11px] font-bold tracking-wide">{task.taskKey}</span>
+              {platform && (
+                <span className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-[11px] font-semibold capitalize ${platformStyle}`}>
+                  <AtSign className="h-3 w-3" />{platform}
+                </span>
+              )}
+              <span className="inline-flex items-center rounded-lg bg-brand-blue/10 text-brand-blue px-2 py-0.5 text-[10px] font-medium">{columnTitle}</span>
+            </div>
+            <div className="group/title">
+              {editingTitle ? (
+                <input ref={titleRef} value={titleDraft} onChange={(e) => setTitleDraft(e.target.value)} onBlur={saveTitle}
+                  onKeyDown={(e) => { if (e.key === 'Enter') saveTitle(); if (e.key === 'Escape') { setTitleDraft(task.title); setEditingTitle(false); } }}
+                  className="w-full text-xl sm:text-2xl font-bold text-gray-900 dark:text-brand-off-white bg-transparent border-b-2 border-brand-light-pink/60 focus-visible:outline-none pb-1" />
+              ) : (
+                <button type="button" onClick={() => setEditingTitle(true)} className="flex items-center gap-2 w-full text-left">
+                  <h2 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-brand-off-white">{task.title}</h2>
+                  <Pencil className="h-4 w-4 text-gray-400 opacity-0 group-hover/title:opacity-100 transition-opacity shrink-0" />
+                </button>
+              )}
+            </div>
+          </div>
+          <button type="button" onClick={onClose} className="shrink-0 inline-flex h-8 w-8 items-center justify-center rounded-full border border-gray-200 dark:border-brand-mid-pink/30 bg-white/80 dark:bg-gray-900/80 text-gray-500 hover:text-gray-900 dark:hover:text-brand-off-white hover:border-brand-light-pink/60 transition-colors">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="border-b border-gray-200 dark:border-brand-mid-pink/15" />
+
+        {/* ── Body: content area (left) + details panel (right) */}
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr_300px]">
+
+          {/* Left — Caption editor + media upload zone */}
+          <div className="px-6 sm:px-8 py-6 border-r-0 lg:border-r border-gray-200 dark:border-brand-mid-pink/15 min-h-[50vh]">
+
+            {/* Caption */}
+            <div className="mb-6">
+              <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2">Caption</h3>
+              <div className="group/cap">
+                {editingCaption ? (
+                  <div>
+                    <textarea ref={captionRef} value={captionDraft} onChange={(e) => setCaptionDraft(e.target.value)} rows={6} placeholder="Write your post caption..."
+                      className="w-full rounded-xl border border-brand-light-pink/40 bg-white/80 dark:bg-gray-900/80 px-4 py-3 text-sm text-gray-800 dark:text-brand-off-white placeholder:text-gray-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-light-pink/60 resize-none leading-relaxed" />
+                    <div className="flex items-center gap-2 mt-2">
+                      <button type="button" onClick={saveCaption} className="px-3 py-1.5 rounded-lg bg-brand-light-pink text-white text-xs font-medium hover:bg-brand-mid-pink">Save</button>
+                      <button type="button" onClick={() => { setCaptionDraft(caption); setEditingCaption(false); }} className="px-3 py-1.5 rounded-lg text-gray-500 text-xs font-medium hover:bg-gray-100 dark:hover:bg-gray-800">Cancel</button>
+                    </div>
+                  </div>
+                ) : (
+                  <button type="button" onClick={() => setEditingCaption(true)} className="flex items-start gap-2 w-full text-left">
+                    <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap flex-1 leading-relaxed">{caption || <span className="text-gray-400 italic">Click to write a caption...</span>}</p>
+                    <Pencil className="h-3.5 w-3.5 text-gray-400 opacity-0 group-hover/cap:opacity-100 transition-opacity shrink-0 mt-0.5" />
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {/* Hashtags inline */}
+            {hashtags.length > 0 && (
+              <div className="mb-6 flex items-center gap-1.5 flex-wrap">
+                {hashtags.map((h) => (
+                  <span key={h} className="inline-flex items-center rounded-full bg-brand-blue/10 text-brand-blue px-2.5 py-0.5 text-[11px] font-medium">#{h}</span>
+                ))}
+              </div>
+            )}
+
+            {/* Media upload zone */}
+            <div className="mb-6">
+              <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2">Media</h3>
+              <div className="rounded-2xl border-2 border-dashed border-gray-300 dark:border-brand-mid-pink/25 bg-gray-50/50 dark:bg-gray-900/30 p-8 flex flex-col items-center justify-center gap-3 text-center">
+                <div className="h-12 w-12 rounded-full bg-brand-light-pink/10 flex items-center justify-center">
+                  <Upload className="h-5 w-5 text-brand-light-pink" />
+                </div>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  Drag &amp; drop media here, or <span className="text-brand-light-pink font-medium cursor-pointer hover:underline">browse</span>
+                </p>
+                <p className="text-[10px] text-gray-400">
+                  {mediaCount > 0 ? `${mediaCount} file(s) attached` : 'No files yet'}
+                </p>
+              </div>
+            </div>
+
+            {/* Activity */}
+            <ActivityFeed comments={comments} history={PLACEHOLDER_HISTORY} onAddComment={(c) => setComments((p) => [{ id: `c-${Date.now()}`, author: 'You', content: c, createdAt: new Date().toISOString() }, ...p])} />
+          </div>
+
+          {/* Right — scheduling & post details */}
+          <div className="px-5 py-6 bg-gray-50/70 dark:bg-gray-950/60 space-y-5">
+
+            <div>
+              <div className="flex items-center gap-1.5 mb-1.5">
+                <AtSign className="h-3.5 w-3.5 text-gray-400" />
+                <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Platform</span>
+              </div>
+              <SelectField value={platform} options={PLATFORM_OPTIONS} onSave={(v) => updateMeta({ platform: v })} />
+            </div>
+
+            <div>
+              <div className="flex items-center gap-1.5 mb-1.5">
+                <CalendarDays className="h-3.5 w-3.5 text-gray-400" />
+                <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Scheduled Date</span>
+              </div>
+              <EditableField value={scheduledDate} type="date" placeholder="Not scheduled" onSave={(v) => updateMeta({ scheduledDate: v })} />
+            </div>
+
+            <div>
+              <div className="flex items-center gap-1.5 mb-1.5">
+                <User className="h-3.5 w-3.5 text-gray-400" />
+                <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Model</span>
+              </div>
+              <EditableField value={model} placeholder="Model name" onSave={(v) => updateMeta({ model: v })} />
+            </div>
+
+            <div>
+              <div className="flex items-center gap-1.5 mb-1.5">
+                <ImageIcon className="h-3.5 w-3.5 text-gray-400" />
+                <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Media Count</span>
+              </div>
+              <EditableField value={String(mediaCount)} placeholder="0" onSave={(v) => updateMeta({ mediaCount: Number(v) || 0 })} />
+            </div>
+
+            <div>
+              <div className="flex items-center gap-1.5 mb-1.5">
+                <Hash className="h-3.5 w-3.5 text-gray-400" />
+                <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Hashtags</span>
+              </div>
+              {hashtags.length > 0 ? (
+                <div className="flex items-center gap-1.5 flex-wrap">{hashtags.map((h) => (<span key={h} className="inline-flex items-center rounded-full bg-brand-blue/10 text-brand-blue px-2 py-0.5 text-[10px] font-medium">#{h}</span>))}</div>
+              ) : (<span className="text-xs text-gray-400 italic">No hashtags</span>)}
+            </div>
+
+            {/* Description (secondary for wall posts) */}
+            <div className="pt-4 border-t border-gray-200 dark:border-brand-mid-pink/15">
+              <div className="flex items-center gap-1.5 mb-1.5">
+                <Pencil className="h-3.5 w-3.5 text-gray-400" />
+                <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Notes</span>
+              </div>
+              <EditableField value={task.description ?? ''} placeholder="Internal notes..." onSave={(v) => onUpdate({ ...task, description: v || undefined })} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/WallPostTemplate.tsx
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/WallPostTemplate.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { DragDropContext } from '@hello-pangea/dnd';
+import {
+  BoardLayout,
+  BoardColumn,
+  type BoardTask,
+  type BoardTab,
+} from '../../board';
+import { useSpaceBoard } from '../useSpaceBoard';
+import { WallPostTaskDetailModal } from './WallPostTaskDetailModal';
+import type { BoardItem } from '@/lib/hooks/useBoardItems.query';
+import { Loader2, Image as ImageIcon } from 'lucide-react';
+import type { TemplateProps } from './types';
+
+const TABS: BoardTab[] = [
+  { id: 'summary', label: 'Summary' },
+  { id: 'board', label: 'Board' },
+  { id: 'calendar', label: 'Calendar' },
+];
+
+function wallPostItemToTask(item: BoardItem, spaceKey: string): BoardTask {
+  const meta = (item.metadata ?? {}) as Record<string, unknown>;
+  return {
+    id: item.id,
+    taskKey: spaceKey
+      ? `${spaceKey}-${item.position + 1}`
+      : item.id.slice(-6).toUpperCase(),
+    title: item.title,
+    description: (item.description as string) ?? undefined,
+    assignee: (meta.model as string) ?? (item.assigneeId as string) ?? undefined,
+    priority: undefined,
+    tags: [
+      ...(meta.platform ? [meta.platform as string] : []),
+      ...(Array.isArray(meta.hashtags) ? (meta.hashtags as string[]) : []),
+    ],
+    startDate: undefined,
+    dueDate: (meta.scheduledDate as string) ?? item.dueDate ?? undefined,
+    reporter: undefined,
+    metadata: meta,
+  };
+}
+
+export function WallPostTemplate({ space }: TemplateProps) {
+  const {
+    itemsLoading,
+    effectiveColumns,
+    effectiveTasks,
+    effectiveColumnOrder,
+    selectedTask,
+    selectedColumnTitle,
+    handleDragEnd,
+    handleAddTask,
+    handleTaskClick,
+    handleTaskUpdate,
+    handleTitleUpdate,
+    closeTaskModal,
+  } = useSpaceBoard({ space, itemToTask: wallPostItemToTask });
+
+  return (
+    <>
+      <BoardLayout
+        spaceName={space.name}
+        templateLabel="Wall Post"
+        tabs={TABS}
+        defaultTab="board"
+      >
+        {(activeTab, searchQuery) => {
+          if (activeTab === 'summary') {
+            return (
+              <div className="rounded-2xl border border-dashed border-gray-200 dark:border-brand-mid-pink/20 bg-white/50 dark:bg-gray-900/40 px-6 py-10 text-center">
+                <div className="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-brand-light-pink/10">
+                  <ImageIcon className="h-5 w-5 text-brand-light-pink" />
+                </div>
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  Wall Post summary &mdash; content calendar overview, scheduling
+                  stats, and platform distribution will appear here.
+                </p>
+              </div>
+            );
+          }
+
+          if (activeTab === 'calendar') {
+            return (
+              <div className="rounded-2xl border border-dashed border-gray-200 dark:border-brand-mid-pink/20 bg-white/50 dark:bg-gray-900/40 px-6 py-10 text-center">
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  Calendar view coming soon &mdash; visualize scheduled posts
+                  across time.
+                </p>
+              </div>
+            );
+          }
+
+          if (itemsLoading) {
+            return (
+              <div className="flex items-center justify-center py-16">
+                <Loader2 className="h-5 w-5 animate-spin text-brand-light-pink" />
+                <span className="ml-2 text-sm text-gray-500 dark:text-gray-400">
+                  Loading board...
+                </span>
+              </div>
+            );
+          }
+
+          const query = searchQuery.toLowerCase();
+
+          return (
+            <div className="rounded-2xl border border-gray-200 dark:border-brand-mid-pink/15 bg-gray-100/50 dark:bg-gray-950/40 p-3 sm:p-4 overflow-x-auto">
+              <DragDropContext onDragEnd={handleDragEnd}>
+                <div className="flex gap-3 sm:gap-4 min-w-max">
+                  {effectiveColumnOrder.map((colId) => {
+                    const col = effectiveColumns[colId];
+                    if (!col) return null;
+
+                    const colTasks = col.taskIds
+                      .map((id) => effectiveTasks[id])
+                      .filter(Boolean)
+                      .filter(
+                        (t) =>
+                          !query ||
+                          t.title.toLowerCase().includes(query) ||
+                          t.taskKey.toLowerCase().includes(query) ||
+                          t.assignee?.toLowerCase().includes(query) ||
+                          t.tags?.some((tag) =>
+                            tag.toLowerCase().includes(query),
+                          ),
+                      );
+
+                    return (
+                      <BoardColumn
+                        key={col.id}
+                        column={col}
+                        tasks={colTasks}
+                        onAddTask={handleAddTask}
+                        onTaskClick={handleTaskClick}
+                        onTaskTitleUpdate={handleTitleUpdate}
+                      />
+                    );
+                  })}
+                </div>
+              </DragDropContext>
+            </div>
+          );
+        }}
+      </BoardLayout>
+
+      {selectedTask && (
+        <WallPostTaskDetailModal
+          task={selectedTask}
+          columnTitle={selectedColumnTitle}
+          isOpen={!!selectedTask}
+          onClose={closeTaskModal}
+          onUpdate={handleTaskUpdate}
+        />
+      )}
+    </>
+  );
+}

--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/index.ts
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/index.ts
@@ -1,0 +1,11 @@
+export { KanbanTemplate } from './KanbanTemplate';
+export { WallPostTemplate } from './WallPostTemplate';
+export { SextingSetsTemplate } from './SextingSetsTemplate';
+export { OtpPtrTemplate } from './OtpPtrTemplate';
+
+export { KanbanTaskDetailModal } from './KanbanTaskDetailModal';
+export { WallPostTaskDetailModal } from './WallPostTaskDetailModal';
+export { SextingSetsTaskDetailModal } from './SextingSetsTaskDetailModal';
+export { OtpPtrTaskDetailModal } from './OtpPtrTaskDetailModal';
+
+export type { TemplateProps } from './types';

--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/types.ts
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/types.ts
@@ -1,0 +1,9 @@
+import type { SpaceWithBoards } from '@/lib/hooks/useSpaces.query';
+
+/**
+ * Shared props every template component receives.
+ * Templates can extend this if they need extra props.
+ */
+export interface TemplateProps {
+  space: SpaceWithBoards;
+}

--- a/app/[tenant]/(dashboard)/spaces/[slug]/useSpaceBoard.ts
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/useSpaceBoard.ts
@@ -1,0 +1,260 @@
+'use client';
+
+import { useState, useCallback, useMemo } from 'react';
+import type { DropResult } from '@hello-pangea/dnd';
+import type { BoardTask, BoardColumnData } from '../board';
+import {
+  useBoardItems,
+  useCreateBoardItem,
+  useUpdateBoardItem,
+  type BoardItem,
+} from '@/lib/hooks/useBoardItems.query';
+import type { SpaceWithBoards } from '@/lib/hooks/useSpaces.query';
+
+/* ------------------------------------------------------------------ */
+/*  Column state with task IDs for DnD                                 */
+/* ------------------------------------------------------------------ */
+
+export type ColumnWithTasks = BoardColumnData & { taskIds: string[] };
+
+/* ------------------------------------------------------------------ */
+/*  DB → UI transformer (overridable per template)                     */
+/* ------------------------------------------------------------------ */
+
+export type ItemToTaskFn = (item: BoardItem, spaceKey: string) => BoardTask;
+
+function capitalize(s: string) {
+  return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+}
+
+export const defaultItemToTask: ItemToTaskFn = (item, spaceKey) => {
+  const meta = (item.metadata ?? {}) as Record<string, unknown>;
+  return {
+    id: item.id,
+    taskKey: spaceKey
+      ? `${spaceKey}-${item.position + 1}`
+      : item.id.slice(-6).toUpperCase(),
+    title: item.title,
+    description: (item.description as string) ?? undefined,
+    assignee: (item.assigneeId as string) ?? undefined,
+    priority: capitalize(item.priority) as BoardTask['priority'],
+    tags: Array.isArray(meta.tags) ? (meta.tags as string[]) : undefined,
+    startDate: undefined,
+    dueDate: item.dueDate ?? undefined,
+    reporter: undefined,
+    metadata: meta,
+  };
+};
+
+/* ------------------------------------------------------------------ */
+/*  Hook                                                               */
+/* ------------------------------------------------------------------ */
+
+interface UseSpaceBoardOptions {
+  space: SpaceWithBoards | undefined;
+  itemToTask?: ItemToTaskFn;
+}
+
+export function useSpaceBoard({ space, itemToTask = defaultItemToTask }: UseSpaceBoardOptions) {
+  const defaultBoard = space?.boards?.[0];
+
+  const {
+    data: boardData,
+    isLoading: itemsLoading,
+  } = useBoardItems(space?.id, defaultBoard?.id);
+
+  const createItemMutation = useCreateBoardItem(
+    space?.id ?? '',
+    defaultBoard?.id ?? '',
+  );
+  const updateItemMutation = useUpdateBoardItem(
+    space?.id ?? '',
+    defaultBoard?.id ?? '',
+  );
+
+  const [selectedTask, setSelectedTask] = useState<BoardTask | null>(null);
+  const [selectedColumnTitle, setSelectedColumnTitle] = useState('');
+
+  // Build columns + tasks from real data
+  const { columnsMap, columnOrder, tasksMap } = useMemo(() => {
+    const empty = {
+      columnsMap: {} as Record<string, ColumnWithTasks>,
+      columnOrder: [] as string[],
+      tasksMap: {} as Record<string, BoardTask>,
+    };
+    if (!boardData) return empty;
+
+    const cols = [...boardData.columns].sort((a, b) => a.position - b.position);
+    const spaceKey = space?.key ?? '';
+
+    const tMap: Record<string, BoardTask> = {};
+    const cMap: Record<string, ColumnWithTasks> = {};
+    const cOrder: string[] = [];
+
+    for (const col of cols) {
+      cOrder.push(col.id);
+      cMap[col.id] = {
+        id: col.id,
+        title: col.name,
+        color: col.color ?? 'gray',
+        taskIds: [],
+      };
+    }
+
+    const sortedItems = [...boardData.items].sort(
+      (a, b) => a.position - b.position,
+    );
+
+    for (const item of sortedItems) {
+      const task = itemToTask(item, spaceKey);
+      tMap[task.id] = task;
+      if (cMap[item.columnId]) {
+        cMap[item.columnId].taskIds.push(task.id);
+      }
+    }
+
+    return { columnsMap: cMap, columnOrder: cOrder, tasksMap: tMap };
+  }, [boardData, space?.key, itemToTask]);
+
+  // Local state for optimistic drag-and-drop
+  const [localColumns, setLocalColumns] = useState<Record<string, ColumnWithTasks> | null>(null);
+  const [localTasks, setLocalTasks] = useState<Record<string, BoardTask> | null>(null);
+
+  const effectiveColumns = localColumns ?? columnsMap;
+  const effectiveTasks = localTasks ?? tasksMap;
+  const effectiveColumnOrder = localColumns
+    ? Object.keys(localColumns).sort((a, b) => {
+        const posA = boardData?.columns.find((c) => c.id === a)?.position ?? 0;
+        const posB = boardData?.columns.find((c) => c.id === b)?.position ?? 0;
+        return posA - posB;
+      })
+    : columnOrder;
+
+  const findColumnForTask = useCallback(
+    (taskId: string) => {
+      for (const col of Object.values(effectiveColumns)) {
+        if (col.taskIds.includes(taskId)) return col;
+      }
+      return null;
+    },
+    [effectiveColumns],
+  );
+
+  /* ── Handlers ───────────────────────────────────────────────── */
+
+  const handleDragEnd = useCallback(
+    (result: DropResult) => {
+      const { source, destination, draggableId } = result;
+      if (!destination) return;
+      if (
+        destination.droppableId === source.droppableId &&
+        destination.index === source.index
+      )
+        return;
+
+      const startCol = effectiveColumns[source.droppableId];
+      const finishCol = effectiveColumns[destination.droppableId];
+      if (!startCol || !finishCol) return;
+
+      const newCols = { ...effectiveColumns };
+
+      if (startCol.id === finishCol.id) {
+        const ids = Array.from(startCol.taskIds);
+        ids.splice(source.index, 1);
+        ids.splice(destination.index, 0, draggableId);
+        newCols[startCol.id] = { ...startCol, taskIds: ids };
+      } else {
+        const startIds = Array.from(startCol.taskIds);
+        startIds.splice(source.index, 1);
+        const finishIds = Array.from(finishCol.taskIds);
+        finishIds.splice(destination.index, 0, draggableId);
+        newCols[startCol.id] = { ...startCol, taskIds: startIds };
+        newCols[finishCol.id] = { ...finishCol, taskIds: finishIds };
+
+        updateItemMutation.mutate({
+          itemId: draggableId,
+          columnId: finishCol.id,
+          position: destination.index,
+        });
+      }
+
+      setLocalColumns(newCols);
+    },
+    [effectiveColumns, updateItemMutation],
+  );
+
+  const handleAddTask = useCallback(
+    (columnId: string, title: string) => {
+      createItemMutation.mutate(
+        { title, columnId },
+        {
+          onSuccess: () => {
+            setLocalColumns(null);
+            setLocalTasks(null);
+          },
+        },
+      );
+    },
+    [createItemMutation],
+  );
+
+  const handleTaskClick = useCallback(
+    (task: BoardTask) => {
+      const col = findColumnForTask(task.id);
+      setSelectedTask(task);
+      setSelectedColumnTitle(col?.title ?? '');
+    },
+    [findColumnForTask],
+  );
+
+  const handleTaskUpdate = useCallback(
+    (updated: BoardTask) => {
+      setLocalTasks((prev) => ({
+        ...(prev ?? effectiveTasks),
+        [updated.id]: updated,
+      }));
+
+      updateItemMutation.mutate({
+        itemId: updated.id,
+        title: updated.title,
+        description: updated.description,
+        priority: updated.priority?.toUpperCase(),
+        dueDate: updated.dueDate,
+        assigneeId: updated.assignee,
+      });
+
+      setSelectedTask(updated);
+    },
+    [effectiveTasks, updateItemMutation],
+  );
+
+  const handleTitleUpdate = useCallback(
+    (task: BoardTask, newTitle: string) => {
+      const updated = { ...task, title: newTitle };
+      setLocalTasks((prev) => ({
+        ...(prev ?? effectiveTasks),
+        [task.id]: updated,
+      }));
+      updateItemMutation.mutate({ itemId: task.id, title: newTitle });
+    },
+    [effectiveTasks, updateItemMutation],
+  );
+
+  const closeTaskModal = useCallback(() => setSelectedTask(null), []);
+
+  return {
+    boardData,
+    itemsLoading,
+    effectiveColumns,
+    effectiveTasks,
+    effectiveColumnOrder,
+    selectedTask,
+    selectedColumnTitle,
+    handleDragEnd,
+    handleAddTask,
+    handleTaskClick,
+    handleTaskUpdate,
+    handleTitleUpdate,
+    closeTaskModal,
+  };
+}

--- a/app/[tenant]/(dashboard)/spaces/board/BoardTaskCard.tsx
+++ b/app/[tenant]/(dashboard)/spaces/board/BoardTaskCard.tsx
@@ -16,6 +16,7 @@ export interface BoardTask {
   tags?: string[];
   startDate?: string;
   dueDate?: string;
+  metadata?: Record<string, unknown>;
 }
 
 interface BoardTaskCardProps {

--- a/app/[tenant]/(dashboard)/spaces/board/TaskDetailModal.tsx
+++ b/app/[tenant]/(dashboard)/spaces/board/TaskDetailModal.tsx
@@ -16,40 +16,19 @@ interface TaskDetailModalProps {
 }
 
 const PLACEHOLDER_HISTORY: TaskHistoryEntry[] = [
-  {
-    id: 'h1',
-    field: 'priority',
-    oldValue: 'Low',
-    newValue: 'High',
-    changedBy: 'Alex',
-    changedAt: new Date(Date.now() - 86400000).toISOString(),
-  },
-  {
-    id: 'h2',
-    field: 'assignee',
-    oldValue: '',
-    newValue: 'Alex',
-    changedBy: 'System',
-    changedAt: new Date(Date.now() - 172800000).toISOString(),
-  },
+  { id: 'h1', field: 'priority', oldValue: 'Low', newValue: 'High', changedBy: 'Alex', changedAt: new Date(Date.now() - 86400000).toISOString() },
+  { id: 'h2', field: 'assignee', oldValue: '', newValue: 'Alex', changedBy: 'System', changedAt: new Date(Date.now() - 172800000).toISOString() },
 ];
 
 const INITIAL_COMMENTS: TaskComment[] = [
-  {
-    id: 'c1',
-    author: 'Jordan',
-    content: 'Let me know if you need help breaking this down into subtasks.',
-    createdAt: new Date(Date.now() - 43200000).toISOString(),
-  },
+  { id: 'c1', author: 'Jordan', content: 'Let me know if you need help breaking this down into subtasks.', createdAt: new Date(Date.now() - 43200000).toISOString() },
 ];
 
-export function TaskDetailModal({
-  task,
-  columnTitle,
-  isOpen,
-  onClose,
-  onUpdate,
-}: TaskDetailModalProps) {
+/**
+ * Generic task detail modal (used by the old KanbanBoard for backward compat).
+ * Template-specific modals live in [slug]/templates/ instead.
+ */
+export function TaskDetailModal({ task, columnTitle, isOpen, onClose, onUpdate }: TaskDetailModalProps) {
   const [mounted, setMounted] = useState(false);
   const [editingTitle, setEditingTitle] = useState(false);
   const [editingDescription, setEditingDescription] = useState(false);
@@ -60,186 +39,68 @@ export function TaskDetailModal({
   const descRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => setMounted(true), []);
-
-  useEffect(() => {
-    setTitleDraft(task.title);
-    setDescDraft(task.description ?? '');
-  }, [task]);
-
-  useEffect(() => {
-    if (editingTitle) titleRef.current?.focus();
-  }, [editingTitle]);
-
-  useEffect(() => {
-    if (editingDescription) descRef.current?.focus();
-  }, [editingDescription]);
+  useEffect(() => { setTitleDraft(task.title); setDescDraft(task.description ?? ''); }, [task]);
+  useEffect(() => { if (editingTitle) titleRef.current?.focus(); }, [editingTitle]);
+  useEffect(() => { if (editingDescription) descRef.current?.focus(); }, [editingDescription]);
 
   if (!mounted || !isOpen) return null;
 
-  const saveTitle = () => {
-    setEditingTitle(false);
-    if (titleDraft.trim() && titleDraft !== task.title) {
-      onUpdate({ ...task, title: titleDraft.trim() });
-    } else {
-      setTitleDraft(task.title);
-    }
-  };
-
-  const saveDescription = () => {
-    setEditingDescription(false);
-    if (descDraft !== (task.description ?? '')) {
-      onUpdate({ ...task, description: descDraft });
-    }
-  };
-
-  const handleAddComment = (content: string) => {
-    setComments((prev) => [
-      {
-        id: `c-${Date.now()}`,
-        author: 'You',
-        content,
-        createdAt: new Date().toISOString(),
-      },
-      ...prev,
-    ]);
-  };
+  const saveTitle = () => { setEditingTitle(false); if (titleDraft.trim() && titleDraft !== task.title) onUpdate({ ...task, title: titleDraft.trim() }); else setTitleDraft(task.title); };
+  const saveDescription = () => { setEditingDescription(false); if (descDraft !== (task.description ?? '')) onUpdate({ ...task, description: descDraft }); };
 
   return createPortal(
-    <div
-      className="fixed inset-0 z-9999 flex items-start justify-center bg-black/50 backdrop-blur-sm overflow-y-auto py-8 px-3"
-      onClick={onClose}
-    >
-      <div
-        className="relative w-full max-w-5xl bg-white dark:bg-gray-950 rounded-2xl shadow-2xl border border-gray-200 dark:border-brand-mid-pink/20 overflow-hidden"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* ── Full-width header ──────────────────────────────── */}
+    <div className="fixed inset-0 z-9999 flex items-start justify-center bg-black/50 backdrop-blur-sm overflow-y-auto py-8 px-3" onClick={onClose}>
+      <div className="relative w-full max-w-5xl bg-white dark:bg-gray-950 rounded-2xl shadow-2xl border border-gray-200 dark:border-brand-mid-pink/20 overflow-hidden" onClick={(e) => e.stopPropagation()}>
+
         <div className="px-6 sm:px-8 pt-6 pb-4 flex items-start justify-between gap-4">
           <div className="flex-1 min-w-0">
-            {/* Task key */}
-            <span className="inline-flex items-center rounded-md bg-brand-blue/10 text-brand-blue px-2 py-0.5 text-[11px] font-bold tracking-wide mb-2">
-              {task.taskKey}
-            </span>
-
-            {/* Editable title */}
+            <span className="inline-flex items-center rounded-md bg-brand-blue/10 text-brand-blue px-2 py-0.5 text-[11px] font-bold tracking-wide mb-2">{task.taskKey}</span>
             <div className="group/title">
               {editingTitle ? (
-                <input
-                  ref={titleRef}
-                  value={titleDraft}
-                  onChange={(e) => setTitleDraft(e.target.value)}
-                  onBlur={saveTitle}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') saveTitle();
-                    if (e.key === 'Escape') {
-                      setTitleDraft(task.title);
-                      setEditingTitle(false);
-                    }
-                  }}
-                  className="w-full text-xl sm:text-2xl font-bold text-gray-900 dark:text-brand-off-white bg-transparent border-b-2 border-brand-light-pink/60 focus-visible:outline-none pb-1"
-                />
+                <input ref={titleRef} value={titleDraft} onChange={(e) => setTitleDraft(e.target.value)} onBlur={saveTitle}
+                  onKeyDown={(e) => { if (e.key === 'Enter') saveTitle(); if (e.key === 'Escape') { setTitleDraft(task.title); setEditingTitle(false); } }}
+                  className="w-full text-xl sm:text-2xl font-bold text-gray-900 dark:text-brand-off-white bg-transparent border-b-2 border-brand-light-pink/60 focus-visible:outline-none pb-1" />
               ) : (
-                <button
-                  type="button"
-                  onClick={() => setEditingTitle(true)}
-                  className="flex items-center gap-2 w-full text-left"
-                >
-                  <h2 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-brand-off-white">
-                    {task.title}
-                  </h2>
+                <button type="button" onClick={() => setEditingTitle(true)} className="flex items-center gap-2 w-full text-left">
+                  <h2 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-brand-off-white">{task.title}</h2>
                   <Pencil className="h-4 w-4 text-gray-400 opacity-0 group-hover/title:opacity-100 transition-opacity shrink-0" />
                 </button>
               )}
             </div>
           </div>
-
-          {/* Close button */}
-          <button
-            type="button"
-            onClick={onClose}
-            className="shrink-0 inline-flex h-8 w-8 items-center justify-center rounded-full border border-gray-200 dark:border-brand-mid-pink/30 bg-white/80 dark:bg-gray-900/80 text-gray-500 hover:text-gray-900 dark:hover:text-brand-off-white hover:border-brand-light-pink/60 transition-colors"
-          >
+          <button type="button" onClick={onClose} className="shrink-0 inline-flex h-8 w-8 items-center justify-center rounded-full border border-gray-200 dark:border-brand-mid-pink/30 bg-white/80 dark:bg-gray-900/80 text-gray-500 hover:text-gray-900 dark:hover:text-brand-off-white hover:border-brand-light-pink/60 transition-colors">
             <X className="h-4 w-4" />
           </button>
         </div>
 
-        {/* ── Separator ─────────────────────────────────────── */}
         <div className="border-b border-gray-200 dark:border-brand-mid-pink/15" />
 
-        {/* ── Two-column body ────────────────────────────────── */}
         <div className="grid grid-cols-1 lg:grid-cols-[1fr_320px]">
-          {/* Left column */}
           <div className="px-6 sm:px-8 py-6 border-r-0 lg:border-r border-gray-200 dark:border-brand-mid-pink/15 min-h-[50vh]">
-            {/* Description */}
             <div className="mb-8">
-              <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2">
-                Description
-              </h3>
+              <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2">Description</h3>
               <div className="group/desc">
                 {editingDescription ? (
                   <div>
-                    <textarea
-                      ref={descRef}
-                      value={descDraft}
-                      onChange={(e) => setDescDraft(e.target.value)}
-                      rows={5}
-                      placeholder="Add a description..."
-                      className="w-full rounded-xl border border-brand-light-pink/40 bg-white/80 dark:bg-gray-900/80 px-3 py-2.5 text-sm text-gray-800 dark:text-brand-off-white placeholder:text-gray-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-light-pink/60 resize-none"
-                    />
+                    <textarea ref={descRef} value={descDraft} onChange={(e) => setDescDraft(e.target.value)} rows={5} placeholder="Add a description..."
+                      className="w-full rounded-xl border border-brand-light-pink/40 bg-white/80 dark:bg-gray-900/80 px-3 py-2.5 text-sm text-gray-800 dark:text-brand-off-white placeholder:text-gray-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-light-pink/60 resize-none" />
                     <div className="flex items-center gap-2 mt-2">
-                      <button
-                        type="button"
-                        onClick={saveDescription}
-                        className="px-3 py-1.5 rounded-lg bg-brand-light-pink text-white text-xs font-medium hover:bg-brand-mid-pink"
-                      >
-                        Save
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => {
-                          setDescDraft(task.description ?? '');
-                          setEditingDescription(false);
-                        }}
-                        className="px-3 py-1.5 rounded-lg text-gray-500 text-xs font-medium hover:bg-gray-100 dark:hover:bg-gray-800"
-                      >
-                        Cancel
-                      </button>
+                      <button type="button" onClick={saveDescription} className="px-3 py-1.5 rounded-lg bg-brand-light-pink text-white text-xs font-medium hover:bg-brand-mid-pink">Save</button>
+                      <button type="button" onClick={() => { setDescDraft(task.description ?? ''); setEditingDescription(false); }} className="px-3 py-1.5 rounded-lg text-gray-500 text-xs font-medium hover:bg-gray-100 dark:hover:bg-gray-800">Cancel</button>
                     </div>
                   </div>
                 ) : (
-                  <button
-                    type="button"
-                    onClick={() => setEditingDescription(true)}
-                    className="flex items-start gap-2 w-full text-left"
-                  >
-                    <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap flex-1">
-                      {task.description || (
-                        <span className="text-gray-400 italic">
-                          Click to add a description...
-                        </span>
-                      )}
-                    </p>
+                  <button type="button" onClick={() => setEditingDescription(true)} className="flex items-start gap-2 w-full text-left">
+                    <p className="text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap flex-1">{task.description || <span className="text-gray-400 italic">Click to add a description...</span>}</p>
                     <Pencil className="h-3.5 w-3.5 text-gray-400 opacity-0 group-hover/desc:opacity-100 transition-opacity shrink-0 mt-0.5" />
                   </button>
                 )}
               </div>
             </div>
-
-            {/* Activity */}
-            <ActivityFeed
-              comments={comments}
-              history={PLACEHOLDER_HISTORY}
-              onAddComment={handleAddComment}
-            />
+            <ActivityFeed comments={comments} history={PLACEHOLDER_HISTORY} onAddComment={(c) => setComments((p) => [{ id: `c-${Date.now()}`, author: 'You', content: c, createdAt: new Date().toISOString() }, ...p])} />
           </div>
-
-          {/* Right column (sidebar) */}
           <div className="px-6 py-6 bg-gray-50/70 dark:bg-gray-950/60">
-            <TaskSidebar
-              task={task}
-              columnTitle={columnTitle}
-              onUpdate={onUpdate}
-            />
+            <TaskSidebar task={task} columnTitle={columnTitle} onUpdate={onUpdate} />
           </div>
         </div>
       </div>

--- a/app/api/spaces/by-slug/[slug]/route.ts
+++ b/app/api/spaces/by-slug/[slug]/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+import { prisma } from '@/lib/database';
+
+type Params = { params: Promise<{ slug: string }> };
+
+export async function GET(_req: NextRequest, { params }: Params) {
+  try {
+    const { userId } = await auth();
+    if (!userId) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+    const { slug } = await params;
+
+    const user = await prisma.user.findUnique({
+      where: { clerkId: userId },
+      select: { currentOrganizationId: true },
+    });
+
+    if (!user?.currentOrganizationId) {
+      return NextResponse.json({ error: 'No organization' }, { status: 400 });
+    }
+
+    const workspace = await prisma.workspace.findFirst({
+      where: {
+        organizationId: user.currentOrganizationId,
+        slug,
+        isActive: true,
+      },
+      include: {
+        boards: {
+          orderBy: { position: 'asc' },
+          include: {
+            columns: { orderBy: { position: 'asc' } },
+          },
+        },
+      },
+    });
+
+    if (!workspace) {
+      return NextResponse.json({ error: 'Space not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({
+      id: workspace.id,
+      name: workspace.name,
+      slug: workspace.slug,
+      description: workspace.description,
+      templateType: workspace.templateType,
+      key: workspace.key,
+      access: workspace.access,
+      config: workspace.config,
+      createdAt: workspace.createdAt.toISOString(),
+      boards: workspace.boards.map((b) => ({
+        id: b.id,
+        name: b.name,
+        description: b.description,
+        position: b.position,
+        columns: b.columns.map((c) => ({
+          id: c.id,
+          name: c.name,
+          color: c.color,
+          position: c.position,
+        })),
+      })),
+    });
+  } catch (error) {
+    console.error('Error fetching space by slug:', error);
+    return NextResponse.json({ error: 'Failed to fetch space' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
- Implemented SextingSetsTemplate and WallPostTemplate for managing tasks.
- Created corresponding task detail modals: SextingSetsTaskDetailModal and WallPostTaskDetailModal.
- Integrated drag-and-drop functionality using @hello-pangea/dnd.
- Enhanced useSpaceBoard hook to support new templates and task transformations.
- Updated API route to fetch workspace details including boards and columns.
- Added shared types and props for template components.