### PR TITLE
feat(submissions): link content submissions to spaces with workspace …

### DIFF
--- a/app/api/content-submissions/route.ts
+++ b/app/api/content-submissions/route.ts
@@ -48,6 +48,7 @@ export async function POST(req: NextRequest) {
         id: submissionId,
         organizationId: user.currentOrganizationId,
         clerkId: userId,
+        workspaceId: data.workspaceId ?? null,
         submissionType: data.submissionType,
         contentStyle: data.submissionType,
         status: data.metadata?.submitStatus === 'SUBMITTED' ? 'SUBMITTED' : 'DRAFT',

--- a/components/content-submission/ContentDetailsFields.tsx
+++ b/components/content-submission/ContentDetailsFields.tsx
@@ -87,12 +87,14 @@ interface ContentDetailsFieldsProps {
   setValue: UseFormSetValue<CreateSubmissionWithComponents>;
   watch: UseFormWatch<CreateSubmissionWithComponents>;
   errors: FieldErrors<CreateSubmissionWithComponents>;
+  readOnlyType?: SubmissionTemplateType;
 }
 
 export function ContentDetailsFields({
   setValue,
   watch,
   errors,
+  readOnlyType,
 }: ContentDetailsFieldsProps) {
   const submissionType = (watch('submissionType') ?? 'OTP_PTR') as SubmissionTemplateType;
   const metadata = watch('metadata') || {};
@@ -123,48 +125,68 @@ export function ContentDetailsFields({
         <label className="block text-sm font-medium text-zinc-300 mb-3">
           Submission Type <span className="text-brand-light-pink">*</span>
         </label>
-        <div className="grid grid-cols-3 gap-3">
-          {TEMPLATE_OPTIONS.map(({ value, label, description, icon: Icon }) => {
-            const isSelected = submissionType === value;
+        {readOnlyType ? (
+          /* Read-only display when type is auto-determined from space */
+          (() => {
+            const opt = TEMPLATE_OPTIONS.find((t) => t.value === readOnlyType);
+            if (!opt) return null;
+            const Icon = opt.icon;
             return (
-              <button
-                key={value}
-                type="button"
-                onClick={() => handleTemplateChange(value)}
-                className={`relative flex flex-col items-start gap-3 p-5 rounded-xl border transition-all duration-200 text-left ${
-                  isSelected
-                    ? 'bg-gradient-to-br from-brand-light-pink/15 via-brand-mid-pink/5 to-transparent border-brand-light-pink shadow-lg shadow-brand-light-pink/10'
-                    : 'border-zinc-700/50 bg-zinc-800/30 hover:bg-zinc-800/60 hover:border-zinc-600'
-                }`}
-              >
-                <div
-                  className={`w-10 h-10 flex items-center justify-center rounded-lg ${
-                    isSelected
-                      ? 'bg-gradient-to-br from-brand-light-pink/30 to-brand-dark-pink/20'
-                      : 'bg-zinc-700/40'
-                  }`}
-                >
-                  <Icon
-                    className={`w-5 h-5 ${isSelected ? 'text-brand-light-pink' : 'text-zinc-400'}`}
-                  />
+              <div className="flex items-center gap-3 px-4 py-3 bg-zinc-800/40 border border-zinc-700/40 rounded-xl">
+                <div className="w-8 h-8 flex items-center justify-center rounded-lg bg-brand-light-pink/20">
+                  <Icon className="w-4 h-4 text-brand-light-pink" />
                 </div>
                 <div>
-                  <p
-                    className={`text-sm font-semibold ${isSelected ? 'text-white' : 'text-zinc-300'}`}
-                  >
-                    {label}
-                  </p>
-                  <p className="text-xs text-zinc-500 mt-1 leading-relaxed">{description}</p>
+                  <p className="text-sm font-semibold text-white">{opt.label}</p>
+                  <p className="text-xs text-zinc-500">Auto-determined from selected space</p>
                 </div>
-                {isSelected && (
-                  <div className="absolute top-2.5 right-2.5 w-5 h-5 rounded-full bg-brand-light-pink flex items-center justify-center">
-                    <Check className="w-3 h-3 text-white" strokeWidth={3} />
-                  </div>
-                )}
-              </button>
+              </div>
             );
-          })}
-        </div>
+          })()
+        ) : (
+          <div className="grid grid-cols-3 gap-3">
+            {TEMPLATE_OPTIONS.map(({ value, label, description, icon: Icon }) => {
+              const isSelected = submissionType === value;
+              return (
+                <button
+                  key={value}
+                  type="button"
+                  onClick={() => handleTemplateChange(value)}
+                  className={`relative flex flex-col items-start gap-3 p-5 rounded-xl border transition-all duration-200 text-left ${
+                    isSelected
+                      ? 'bg-gradient-to-br from-brand-light-pink/15 via-brand-mid-pink/5 to-transparent border-brand-light-pink shadow-lg shadow-brand-light-pink/10'
+                      : 'border-zinc-700/50 bg-zinc-800/30 hover:bg-zinc-800/60 hover:border-zinc-600'
+                  }`}
+                >
+                  <div
+                    className={`w-10 h-10 flex items-center justify-center rounded-lg ${
+                      isSelected
+                        ? 'bg-gradient-to-br from-brand-light-pink/30 to-brand-dark-pink/20'
+                        : 'bg-zinc-700/40'
+                    }`}
+                  >
+                    <Icon
+                      className={`w-5 h-5 ${isSelected ? 'text-brand-light-pink' : 'text-zinc-400'}`}
+                    />
+                  </div>
+                  <div>
+                    <p
+                      className={`text-sm font-semibold ${isSelected ? 'text-white' : 'text-zinc-300'}`}
+                    >
+                      {label}
+                    </p>
+                    <p className="text-xs text-zinc-500 mt-1 leading-relaxed">{description}</p>
+                  </div>
+                  {isSelected && (
+                    <div className="absolute top-2.5 right-2.5 w-5 h-5 rounded-full bg-brand-light-pink flex items-center justify-center">
+                      <Check className="w-3 h-3 text-white" strokeWidth={3} />
+                    </div>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        )}
         {errors.submissionType && (
           <p className="text-sm text-red-400 mt-1">{errors.submissionType.message}</p>
         )}

--- a/components/content-submission/SpacePicker.tsx
+++ b/components/content-submission/SpacePicker.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { memo } from 'react';
+import { useSpaces, type Space } from '@/lib/hooks/useSpaces.query';
+import {
+  Check,
+  Loader2,
+  AlertTriangle,
+  DollarSign,
+  Image,
+  MessageSquare,
+  LayoutGrid,
+} from 'lucide-react';
+
+const TEMPLATE_INFO: Record<
+  string,
+  { label: string; description: string; icon: React.ElementType }
+> = {
+  OTP_PTR: {
+    label: 'OTP / PTR',
+    description: 'Custom paid requests',
+    icon: DollarSign,
+  },
+  WALL_POST: {
+    label: 'Wall Post',
+    description: 'Post photos & captions',
+    icon: Image,
+  },
+  SEXTING_SETS: {
+    label: 'Sexting Sets',
+    description: 'Adult content sets',
+    icon: MessageSquare,
+  },
+  KANBAN: {
+    label: 'General',
+    description: 'Kanban board',
+    icon: LayoutGrid,
+  },
+};
+
+interface SpacePickerProps {
+  selectedSpaceId: string | undefined;
+  onSelect: (space: Space) => void;
+}
+
+export const SpacePicker = memo(function SpacePicker({
+  selectedSpaceId,
+  onSelect,
+}: SpacePickerProps) {
+  const { data, isLoading } = useSpaces();
+
+  const submissionSpaces = data?.spaces ?? [];
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="w-6 h-6 animate-spin text-zinc-400" />
+      </div>
+    );
+  }
+
+  if (submissionSpaces.length === 0) {
+    return (
+      <div className="bg-amber-500/10 border border-amber-500/30 rounded-xl p-6 flex items-start gap-3">
+        <AlertTriangle className="w-5 h-5 text-amber-400 mt-0.5 shrink-0" />
+        <div>
+          <p className="text-amber-200 font-medium mb-1">No spaces found</p>
+          <p className="text-sm text-amber-200/70">
+            Create a space first in the Spaces section before submitting
+            content.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+      {submissionSpaces.map((space) => {
+        const isSelected = selectedSpaceId === space.id;
+        const info = TEMPLATE_INFO[space.templateType] ?? {
+          label: space.templateType,
+          description: '',
+          icon: LayoutGrid,
+        };
+        const Icon = info.icon;
+
+        return (
+          <button
+            key={space.id}
+            type="button"
+            onClick={() => onSelect(space)}
+            className={`relative flex flex-col items-start gap-3 p-5 rounded-xl border transition-all duration-200 text-left ${
+              isSelected
+                ? 'bg-gradient-to-br from-brand-light-pink/15 via-brand-mid-pink/5 to-transparent border-brand-light-pink shadow-lg shadow-brand-light-pink/10'
+                : 'border-zinc-700/50 bg-zinc-800/30 hover:bg-zinc-800/60 hover:border-zinc-600'
+            }`}
+          >
+            {/* Icon */}
+            <div
+              className={`w-10 h-10 flex items-center justify-center rounded-lg ${
+                isSelected
+                  ? 'bg-gradient-to-br from-brand-light-pink/30 to-brand-dark-pink/20'
+                  : 'bg-zinc-700/40'
+              }`}
+            >
+              <Icon
+                className={`w-5 h-5 ${isSelected ? 'text-brand-light-pink' : 'text-zinc-400'}`}
+              />
+            </div>
+            {/* Space name + template info */}
+            <div>
+              <p
+                className={`text-sm font-semibold ${isSelected ? 'text-white' : 'text-zinc-300'}`}
+              >
+                {space.name}
+              </p>
+              <p className="text-xs text-zinc-500 mt-1">
+                {info.label}
+              </p>
+            </div>
+            {/* Check mark */}
+            {isSelected && (
+              <div className="absolute top-2.5 right-2.5 w-5 h-5 rounded-full bg-brand-light-pink flex items-center justify-center">
+                <Check className="w-3 h-3 text-white" strokeWidth={3} />
+              </div>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+});

--- a/lib/content-submission/step-generator.ts
+++ b/lib/content-submission/step-generator.ts
@@ -6,11 +6,12 @@ export interface WizardStep {
 }
 
 /**
- * Fixed 3-step wizard for content submissions.
- * Template type is selected inside the Content Details step.
+ * Fixed 4-step wizard for content submissions.
+ * Space is selected first, which determines the submission type.
  */
 export function generateSteps(): WizardStep[] {
   return [
+    { id: 'space', title: 'Select Space' },
     { id: 'details', title: 'Content Details' },
     { id: 'files', title: 'File Uploads' },
     { id: 'review', title: 'Review & Submit' },
@@ -22,6 +23,7 @@ export function generateSteps(): WizardStep[] {
  */
 export function stepHasErrors(stepId: string, errors: FieldErrors): boolean {
   const fieldMap: Record<string, string[]> = {
+    space: ['workspaceId'],
     details: [
       'submissionType',
       'modelName',

--- a/lib/validations/content-submission.ts
+++ b/lib/validations/content-submission.ts
@@ -26,6 +26,9 @@ export const pricingCategorySchema = z.enum([
 
 // Base submission input
 export const createSubmissionInputSchema = z.object({
+  // Space link (optional for backward compat — required in wizard flow)
+  workspaceId: z.string().optional(),
+
   // Required fields
   submissionType: submissionTypeSchema,
 

--- a/prisma/migrations/20260225000000_add_workspace_to_submissions/migration.sql
+++ b/prisma/migrations/20260225000000_add_workspace_to_submissions/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "content_submissions" ADD COLUMN "workspaceId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "content_submissions_workspaceId_idx" ON "content_submissions"("workspaceId");
+
+-- AddForeignKey
+ALTER TABLE "content_submissions" ADD CONSTRAINT "content_submissions_workspaceId_fkey" FOREIGN KEY ("workspaceId") REFERENCES "workspaces"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1376,9 +1376,10 @@ model Workspace {
   config         Json?
   key            String?
   templateType   SpaceTemplateType @default(KANBAN)
-  boards         Board[]
-  members        WorkspaceMember[]
-  organization   Organization      @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  boards              Board[]
+  members             WorkspaceMember[]
+  contentSubmissions  content_submissions[]
+  organization        Organization      @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
   @@unique([organizationId, slug])
   @@unique([organizationId, key])
@@ -2005,12 +2006,14 @@ model content_submissions {
   updatedAt                            DateTime
   pricingCategory                      String?                               @default("PORN_ACCURATE")
   contentTypeOptionId                  String?
+  workspaceId                          String?
   content_submission_files             content_submission_files[]
   content_submission_pricing           content_submission_pricing?
   content_submission_release_schedules content_submission_release_schedules?
   users                                User                                  @relation(fields: [clerkId], references: [clerkId], onDelete: Cascade)
   contentTypeOption                    ContentTypeOption?                    @relation("SubmissionContentType", fields: [contentTypeOptionId], references: [id])
   organizations                        Organization                          @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  workspace                            Workspace?                            @relation(fields: [workspaceId], references: [id], onDelete: SetNull)
 
   @@index([clerkId])
   @@index([contentStyle])
@@ -2021,6 +2024,7 @@ model content_submissions {
   @@index([pricingCategory])
   @@index([status])
   @@index([submissionType])
+  @@index([workspaceId])
 }
 
 model ContentTypeOption {


### PR DESCRIPTION
…selection

Add a Space picker as the first step in the submission wizard, allowing users to choose which workspace their submission belongs to. The selected space auto-determines the submission type and creates both a board item and a content_submission record linked via workspaceId. Includes database migration, schema updates, and support in both wizard and classic forms.