### PR TITLE
feat(submissions): expand OTP/PTR fields and fix submission form bugs

### DIFF
--- a/components/content-submission/ClassicSubmissionForm.tsx
+++ b/components/content-submission/ClassicSubmissionForm.tsx
@@ -85,21 +85,21 @@ export const ClassicSubmissionForm = memo(function ClassicSubmissionForm({
           id: submissionId,
           ...data,
         });
+        if (onSuccess) onSuccess(submissionId);
       } else {
-        await createSubmission.mutateAsync(data);
+        const result = await createSubmission.mutateAsync(data);
+        setShowSuccess(true);
+        setTimeout(() => {
+          if (onSuccess) {
+            onSuccess(result.id ?? '');
+          } else {
+            setShowSuccess(false);
+            reset();
+          }
+        }, 2000);
       }
-
-      // Show success message
-      setShowSuccess(true);
-
-      // Reset form after delay
-      setTimeout(() => {
-        setShowSuccess(false);
-        reset();
-      }, 3000);
     } catch (error) {
       console.error('Submission failed:', error);
-      alert('Failed to save submission');
     }
   };
 
@@ -120,12 +120,9 @@ export const ClassicSubmissionForm = memo(function ClassicSubmissionForm({
               </div>
               <h2 className="text-3xl font-bold text-white mb-2">Submission Created!</h2>
               <p className="text-zinc-400">
-                Your content submission has been logged to the console. Check DevTools to see the data.
+                Your content has been successfully submitted and added to the board.
               </p>
             </div>
-            <p className="text-sm text-zinc-500">
-              This is design-only mode. No data was saved to a backend.
-            </p>
           </div>
         </div>
       )}

--- a/components/content-submission/SubmissionForm.tsx
+++ b/components/content-submission/SubmissionForm.tsx
@@ -524,6 +524,7 @@ const LocalFilePicker = memo(function LocalFilePicker({
   maxFileSizeMB?: number;
 }) {
   const [dragActive, setDragActive] = useState(false);
+  const [sizeError, setSizeError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const addFiles = useCallback(
@@ -531,7 +532,8 @@ const LocalFilePicker = memo(function LocalFilePicker({
       const maxBytes = maxFileSizeMB * 1024 * 1024;
       const valid = incoming.filter((f) => f.size <= maxBytes);
       if (valid.length < incoming.length) {
-        alert(`Some files exceed the ${maxFileSizeMB} MB limit and were skipped.`);
+        setSizeError(`${incoming.length - valid.length} file(s) exceeded the ${maxFileSizeMB} MB limit and were skipped.`);
+        setTimeout(() => setSizeError(null), 4000);
       }
       onChange([...files, ...valid].slice(0, maxFiles));
     },
@@ -601,6 +603,14 @@ const LocalFilePicker = memo(function LocalFilePicker({
           </p>
         </div>
       </div>
+
+      {/* Size error */}
+      {sizeError && (
+        <div className="flex items-center gap-2 px-4 py-3 bg-amber-500/10 border border-amber-500/30 rounded-xl text-sm text-amber-300">
+          <AlertTriangle className="w-4 h-4 shrink-0" />
+          {sizeError}
+        </div>
+      )}
 
       {/* Queued file list */}
       {files.length > 0 && (

--- a/lib/spaces/template-metadata.ts
+++ b/lib/spaces/template-metadata.ts
@@ -143,9 +143,17 @@ export const SEXTING_SETS_METADATA_FIELDS: MetadataFieldDescriptor[] = [
 export interface OtpPtrItemMetadata {
   requestType: 'OTP' | 'PTR' | 'CUSTOM';
   price: number;
-  buyer: string;
   model: string;
+  pricingTier: string;
+  pageType: string;
+  driveLink: string;
+  contentType: string;
+  contentLength: string;
+  contentCount: string;
   deliverables: string[];
+  externalCreatorTags: string[];
+  internalModelTags: string[];
+  contentTags: string[];
   deadline: string;
   isPaid: boolean;
   fulfillmentNotes: string;
@@ -154,9 +162,17 @@ export interface OtpPtrItemMetadata {
 export const OTP_PTR_METADATA_DEFAULTS: OtpPtrItemMetadata = {
   requestType: 'OTP',
   price: 0,
-  buyer: '',
   model: '',
+  pricingTier: '',
+  pageType: '',
+  driveLink: '',
+  contentType: '',
+  contentLength: '',
+  contentCount: '',
   deliverables: [],
+  externalCreatorTags: [],
+  internalModelTags: [],
+  contentTags: [],
   deadline: '',
   isPaid: false,
   fulfillmentNotes: '',
@@ -171,9 +187,32 @@ export const OTP_PTR_METADATA_FIELDS: MetadataFieldDescriptor[] = [
     options: ['OTP', 'PTR', 'CUSTOM'],
   },
   { key: 'price', label: 'Price ($)', type: 'number', required: true, placeholder: '0.00' },
-  { key: 'buyer', label: 'Buyer', type: 'text', required: true, placeholder: '@username' },
   { key: 'model', label: 'Model', type: 'text', placeholder: 'Model name' },
+  {
+    key: 'pricingTier',
+    label: 'Pricing Tier',
+    type: 'select',
+    options: ['Porn Accurate', 'Porn Scam', 'GF Accurate', 'GF Scam'],
+  },
+  {
+    key: 'pageType',
+    label: 'Page Type',
+    type: 'select',
+    options: ['All Pages', 'Free', 'Paid', 'VIP'],
+  },
+  { key: 'driveLink', label: 'Drive Link', type: 'text', placeholder: 'https://drive.google.com/...' },
+  {
+    key: 'contentType',
+    label: 'Content Type',
+    type: 'select',
+    options: ['Photo', 'Video', 'Photo Set', 'Video Set', 'Mixed (Photos + Videos)', 'GIF', 'Livestream', 'Audio', 'Text Only'],
+  },
+  { key: 'contentLength', label: 'Content Length', type: 'text', placeholder: 'e.g. 8:43 or 8 mins 43 secs' },
+  { key: 'contentCount', label: 'Content Count', type: 'text', placeholder: 'e.g. 1 Video, 3 Photos' },
   { key: 'deliverables', label: 'Deliverables', type: 'tags', placeholder: 'e.g. 3 photos, 1 video' },
+  { key: 'externalCreatorTags', label: 'Tags — External Creators', type: 'tags', placeholder: '@johndoe @janedoe' },
+  { key: 'internalModelTags', label: 'Tags — Internal Models', type: 'tags', placeholder: '@modelname' },
+  { key: 'contentTags', label: 'Content Tags', type: 'tags', placeholder: 'e.g. exclusive, solo, custom' },
   { key: 'deadline', label: 'Deadline', type: 'date' },
   { key: 'isPaid', label: 'Paid', type: 'boolean' },
   { key: 'fulfillmentNotes', label: 'Fulfillment Notes', type: 'textarea', placeholder: 'Delivery instructions...' },


### PR DESCRIPTION
- Add missing OTP/PTR metadata fields: Pricing Tier, Page Type, Drive Link, Content Type, Content Length, Content Count, External Creator Tags, Internal Model Tags, Content Tags
- Correct dropdown options to match source-of-truth system (pricing tiers, page types, content types)
- Remove Buyer field from OTP/PTR metadata
- Fix ClassicSubmissionForm: call onSuccess after submit so user is redirected; remove stale dev-only success message
- Replace alert() in file picker with inline amber warning banner