### PR TITLE
feat: add team-specific fields and assignee name resolution to OTP/PT…

### DIFF
--- a/app/[tenant]/(dashboard)/spaces/[slug]/SpaceBoardView.tsx
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/SpaceBoardView.tsx
@@ -5,6 +5,7 @@ import { useRouter, useParams } from 'next/navigation';
 import { DragDropContext } from '@hello-pangea/dnd';
 import { useSpaceBySlug, useUpdateSpace } from '@/lib/hooks/useSpaces.query';
 import { useSpaceMembers } from '@/lib/hooks/useSpaceMembers.query';
+import { useOrgMembers } from '@/lib/hooks/useOrgMembers.query';
 import { useOrganization } from '@/lib/hooks/useOrganization.query';
 import { useUser } from '@clerk/nextjs';
 import { Loader2 } from 'lucide-react';
@@ -79,6 +80,7 @@ function TemplateBoardView({ slug }: { slug: string }) {
   const { user } = useUser();
   const { data: space } = useSpaceBySlug(slug);
   const { data: members = [] } = useSpaceMembers(space?.id);
+  const { data: orgMembers = [] } = useOrgMembers();
   const { currentOrganization } = useOrganization();
   const updateSpaceMutation = useUpdateSpace(space?.id ?? '');
   const config = TEMPLATE_CONFIG[space!.templateType];
@@ -89,6 +91,13 @@ function TemplateBoardView({ slug }: { slug: string }) {
   const currentMember = members.find((m) => m.user.clerkId === user?.id);
   const userRole = currentMember?.role;
   const organizationRole = currentOrganization?.role;
+
+  const resolveMemberName = (id?: string) => {
+    if (!id) return undefined;
+    const m = orgMembers.find((mb) => mb.clerkId === id || mb.id === id);
+    if (!m) return id;
+    return m.name || `${m.firstName ?? ''} ${m.lastName ?? ''}`.trim() || m.email;
+  };
 
   // Handler for updating space name
   const handleSpaceNameUpdate = async (newName: string) => {
@@ -114,11 +123,11 @@ function TemplateBoardView({ slug }: { slug: string }) {
     closeTaskModal,
   } = useSpaceBoard({ space, itemToTask: config.itemToTask });
 
-  // Extract unique assignees from all tasks
+  // Extract unique assignees from all tasks (resolve IDs to display names)
   const uniqueAssignees = Array.from(
     new Set(
       Object.values(effectiveTasks)
-        .map((t) => t.assignee)
+        .map((t) => resolveMemberName(t.assignee))
         .filter(Boolean) as string[],
     ),
   ).sort();
@@ -194,8 +203,8 @@ function TemplateBoardView({ slug }: { slug: string }) {
                           return false;
                         }
 
-                        // Assignee filter
-                        if (filters.assigneeFilter && t.assignee !== filters.assigneeFilter) {
+                        // Assignee filter (compare resolved name)
+                        if (filters.assigneeFilter && resolveMemberName(t.assignee) !== filters.assigneeFilter) {
                           return false;
                         }
 

--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/OtpPtrTaskCard.tsx
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/OtpPtrTaskCard.tsx
@@ -18,6 +18,7 @@ import {
   CheckCircle2,
   CircleX,
 } from 'lucide-react';
+import { useOrgMembers } from '@/lib/hooks/useOrgMembers.query';
 import type { BoardTask } from '../../board';
 
 interface OtpPtrTaskCardProps {
@@ -105,6 +106,7 @@ export function OtpPtrTaskCard({ task, index, onClick, onTitleUpdate }: OtpPtrTa
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(task.title);
   const inputRef = useRef<HTMLInputElement>(null);
+  const { data: orgMembers = [] } = useOrgMembers();
 
   const meta = (task.metadata ?? {}) as Record<string, unknown>;
 
@@ -133,7 +135,12 @@ export function OtpPtrTaskCard({ task, index, onClick, onTitleUpdate }: OtpPtrTa
   const price = meta.price as number | undefined;
   const isPaid = meta.isPaid as boolean | undefined;
   const createdAt = typeof meta._createdAt === 'string' ? meta._createdAt : '';
-  const model = (meta.model as string) || task.assignee;
+  const assigneeName = (() => {
+    if (!task.assignee) return undefined;
+    const m = orgMembers.find((mb) => mb.clerkId === task.assignee || mb.id === task.assignee);
+    if (!m) return task.assignee;
+    return m.name || `${m.firstName ?? ''} ${m.lastName ?? ''}`.trim() || m.email;
+  })();
 
   return (
     <Draggable draggableId={task.id} index={index}>
@@ -289,7 +296,7 @@ export function OtpPtrTaskCard({ task, index, onClick, onTitleUpdate }: OtpPtrTa
 
                 <span className="inline-flex items-center gap-0.5 text-gray-400 dark:text-gray-500 truncate max-w-[100px]">
                   <User className="h-3 w-3 shrink-0" />
-                  {model || 'Unassigned'}
+                  {assigneeName || 'Unassigned'}
                 </span>
               </div>
             </div>

--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/OtpPtrTaskDetailModal.tsx
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/OtpPtrTaskDetailModal.tsx
@@ -34,7 +34,9 @@ import {
 import type { BoardTask } from '../../board/BoardTaskCard';
 import { EditableField } from '../../board/EditableField';
 import { SelectField } from '../../board/SelectField';
+import { SearchableDropdown } from '@/components/ui/SearchableDropdown';
 import { useSpaceBySlug } from '@/lib/hooks/useSpaces.query';
+import { useOrgMembers } from '@/lib/hooks/useOrgMembers.query';
 import {
   useBoardItemComments,
   useAddComment,
@@ -132,6 +134,7 @@ function GlowCard({
   defaultOpen = true,
   badge,
   iconColorClass,
+  className,
 }: {
   icon: LucideIcon;
   title: string;
@@ -139,12 +142,13 @@ function GlowCard({
   defaultOpen?: boolean;
   badge?: React.ReactNode;
   iconColorClass?: string;
+  className?: string;
 }) {
   const [open, setOpen] = useState(defaultOpen);
   const iconClasses = iconColorClass ?? 'bg-brand-light-pink/10 text-brand-light-pink';
 
   return (
-    <div className="relative mb-4 rounded-xl overflow-hidden group/glow">
+    <div className={`relative mb-4 rounded-xl group/glow ${open ? 'overflow-visible' : 'overflow-hidden'} ${className ?? ''}`}>
       {/* Gradient left border */}
       <div
         className="absolute inset-y-0 left-0 w-[3px] transition-opacity"
@@ -190,7 +194,7 @@ function GlowCard({
             gridTemplateRows: open ? '1fr' : '0fr',
           }}
         >
-          <div className="overflow-hidden">
+          <div className={open ? 'overflow-visible' : 'overflow-hidden'}>
             <div className="px-5 pb-4 pt-0">
               <div
                 className="pt-3.5"
@@ -318,18 +322,28 @@ export function OtpPtrTaskDetailModal({
 }: Props) {
   const params = useParams<{ slug: string }>();
   const { data: space } = useSpaceBySlug(params.slug);
+  const { data: orgMembers = [] } = useOrgMembers();
   const { user } = useUser();
   const spaceId = space?.id;
   const boardId = space?.boards?.[0]?.id;
+
+  const getMemberName = (id?: string) => {
+    if (!id) return undefined;
+    const m = orgMembers.find((mb) => mb.clerkId === id || mb.id === id);
+    if (!m) return undefined;
+    return m.name || `${m.firstName ?? ''} ${m.lastName ?? ''}`.trim() || m.email;
+  };
 
   const [activeTab, setActiveTab] = useState<ModalTab>('details');
   const [mounted, setMounted] = useState(false);
   const [editingTitle, setEditingTitle] = useState(false);
   const [editingNotes, setEditingNotes] = useState(false);
+  const [editingCaption, setEditingCaption] = useState(false);
   const [titleDraft, setTitleDraft] = useState(task.title);
   const [newComment, setNewComment] = useState('');
   const titleRef = useRef<HTMLInputElement>(null);
   const notesRef = useRef<HTMLTextAreaElement>(null);
+  const captionRef = useRef<HTMLTextAreaElement>(null);
 
   /* ── Metadata ────────────────────────────────────────── */
 
@@ -361,10 +375,14 @@ export function OtpPtrTaskDetailModal({
   const contentTags = Array.isArray(meta.contentTags)
     ? (meta.contentTags as string[])
     : [];
+  const caption = (meta.caption as string) ?? '';
+  const gameType = (meta.gameType as string) ?? '';
+  const gifUrl = (meta.gifUrl as string) ?? '';
 
   const tier = pricingCategory || pricingTier;
 
   const [notesDraft, setNotesDraft] = useState(fulfillmentNotes);
+  const [captionDraft, setCaptionDraft] = useState(caption);
   const [tagInputs, setTagInputs] = useState<Record<string, string>>({});
 
   /* ── API hooks ───────────────────────────────────────── */
@@ -416,13 +434,17 @@ export function OtpPtrTaskDetailModal({
   useEffect(() => {
     setTitleDraft(task.title);
     setNotesDraft(fulfillmentNotes);
-  }, [task, fulfillmentNotes]);
+    setCaptionDraft(caption);
+  }, [task, fulfillmentNotes, caption]);
   useEffect(() => {
     if (editingTitle) titleRef.current?.focus();
   }, [editingTitle]);
   useEffect(() => {
     if (editingNotes) notesRef.current?.focus();
   }, [editingNotes]);
+  useEffect(() => {
+    if (editingCaption) captionRef.current?.focus();
+  }, [editingCaption]);
 
   if (!mounted || !isOpen) return null;
 
@@ -442,6 +464,12 @@ export function OtpPtrTaskDetailModal({
     setEditingNotes(false);
     if (notesDraft !== fulfillmentNotes)
       updateMeta({ fulfillmentNotes: notesDraft });
+  };
+
+  const saveCaption = () => {
+    setEditingCaption(false);
+    if (captionDraft !== caption)
+      updateMeta({ caption: captionDraft });
   };
 
   const getTagInput = (key: string) => tagInputs[key] ?? '';
@@ -496,7 +524,7 @@ export function OtpPtrTaskDetailModal({
       }}
     >
       <div
-        className="relative w-full max-w-[1120px] rounded-2xl overflow-hidden shadow-2xl"
+        className="relative w-full max-w-[1120px] rounded-2xl shadow-2xl"
         onClick={(e) => e.stopPropagation()}
         style={{
           background:
@@ -685,7 +713,7 @@ export function OtpPtrTaskDetailModal({
             {activeTab === 'details' && (
               <>
                 {/* Basic Information */}
-                <GlowCard icon={Info} title="Basic Information" iconColorClass="bg-brand-blue/10 text-brand-blue">
+                <GlowCard icon={Info} title="Basic Information" iconColorClass="bg-brand-blue/10 text-brand-blue" className="z-10">
                   <div className="grid grid-cols-2 gap-x-6 gap-y-3">
                     <div>
                       <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-gray-500 block mb-1.5">
@@ -711,17 +739,127 @@ export function OtpPtrTaskDetailModal({
                       <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-gray-500 block mb-1.5">
                         Assignee
                       </span>
-                      <EditableField
-                        value={model}
+                      <SearchableDropdown
+                        value={getMemberName(task.assignee) ?? ''}
                         placeholder="Unassigned"
-                        onSave={(v) => updateMeta({ model: v })}
+                        searchPlaceholder="Search members..."
+                        options={orgMembers.map((m) => getMemberName(m.clerkId) ?? m.email)}
+                        onChange={(v) => {
+                          if (!v) {
+                            onUpdate({ ...task, assignee: undefined });
+                          } else {
+                            const member = orgMembers.find((m) => (getMemberName(m.clerkId) ?? m.email) === v);
+                            if (member) onUpdate({ ...task, assignee: member.clerkId });
+                          }
+                        }}
+                        clearable
                       />
                     </div>
                   </div>
                 </GlowCard>
 
+                {/* PGT Team */}
+                <GlowCard icon={FileText} title="PGT Team" iconColorClass="bg-amber-400/10 text-amber-400">
+                  <div>
+                    <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-gray-500 block mb-1.5">
+                      Caption
+                    </span>
+                    <div className="group/caption">
+                      {editingCaption ? (
+                        <div>
+                          <textarea
+                            ref={captionRef}
+                            value={captionDraft}
+                            onChange={(e) => setCaptionDraft(e.target.value)}
+                            rows={4}
+                            placeholder="PGT caption text..."
+                            className="w-full rounded-lg border border-brand-light-pink/25 bg-white/[0.03] px-3.5 py-2.5 text-sm text-brand-off-white placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-light-pink/30 resize-none transition-shadow"
+                          />
+                          <div className="flex items-center gap-2 mt-2.5">
+                            <button
+                              type="button"
+                              onClick={saveCaption}
+                              className="px-4 py-1.5 rounded-lg text-xs font-semibold text-white transition-all hover:brightness-110"
+                              style={{
+                                background:
+                                  'linear-gradient(135deg, #E1518E, #EC67A1)',
+                              }}
+                            >
+                              Save
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setCaptionDraft(caption);
+                                setEditingCaption(false);
+                              }}
+                              className="px-4 py-1.5 rounded-lg text-xs font-medium text-gray-400 hover:text-gray-200 hover:bg-white/[0.06] transition-colors"
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        </div>
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={() => setEditingCaption(true)}
+                          className="flex items-start gap-2 w-full text-left"
+                        >
+                          <p className="text-sm text-gray-300 whitespace-pre-wrap flex-1 leading-relaxed">
+                            {caption || (
+                              <span className="text-gray-600 italic">
+                                Click to add caption...
+                              </span>
+                            )}
+                          </p>
+                          <Pencil className="h-3.5 w-3.5 text-gray-600 opacity-0 group-hover/caption:opacity-100 transition-opacity shrink-0 mt-0.5" />
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                </GlowCard>
+
+                {/* Flyer Team */}
+                <GlowCard icon={Film} title="Flyer Team" iconColorClass="bg-rose-400/10 text-rose-400">
+                  <div className="space-y-3">
+                    <div>
+                      <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-gray-500 block mb-1.5">
+                        Game Type
+                      </span>
+                      <EditableField
+                        value={gameType}
+                        placeholder="e.g. Wheel, Dice, Trivia..."
+                        onSave={(v) => updateMeta({ gameType: v })}
+                      />
+                    </div>
+                    <div>
+                      <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-gray-500 block mb-1.5">
+                        GIF URL
+                      </span>
+                      <EditableField
+                        value={gifUrl}
+                        placeholder="https://..."
+                        onSave={(v) => updateMeta({ gifUrl: v })}
+                      />
+                      {gifUrl && (
+                        <a
+                          href={gifUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-2 text-xs text-brand-blue hover:text-brand-blue/80 transition-colors mt-1.5"
+                        >
+                          <ExternalLink className="h-3 w-3 shrink-0" />
+                          <span className="underline underline-offset-2">
+                            Open GIF
+                          </span>
+                        </a>
+                      )}
+                    </div>
+                  </div>
+                </GlowCard>
+
                 {/* Description */}
-                <GlowCard icon={FileText} title="Description" iconColorClass="bg-brand-light-pink/10 text-brand-light-pink">
+                <GlowCard icon={Info} title="Description" iconColorClass="bg-brand-light-pink/10 text-brand-light-pink">
                   <div className="space-y-4">
                     <EditableField
                       value={task.description ?? ''}
@@ -838,8 +976,8 @@ export function OtpPtrTaskDetailModal({
                   </div>
                 </GlowCard>
 
-                {/* Fulfillment Notes */}
-                <GlowCard icon={ClipboardList} title="Fulfillment Notes" iconColorClass="bg-emerald-400/10 text-emerald-400">
+                {/* Notes */}
+                <GlowCard icon={ClipboardList} title="Notes" iconColorClass="bg-emerald-400/10 text-emerald-400">
                   <div className="group/notes">
                     {editingNotes ? (
                       <div>
@@ -1539,6 +1677,46 @@ export function OtpPtrTaskDetailModal({
                 </div>
               ) : (
                 <span className="text-xs text-gray-600 italic">None</span>
+              )}
+            </SidebarField>
+
+            {/* ── Team Fields ── */}
+            <SidebarSectionHeader label="Team Fields" />
+
+            <SidebarField label="Caption">
+              <EditableField
+                value={caption}
+                placeholder="PGT caption..."
+                onSave={(v) => updateMeta({ caption: v })}
+              />
+            </SidebarField>
+
+            <SidebarField label="Game Type">
+              <EditableField
+                value={gameType}
+                placeholder="Set game type"
+                onSave={(v) => updateMeta({ gameType: v })}
+              />
+            </SidebarField>
+
+            <SidebarField label="GIF URL">
+              <EditableField
+                value={gifUrl}
+                placeholder="Paste URL..."
+                onSave={(v) => updateMeta({ gifUrl: v })}
+              />
+              {gifUrl && (
+                <a
+                  href={gifUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 text-[10px] text-brand-blue hover:text-brand-blue/80 transition-colors mt-1"
+                >
+                  <ExternalLink className="h-2.5 w-2.5 shrink-0" />
+                  <span className="underline underline-offset-2">
+                    Open
+                  </span>
+                </a>
               )}
             </SidebarField>
 

--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/template-config.ts
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/template-config.ts
@@ -72,7 +72,7 @@ const otpPtrItemToTask: ItemToTaskFn = (item: BoardItem, spaceKey: string): Boar
     taskKey: spaceKey ? `${spaceKey}-${item.itemNo}` : item.id.slice(-6).toUpperCase(),
     title: item.title,
     description: (item.description as string) ?? undefined,
-    assignee: (meta.model as string) ?? (item.assigneeId as string) ?? undefined,
+    assignee: (item.assigneeId as string) ?? undefined,
     priority: meta.isPaid ? ('Low' as const) : ('High' as const),
     tags: [
       ...(typeTag ? [typeTag] : []),

--- a/lib/hooks/useOrgMembers.query.ts
+++ b/lib/hooks/useOrgMembers.query.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+export interface OrgMember {
+  id: string;
+  clerkId: string;
+  name: string | null;
+  email: string;
+  firstName: string | null;
+  lastName: string | null;
+}
+
+async function fetchOrgMembers(): Promise<OrgMember[]> {
+  const res = await fetch('/api/organization/members');
+  if (!res.ok) throw new Error('Failed to fetch organization members');
+  return res.json();
+}
+
+export function useOrgMembers() {
+  return useQuery({
+    queryKey: ['organization-members'],
+    queryFn: fetchOrgMembers,
+    staleTime: 1000 * 60 * 2,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/lib/spaces/template-metadata.ts
+++ b/lib/spaces/template-metadata.ts
@@ -157,6 +157,9 @@ export interface OtpPtrItemMetadata {
   deadline: string;
   isPaid: boolean;
   fulfillmentNotes: string;
+  caption: string;
+  gameType: string;
+  gifUrl: string;
 }
 
 export const OTP_PTR_METADATA_DEFAULTS: OtpPtrItemMetadata = {
@@ -176,6 +179,9 @@ export const OTP_PTR_METADATA_DEFAULTS: OtpPtrItemMetadata = {
   deadline: '',
   isPaid: false,
   fulfillmentNotes: '',
+  caption: '',
+  gameType: '',
+  gifUrl: '',
 };
 
 export const OTP_PTR_METADATA_FIELDS: MetadataFieldDescriptor[] = [
@@ -201,6 +207,9 @@ export const OTP_PTR_METADATA_FIELDS: MetadataFieldDescriptor[] = [
   { key: 'deadline', label: 'Deadline', type: 'date' },
   { key: 'isPaid', label: 'Paid', type: 'boolean' },
   { key: 'fulfillmentNotes', label: 'Fulfillment Notes', type: 'textarea', placeholder: 'Delivery instructions...' },
+  { key: 'caption', label: 'Caption', type: 'textarea', placeholder: 'PGT caption text...' },
+  { key: 'gameType', label: 'Game Type', type: 'text', placeholder: 'e.g. Wheel, Dice, Trivia...' },
+  { key: 'gifUrl', label: 'GIF URL', type: 'text', placeholder: 'https://...' },
 ];
 
 /* ================================================================== */

--- a/prisma/seed-templates.ts
+++ b/prisma/seed-templates.ts
@@ -162,10 +162,14 @@ export const TEMPLATE_SEEDS: TemplateSeed[] = [
     description: 'Handle OTP and PTR request workflows efficiently.',
     config: {
       defaultColumns: [
-        { name: 'Incoming', color: 'blue', position: 0 },
-        { name: 'In Production', color: 'amber', position: 1 },
-        { name: 'Delivered', color: 'green', position: 2 },
-        { name: 'Completed', color: 'purple', position: 3 },
+        { name: 'PGT Team', color: 'pink', position: 0 },
+        { name: 'PGT Completed', color: 'gray', position: 1 },
+        { name: 'Flyer Team', color: 'amber', position: 2 },
+        { name: 'Flyer Completed', color: 'gray', position: 3 },
+        { name: 'QA', color: 'green', position: 4 },
+        { name: 'For Approval', color: 'purple', position: 5 },
+        { name: 'Ready to Deploy', color: 'blue', position: 6 },
+        { name: 'Posted', color: 'pink', position: 7 },
       ],
       workTypes: [
         { name: 'OTP Request', icon: 'zap', description: 'One-time purchase content requests' },
@@ -480,7 +484,7 @@ function getSampleItems(
     case 'OTP_PTR':
       return [
         {
-          columnId: columnIds['Incoming'],
+          columnId: columnIds['PGT Team'],
           title: 'Custom video request — @fan123',
           description: 'Requested a 2-minute custom video with specific outfit.',
           type: 'REQUEST',
@@ -490,7 +494,7 @@ function getSampleItems(
           metadata: { ...OTP_PTR_METADATA_DEFAULTS, buyer: '@fan123', price: 50.0, deliverables: ['1 custom video (2 min)'] },
         },
         {
-          columnId: columnIds['In Production'],
+          columnId: columnIds['Flyer Team'],
           title: 'Photo bundle — @vipuser',
           description: '5 exclusive photos, already paid.',
           type: 'REQUEST',
@@ -499,7 +503,7 @@ function getSampleItems(
           metadata: { ...OTP_PTR_METADATA_DEFAULTS, buyer: '@vipuser', price: 35.0, deliverables: ['5 photos'], isPaid: true },
         },
         {
-          columnId: columnIds['Delivered'],
+          columnId: columnIds['For Approval'],
           title: 'Voice note — @subscriber99',
           description: 'Personalized voice note, delivered via DM.',
           type: 'REQUEST',
@@ -508,7 +512,7 @@ function getSampleItems(
           metadata: { ...OTP_PTR_METADATA_DEFAULTS, requestType: 'PTR', buyer: '@subscriber99', price: 15.0, isPaid: true },
         },
         {
-          columnId: columnIds['Completed'],
+          columnId: columnIds['Posted'],
           title: 'GFE package — @loyalfan',
           description: 'Girlfriend-experience message bundle, completed and reviewed.',
           type: 'REQUEST',


### PR DESCRIPTION
…R board

- Add PGT Team (caption) and Flyer Team (gameType, gifUrl) sections to detail modal
- Add Team Fields sidebar section with caption, game type, and GIF URL
- Rename Fulfillment Notes to Notes to match external site
- Resolve assignee clerk IDs to display names across board view and task cards
- Replace assignee text input with searchable member dropdown
- Add useOrgMembers query hook for organization member lookups
- Update seed template columns to match production workflow stages