### PR TITLE
feat: add Mark as Final workflow for OTP/PTR board items

### DIFF
--- a/app/[tenant]/(dashboard)/spaces/[slug]/SpaceBoardView.tsx
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/SpaceBoardView.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useCallback, useState } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import { DragDropContext } from '@hello-pangea/dnd';
+import { useQueryClient } from '@tanstack/react-query';
 import { useSpaceBySlug, useUpdateSpace } from '@/lib/hooks/useSpaces.query';
 import { useSpaceMembers } from '@/lib/hooks/useSpaceMembers.query';
 import { useOrgMembers } from '@/lib/hooks/useOrgMembers.query';
@@ -83,9 +84,44 @@ function TemplateBoardView({ slug }: { slug: string }) {
   const { data: orgMembers = [] } = useOrgMembers();
   const { currentOrganization } = useOrganization();
   const updateSpaceMutation = useUpdateSpace(space?.id ?? '');
+  const queryClient = useQueryClient();
   const config = TEMPLATE_CONFIG[space!.templateType];
   const { DetailModal, CardComponent } = config;
   const boardContainerRef = useRef<HTMLDivElement>(null);
+
+  // Drag-to-scroll state
+  const [isDragging, setIsDragging] = useState(false);
+  const dragState = useRef({ startX: 0, scrollLeft: 0, hasMoved: false });
+
+  const handlePointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    // Only grab-scroll on the board background / column headers, not on task cards (handled by dnd)
+    const target = e.target as HTMLElement;
+    if (target.closest('[data-rfd-draggable-id]') || target.closest('button') || target.closest('a') || target.closest('input')) return;
+
+    const container = boardContainerRef.current;
+    if (!container) return;
+
+    setIsDragging(true);
+    dragState.current = { startX: e.clientX, scrollLeft: container.scrollLeft, hasMoved: false };
+    container.setPointerCapture(e.pointerId);
+  }, []);
+
+  const handlePointerMove = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDragging) return;
+    const container = boardContainerRef.current;
+    if (!container) return;
+
+    const dx = e.clientX - dragState.current.startX;
+    if (Math.abs(dx) > 3) dragState.current.hasMoved = true;
+    container.scrollLeft = dragState.current.scrollLeft - dx;
+  }, [isDragging]);
+
+  const handlePointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (!isDragging) return;
+    setIsDragging(false);
+    const container = boardContainerRef.current;
+    if (container) container.releasePointerCapture(e.pointerId);
+  }, [isDragging]);
 
   // Get current user's role in the space
   const currentMember = members.find((m) => m.user.clerkId === user?.id);
@@ -103,6 +139,31 @@ function TemplateBoardView({ slug }: { slug: string }) {
   const handleSpaceNameUpdate = async (newName: string) => {
     await updateSpaceMutation.mutateAsync({ name: newName });
   };
+
+  const defaultBoard = space?.boards?.[0];
+
+  // Handler for "Mark as Final" — moves item to Posted + creates gallery entry
+  const handleMarkFinal = useCallback(
+    async (taskId: string) => {
+      if (!space?.id || !defaultBoard?.id) return;
+      try {
+        const res = await fetch(
+          `/api/spaces/${space.id}/boards/${defaultBoard.id}/items/${taskId}/mark-final`,
+          { method: 'POST' },
+        );
+        if (!res.ok) {
+          const data = await res.json().catch(() => ({}));
+          console.error('Mark as final failed:', data.error);
+          return;
+        }
+        // Invalidate board items to refresh the board
+        queryClient.invalidateQueries({ queryKey: ['board-items'] });
+      } catch (err) {
+        console.error('Mark as final error:', err);
+      }
+    },
+    [space?.id, defaultBoard?.id, queryClient],
+  );
 
   const {
     boardData,
@@ -132,6 +193,8 @@ function TemplateBoardView({ slug }: { slug: string }) {
     ),
   ).sort();
 
+  const totalTaskCount = Object.keys(effectiveTasks).length;
+
   return (
     <>
       <BoardLayout
@@ -145,6 +208,8 @@ function TemplateBoardView({ slug }: { slug: string }) {
         defaultTab="board"
         columns={boardData?.columns.map((c) => ({ id: c.id, name: c.name })) ?? []}
         assignees={uniqueAssignees}
+        totalTaskCount={totalTaskCount}
+        currentUserId={user?.id}
       >
         {(activeTab, filters) => {
           // Any non-board tab → placeholder
@@ -175,13 +240,20 @@ function TemplateBoardView({ slug }: { slug: string }) {
           return (
             <div
               ref={boardContainerRef}
-              className="rounded-2xl border border-gray-200 dark:border-brand-mid-pink/15 bg-gray-100/50 dark:bg-gray-950/40 p-3 sm:p-4 overflow-x-auto"
+              onPointerDown={handlePointerDown}
+              onPointerMove={handlePointerMove}
+              onPointerUp={handlePointerUp}
+              onPointerCancel={handlePointerUp}
+              className={`rounded-2xl border border-gray-200 dark:border-brand-mid-pink/15 bg-gray-100/50 dark:bg-gray-950/40 p-3 sm:p-4 overflow-x-auto select-none ${isDragging ? 'cursor-grabbing' : 'cursor-grab'}`}
             >
               <DragDropContext onDragEnd={handleDragEnd}>
                 <div className="flex gap-3 sm:gap-4 min-w-max items-stretch">
                   {effectiveColumnOrder.map((colId) => {
                     const col = effectiveColumns[colId];
                     if (!col) return null;
+
+                    // Hide columns toggled off in Columns picker
+                    if (filters.hiddenColumns.has(colId)) return null;
 
                     // Apply filters
                     const colTasks = col.taskIds
@@ -213,6 +285,11 @@ function TemplateBoardView({ slug }: { slug: string }) {
                           return false;
                         }
 
+                        // My tasks filter
+                        if (filters.myTasksOnly && t.assignee !== user?.id) {
+                          return false;
+                        }
+
                         return true;
                       });
 
@@ -226,6 +303,7 @@ function TemplateBoardView({ slug }: { slug: string }) {
                         onTaskTitleUpdate={handleTitleUpdate}
                         onColumnTitleUpdate={handleColumnTitleUpdate}
                         onColumnColorUpdate={handleColumnColorUpdate}
+                        onMarkFinal={handleMarkFinal}
                         CardComponent={CardComponent}
                       />
                     );

--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/OtpPtrTaskCard.tsx
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/OtpPtrTaskCard.tsx
@@ -17,6 +17,8 @@ import {
   DollarSign,
   CheckCircle2,
   CircleX,
+  BadgeCheck,
+  Loader2,
 } from 'lucide-react';
 import { useOrgMembers } from '@/lib/hooks/useOrgMembers.query';
 import type { BoardTask } from '../../board';
@@ -26,6 +28,8 @@ interface OtpPtrTaskCardProps {
   index: number;
   onClick?: (task: BoardTask) => void;
   onTitleUpdate?: (task: BoardTask, newTitle: string) => void;
+  columnTitle?: string;
+  onMarkFinal?: (taskId: string) => void;
 }
 
 /* ── Content style badge config ─────────────────────────────── */
@@ -102,11 +106,14 @@ function timeAgo(dateStr: string): string {
 
 /* ── Card component ─────────────────────────────────────────── */
 
-export function OtpPtrTaskCard({ task, index, onClick, onTitleUpdate }: OtpPtrTaskCardProps) {
+export function OtpPtrTaskCard({ task, index, onClick, onTitleUpdate, columnTitle, onMarkFinal }: OtpPtrTaskCardProps) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(task.title);
+  const [markingFinal, setMarkingFinal] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const { data: orgMembers = [] } = useOrgMembers();
+
+  const isReadyToDeploy = columnTitle?.toLowerCase().includes('ready to deploy') ?? false;
 
   const meta = (task.metadata ?? {}) as Record<string, unknown>;
 
@@ -270,6 +277,27 @@ export function OtpPtrTaskCard({ task, index, onClick, onTitleUpdate }: OtpPtrTa
                 <p className="text-[11px] leading-relaxed text-gray-500 dark:text-gray-400 line-clamp-2 mb-2">
                   {task.description}
                 </p>
+              )}
+
+              {/* Mark as Final button — only in "Ready to Deploy" column */}
+              {isReadyToDeploy && onMarkFinal && (
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setMarkingFinal(true);
+                    onMarkFinal(task.id);
+                  }}
+                  disabled={markingFinal}
+                  className="w-full flex items-center justify-center gap-1.5 rounded-lg border border-emerald-500/30 bg-emerald-500/10 hover:bg-emerald-500/20 text-emerald-400 hover:text-emerald-300 px-2 py-1.5 text-[11px] font-semibold transition-colors mb-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {markingFinal ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <BadgeCheck className="h-3.5 w-3.5" />
+                  )}
+                  {markingFinal ? 'Posting...' : 'Mark as Final'}
+                </button>
               )}
 
               {/* Divider */}

--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/OtpPtrTaskDetailModal.tsx
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/OtpPtrTaskDetailModal.tsx
@@ -387,6 +387,8 @@ export function OtpPtrTaskDetailModal({
   const caption = (meta.caption as string) ?? '';
   const gameType = (meta.gameType as string) ?? '';
   const gifUrl = (meta.gifUrl as string) ?? '';
+  const gameNotes = (meta.gameNotes as string) ?? '';
+  const originalPollReference = (meta.originalPollReference as string) ?? '';
 
   // Caption Workspace integration
   const captionTicketId = (meta.captionTicketId as string) ?? null;
@@ -998,8 +1000,34 @@ export function OtpPtrTaskDetailModal({
                         </a>
                       )}
                     </div>
+                    <div>
+                      <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-gray-500 block mb-1.5">
+                        Game Notes
+                      </span>
+                      <EditableField
+                        value={gameNotes}
+                        placeholder="Notes for the flyer team..."
+                        onSave={(v) => updateMeta({ gameNotes: v })}
+                      />
+                    </div>
                   </div>
                 </GlowCard>
+
+                {/* PPV/Bundle Poll Reference */}
+                {(contentStyle.toLowerCase() === 'ppv' || contentStyle.toLowerCase() === 'bundle') && (
+                  <GlowCard icon={Film} title="PPV/Bundle Details" iconColorClass="bg-purple-400/10 text-purple-400">
+                    <div>
+                      <span className="text-[10px] font-semibold uppercase tracking-[0.1em] text-gray-500 block mb-1.5">
+                        Original Poll Reference
+                      </span>
+                      <EditableField
+                        value={originalPollReference}
+                        placeholder="Reference to original poll..."
+                        onSave={(v) => updateMeta({ originalPollReference: v })}
+                      />
+                    </div>
+                  </GlowCard>
+                )}
 
                 {/* Description */}
                 <GlowCard icon={Info} title="Description" iconColorClass="bg-brand-light-pink/10 text-brand-light-pink">
@@ -1861,6 +1889,22 @@ export function OtpPtrTaskDetailModal({
                   </span>
                 </a>
               )}
+            </SidebarField>
+
+            <SidebarField label="Game Notes">
+              <EditableField
+                value={gameNotes}
+                placeholder="Notes for team..."
+                onSave={(v) => updateMeta({ gameNotes: v })}
+              />
+            </SidebarField>
+
+            <SidebarField label="Poll Reference">
+              <EditableField
+                value={originalPollReference}
+                placeholder="Original poll ref..."
+                onSave={(v) => updateMeta({ originalPollReference: v })}
+              />
             </SidebarField>
 
             {/* Tags summary in sidebar */}

--- a/app/[tenant]/(dashboard)/spaces/board/BoardColumn.tsx
+++ b/app/[tenant]/(dashboard)/spaces/board/BoardColumn.tsx
@@ -20,6 +20,7 @@ interface BoardColumnProps {
   onTaskTitleUpdate?: (task: BoardTask, newTitle: string) => void;
   onColumnTitleUpdate?: (columnId: string, newTitle: string) => void;
   onColumnColorUpdate?: (columnId: string, newColor: string) => void;
+  onMarkFinal?: (taskId: string) => void;
   CardComponent?: ComponentType<BoardTaskCardProps>;
 }
 
@@ -53,6 +54,7 @@ export function BoardColumn({
   onTaskTitleUpdate,
   onColumnTitleUpdate,
   onColumnColorUpdate,
+  onMarkFinal,
   CardComponent,
 }: BoardColumnProps) {
   const Card = CardComponent ?? BoardTaskCard;
@@ -259,6 +261,8 @@ export function BoardColumn({
                   index={index}
                   onClick={onTaskClick}
                   onTitleUpdate={onTaskTitleUpdate}
+                  columnTitle={column.title}
+                  onMarkFinal={onMarkFinal}
                 />
               ))}
               {provided.placeholder}

--- a/app/[tenant]/(dashboard)/spaces/board/BoardLayout.tsx
+++ b/app/[tenant]/(dashboard)/spaces/board/BoardLayout.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState, useRef, useEffect, type ReactNode } from 'react';
-import { Search, SlidersHorizontal, X, ChevronDown, MoreHorizontal, Settings } from 'lucide-react';
+import { useState, useRef, useEffect, useMemo, type ReactNode } from 'react';
+import { Search, SlidersHorizontal, X, ChevronDown, MoreHorizontal, Settings, ArrowUpDown, User, Columns3, Sparkles, LayoutGrid, BarChart3, FileText } from 'lucide-react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 
@@ -10,11 +10,17 @@ export interface BoardTab {
   label: string;
 }
 
+export type SortOption = 'last-updated' | 'newest' | 'oldest' | 'priority' | 'alphabetical';
+
 export interface BoardFilters {
   searchQuery: string;
   statusFilter: string | null;
   assigneeFilter: string | null;
   priorityFilter: string | null;
+  sortBy: SortOption;
+  sortAsc: boolean;
+  myTasksOnly: boolean;
+  hiddenColumns: Set<string>;
 }
 
 interface BoardLayoutProps {
@@ -29,6 +35,9 @@ interface BoardLayoutProps {
   onTabChange?: (tabId: string) => void;
   columns?: { id: string; name: string }[];
   assignees?: string[];
+  totalTaskCount?: number;
+  filteredTaskCount?: number;
+  currentUserId?: string;
   children: (activeTab: string, filters: BoardFilters) => ReactNode;
 }
 
@@ -44,6 +53,9 @@ export function BoardLayout({
   onTabChange,
   columns = [],
   assignees = [],
+  totalTaskCount = 0,
+  filteredTaskCount,
+  currentUserId,
   children,
 }: BoardLayoutProps) {
   const params = useParams<{ tenant: string }>();
@@ -53,15 +65,41 @@ export function BoardLayout({
   const [statusFilter, setStatusFilter] = useState<string | null>(null);
   const [assigneeFilter, setAssigneeFilter] = useState<string | null>(null);
   const [priorityFilter, setPriorityFilter] = useState<string | null>(null);
+  const [sortBy, setSortBy] = useState<SortOption>('last-updated');
+  const [sortAsc, setSortAsc] = useState(false);
+  const [myTasksOnly, setMyTasksOnly] = useState(false);
+  const [showSortDropdown, setShowSortDropdown] = useState(false);
   const [showStatusDropdown, setShowStatusDropdown] = useState(false);
   const [showAssigneeDropdown, setShowAssigneeDropdown] = useState(false);
   const [showPriorityDropdown, setShowPriorityDropdown] = useState(false);
+  const [showColumnsDropdown, setShowColumnsDropdown] = useState(false);
+  const [hiddenColumns, setHiddenColumns] = useState<Set<string>>(new Set());
   const [showSettingsMenu, setShowSettingsMenu] = useState(false);
   const [isEditingName, setIsEditingName] = useState(false);
   const [editedName, setEditedName] = useState(spaceName);
   const [isUpdating, setIsUpdating] = useState(false);
   const settingsMenuRef = useRef<HTMLDivElement>(null);
+  const toolbarRef = useRef<HTMLDivElement>(null);
   const nameInputRef = useRef<HTMLInputElement>(null);
+
+  // Close toolbar dropdowns when clicking outside
+  useEffect(() => {
+    const anyDropdownOpen = showSortDropdown || filtersOpen || showColumnsDropdown;
+    if (!anyDropdownOpen) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (toolbarRef.current && !toolbarRef.current.contains(event.target as Node)) {
+        setShowSortDropdown(false);
+        setShowStatusDropdown(false);
+        setShowAssigneeDropdown(false);
+        setShowPriorityDropdown(false);
+        setShowColumnsDropdown(false);
+        setFiltersOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [showSortDropdown, filtersOpen, showColumnsDropdown]);
 
   // Close settings menu when clicking outside
   useEffect(() => {
@@ -130,14 +168,25 @@ export function BoardLayout({
     onTabChange?.(tabId);
   };
 
+  const closeAllDropdowns = () => {
+    setShowSortDropdown(false);
+    setShowStatusDropdown(false);
+    setShowAssigneeDropdown(false);
+    setShowPriorityDropdown(false);
+    setShowColumnsDropdown(false);
+  };
+
   const clearFilters = () => {
     setStatusFilter(null);
     setAssigneeFilter(null);
     setPriorityFilter(null);
+    setMyTasksOnly(false);
     setFiltersOpen(false);
+    closeAllDropdowns();
   };
 
-  const hasActiveFilters = statusFilter || assigneeFilter || priorityFilter;
+  const hasActiveFilters = statusFilter || assigneeFilter || priorityFilter || myTasksOnly;
+  const activeFilterCount = [statusFilter, assigneeFilter, priorityFilter, myTasksOnly].filter(Boolean).length;
   // Allow access if user is space OWNER/ADMIN OR organization OWNER/ADMIN
   const canAccessSettings =
     userRole === 'OWNER' ||
@@ -146,291 +195,433 @@ export function BoardLayout({
     organizationRole === 'ADMIN';
   const settingsUrl = `/${params.tenant}/spaces/${spaceSlug}/settings/details`;
 
+  const sortLabels: Record<SortOption, string> = {
+    'last-updated': 'Last Updated',
+    'newest': 'Newest First',
+    'oldest': 'Oldest First',
+    'priority': 'Priority',
+    'alphabetical': 'A–Z',
+  };
+
   const filters: BoardFilters = {
     searchQuery,
     statusFilter,
     assigneeFilter,
     priorityFilter,
+    sortBy,
+    sortAsc,
+    myTasksOnly,
+    hiddenColumns,
+  };
+
+  const displayedCount = filteredTaskCount ?? totalTaskCount;
+
+  // Tab icon mapping
+  const tabIcons: Record<string, React.ReactNode> = {
+    summary: <FileText className="h-3.5 w-3.5" />,
+    board: <LayoutGrid className="h-3.5 w-3.5" />,
+    financials: <BarChart3 className="h-3.5 w-3.5" />,
   };
 
   return (
     <div className="flex flex-col gap-0">
-      {/* ── Space header ─────────────────────────────────────── */}
-      <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between pb-4">
-        <div className="min-w-0">
-          <div className="flex items-center gap-0.5">
-            {isEditingName ? (
-              <input
-                ref={nameInputRef}
-                type="text"
-                value={editedName}
-                onChange={(e) => setEditedName(e.target.value)}
-                onBlur={handleNameSave}
-                onKeyDown={handleNameKeyDown}
-                disabled={isUpdating}
-                className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-brand-off-white bg-transparent border-b-2 border-brand-light-pink focus:outline-none focus:border-brand-mid-pink transition-colors px-1 -mx-1"
-              />
-            ) : (
-              <h2
-                onClick={handleNameClick}
-                className={[
-                  'text-xl sm:text-2xl font-bold text-gray-900 dark:text-brand-off-white truncate',
-                  canAccessSettings && 'cursor-pointer hover:text-brand-light-pink transition-colors',
-                ].join(' ')}
-                title={canAccessSettings ? 'Click to edit' : undefined}
+      {/* ── Space header row ──────────────────────────────────── */}
+      <div className="flex items-center justify-between gap-3 pb-3">
+        <div className="flex items-center gap-2.5 min-w-0">
+          {isEditingName ? (
+            <input
+              ref={nameInputRef}
+              type="text"
+              value={editedName}
+              onChange={(e) => setEditedName(e.target.value)}
+              onBlur={handleNameSave}
+              onKeyDown={handleNameKeyDown}
+              disabled={isUpdating}
+              className="text-lg font-bold text-gray-900 dark:text-brand-off-white bg-transparent border-b-2 border-brand-light-pink focus:outline-none focus:border-brand-mid-pink transition-colors leading-snug"
+            />
+          ) : (
+            <h2
+              onClick={handleNameClick}
+              className={[
+                'text-lg font-bold text-gray-900 dark:text-brand-off-white truncate leading-snug',
+                canAccessSettings && 'cursor-pointer hover:text-brand-light-pink transition-colors',
+              ].join(' ')}
+              title={canAccessSettings ? 'Click to edit' : undefined}
+            >
+              {spaceName}
+            </h2>
+          )}
+
+          {canAccessSettings && !isEditingName && (
+            <div className="relative" ref={settingsMenuRef}>
+              <button
+                type="button"
+                onClick={() => setShowSettingsMenu(!showSettingsMenu)}
+                className="shrink-0 p-1 rounded-md text-gray-400 hover:text-brand-light-pink hover:bg-brand-light-pink/10 transition-all"
+                title="Space settings"
               >
-                {spaceName}
-              </h2>
-            )}
+                <MoreHorizontal className="h-4 w-4" />
+              </button>
 
-            {/* Settings Menu - Only visible to OWNER and ADMIN */}
-            {canAccessSettings && !isEditingName && (
-              <div className="relative" ref={settingsMenuRef}>
-                <button
-                  type="button"
-                  onClick={() => setShowSettingsMenu(!showSettingsMenu)}
-                  className="shrink-0 p-1 rounded-lg text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800/50 transition-colors"
-                  title="Space settings"
-                >
-                  <MoreHorizontal className="h-4 w-4" />
-                </button>
-
-                {showSettingsMenu && (
-                  <div className="absolute left-0 top-full mt-1 z-20 min-w-45 rounded-xl border border-gray-200 dark:border-brand-mid-pink/20 bg-white dark:bg-gray-900 shadow-xl overflow-hidden">
-                    <div className="p-1">
-                      <Link
-                        href={settingsUrl}
-                        className="w-full flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors"
-                        onClick={() => setShowSettingsMenu(false)}
-                      >
-                        <Settings className="h-4 w-4" />
-                        Space Settings
-                      </Link>
-                    </div>
+              {showSettingsMenu && (
+                <div className="absolute left-0 top-full mt-1 z-20 min-w-[180px] rounded-xl border border-gray-200 dark:border-brand-mid-pink/20 bg-white dark:bg-gray-900 shadow-2xl overflow-hidden">
+                  <div className="p-1">
+                    <Link
+                      href={settingsUrl}
+                      className="w-full flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800/60 transition-colors"
+                      onClick={() => setShowSettingsMenu(false)}
+                    >
+                      <Settings className="h-3.5 w-3.5" />
+                      Space Settings
+                    </Link>
                   </div>
-                )}
-              </div>
-            )}
-          </div>
-          <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-            Plan, track, and manage work across your team.
-          </p>
+                </div>
+              )}
+            </div>
+          )}
         </div>
 
-        <span className="shrink-0 inline-flex items-center rounded-full bg-brand-dark-pink/10 text-brand-dark-pink px-3 py-1 text-[11px] font-medium">
-          {templateLabel} template
+        <span className="shrink-0 inline-flex items-center rounded-full bg-brand-dark-pink/10 dark:bg-brand-dark-pink/15 text-brand-dark-pink dark:text-brand-light-pink px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide">
+          {templateLabel}
         </span>
       </div>
 
-      {/* ── Tabs ──────────────────────────────────────────────── */}
-      <div className="border-b border-gray-200 dark:border-brand-mid-pink/20 flex items-center gap-1 -mb-px">
-        {tabs.map((tab) => {
-          const isActive = tab.id === activeTab;
-          return (
-            <button
-              key={tab.id}
-              type="button"
-              onClick={() => handleTabChange(tab.id)}
-              className={[
-                'relative px-4 py-2.5 text-[13px] font-medium rounded-t-lg transition-colors',
-                isActive
-                  ? 'text-brand-light-pink bg-white/70 dark:bg-gray-900/50'
-                  : 'text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 hover:bg-gray-100/50 dark:hover:bg-gray-800/30',
-              ].join(' ')}
-            >
-              {tab.label}
-              {isActive && (
-                <span className="absolute inset-x-0 bottom-0 h-[2px] bg-linear-to-r from-brand-light-pink via-brand-mid-pink to-brand-blue rounded-full" />
-              )}
-            </button>
-          );
-        })}
+      {/* ── Tabs + Filter toolbar — unified bar ───────────────── */}
+      <div className="relative rounded-t-xl overflow-hidden border border-b-0 border-gray-200/60 dark:border-brand-mid-pink/10 bg-gray-50/50 dark:bg-gray-900/40">
+        {/* Tab row */}
+        <div className="flex items-center gap-1 px-2 pt-1">
+          {tabs.map((tab) => {
+            const isActive = tab.id === activeTab;
+            const icon = tabIcons[tab.id];
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                onClick={() => handleTabChange(tab.id)}
+                className={[
+                  'relative inline-flex items-center gap-1.5 px-4 py-2 text-[12px] font-semibold transition-all duration-150',
+                  isActive
+                    ? 'text-brand-light-pink'
+                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200',
+                ].join(' ')}
+              >
+                {icon && <span className={isActive ? 'text-brand-light-pink' : 'opacity-40'}>{icon}</span>}
+                {tab.label}
+                {isActive && (
+                  <span className="absolute inset-x-2 bottom-0 h-[2px] rounded-full bg-gradient-to-r from-brand-light-pink via-brand-mid-pink to-brand-light-pink" />
+                )}
+              </button>
+            );
+          })}
+        </div>
       </div>
 
-      {/* ── Filter bar ────────────────────────────────────────── */}
-      <div className="flex flex-col gap-2.5 sm:flex-row sm:items-center sm:justify-between py-3">
-        <div className="relative flex-1 max-w-sm">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-gray-400 pointer-events-none" />
-          <input
-            type="text"
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            placeholder="Search tasks..."
-            className="w-full rounded-xl border border-gray-200 dark:border-brand-mid-pink/20 bg-white/80 dark:bg-gray-900/60 pl-9 pr-3 py-2 text-xs text-gray-900 dark:text-brand-off-white placeholder:text-gray-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-light-pink/60"
-          />
-          {searchQuery && (
+      {/* ── Filter toolbar ─────────────────────────────────────── */}
+      <div className="relative mb-3 z-30" ref={toolbarRef}>
+        <div className="flex items-center gap-2 rounded-b-xl border border-t-0 border-gray-200/60 dark:border-brand-mid-pink/10 bg-gradient-to-b from-gray-50/80 to-white/60 dark:from-gray-900/60 dark:to-gray-950/40 backdrop-blur-sm px-3 py-2">
+          {/* Search */}
+          <div className="relative flex-1 min-w-0 max-w-xs">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-gray-400 dark:text-gray-500 pointer-events-none" />
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search tasks..."
+              className="w-full rounded-lg bg-gray-100/80 dark:bg-gray-800/60 border-0 pl-8 pr-7 py-1.5 text-xs text-gray-900 dark:text-brand-off-white placeholder:text-gray-400 dark:placeholder:text-gray-500 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-brand-light-pink/50 transition-shadow"
+            />
+            {searchQuery && (
+              <button
+                type="button"
+                onClick={() => setSearchQuery('')}
+                className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5 rounded text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            )}
+          </div>
+
+          {/* Divider */}
+          <div className="h-5 w-px bg-gray-200 dark:bg-brand-mid-pink/15 shrink-0" />
+
+          {/* Sort dropdown */}
+          <div className="relative">
             <button
               type="button"
-              onClick={() => setSearchQuery('')}
-              className="absolute right-2.5 top-1/2 -translate-y-1/2 p-0.5 rounded text-gray-400 hover:text-gray-600"
+              onClick={() => {
+                setShowSortDropdown(!showSortDropdown);
+                setShowStatusDropdown(false);
+                setShowAssigneeDropdown(false);
+                setShowPriorityDropdown(false);
+                setShowColumnsDropdown(false);
+              }}
+              className="inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[11px] font-medium text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800/60 transition-colors"
             >
-              <X className="h-3 w-3" />
+              {sortLabels[sortBy]}
+              <ChevronDown className="h-3 w-3 opacity-50" />
             </button>
-          )}
-        </div>
+            {showSortDropdown && (
+              <div className="absolute left-0 top-full mt-1.5 z-20 min-w-[160px] rounded-xl border border-gray-200 dark:border-brand-mid-pink/20 bg-white dark:bg-gray-900 shadow-xl py-1 overflow-hidden">
+                {(Object.entries(sortLabels) as [SortOption, string][]).map(([key, label]) => (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => { setSortBy(key); setShowSortDropdown(false); }}
+                    className={[
+                      'w-full text-left px-3 py-1.5 text-xs transition-colors',
+                      sortBy === key
+                        ? 'text-brand-light-pink bg-brand-light-pink/10 font-medium'
+                        : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800/60',
+                    ].join(' ')}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
 
-        <div className="flex items-center gap-2 flex-wrap">
+          {/* Sort direction toggle */}
           <button
             type="button"
-            onClick={() => setFiltersOpen(!filtersOpen)}
+            onClick={() => setSortAsc(!sortAsc)}
+            title={sortAsc ? 'Ascending' : 'Descending'}
             className={[
-              'inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-[11px] font-medium transition-colors',
-              filtersOpen || hasActiveFilters
-                ? 'border-brand-light-pink/40 bg-brand-light-pink/10 text-brand-light-pink'
-                : 'border-gray-200 dark:border-brand-mid-pink/20 bg-white/80 dark:bg-gray-900/60 text-gray-600 dark:text-gray-300 hover:border-brand-light-pink/40',
+              'rounded-lg p-1.5 transition-colors',
+              sortAsc
+                ? 'text-brand-light-pink bg-brand-light-pink/10'
+                : 'text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800/60 hover:text-gray-600 dark:hover:text-gray-300',
             ].join(' ')}
           >
-            <SlidersHorizontal className="h-3 w-3" />
-            Filters
-            {hasActiveFilters && (
-              <span className="ml-0.5 h-4 w-4 rounded-full bg-brand-light-pink text-white text-[9px] flex items-center justify-center">
-                {[statusFilter, assigneeFilter, priorityFilter].filter(Boolean).length}
-              </span>
-            )}
+            <ArrowUpDown className={`h-3.5 w-3.5 transition-transform ${sortAsc ? 'rotate-180' : ''}`} />
           </button>
 
-          {filtersOpen && (
-            <>
-              {/* Status Filter */}
-              <div className="relative">
-                <button
-                  type="button"
-                  onClick={() => {
-                    setShowStatusDropdown(!showStatusDropdown);
-                    setShowAssigneeDropdown(false);
-                    setShowPriorityDropdown(false);
-                  }}
-                  className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 dark:border-brand-mid-pink/20 bg-white/80 dark:bg-gray-900/60 px-2.5 py-1.5 text-[11px] font-medium text-gray-600 dark:text-gray-300 hover:border-brand-light-pink/40 transition-colors"
-                >
-                  Status: {statusFilter ? columns.find((c) => c.id === statusFilter)?.name : 'All'}
-                  <ChevronDown className="h-3 w-3" />
-                </button>
-                {showStatusDropdown && (
-                  <div className="absolute top-full mt-1 z-10 min-w-[160px] rounded-lg border border-gray-200 dark:border-brand-mid-pink/30 bg-white dark:bg-gray-800 shadow-lg py-1">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setStatusFilter(null);
-                        setShowStatusDropdown(false);
-                      }}
-                      className="w-full text-left px-3 py-1.5 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                    >
-                      All
-                    </button>
-                    {columns.map((col) => (
-                      <button
-                        key={col.id}
-                        type="button"
-                        onClick={() => {
-                          setStatusFilter(col.id);
-                          setShowStatusDropdown(false);
-                        }}
-                        className="w-full text-left px-3 py-1.5 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                      >
-                        {col.name}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
+          {/* Divider */}
+          <div className="h-5 w-px bg-gray-200 dark:bg-brand-mid-pink/15 shrink-0" />
 
-              {/* Assignee Filter */}
-              <div className="relative">
-                <button
-                  type="button"
-                  onClick={() => {
-                    setShowAssigneeDropdown(!showAssigneeDropdown);
-                    setShowStatusDropdown(false);
-                    setShowPriorityDropdown(false);
-                  }}
-                  className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 dark:border-brand-mid-pink/20 bg-white/80 dark:bg-gray-900/60 px-2.5 py-1.5 text-[11px] font-medium text-gray-600 dark:text-gray-300 hover:border-brand-light-pink/40 transition-colors"
-                >
-                  Assignee: {assigneeFilter || 'Any'}
-                  <ChevronDown className="h-3 w-3" />
-                </button>
-                {showAssigneeDropdown && (
-                  <div className="absolute top-full mt-1 z-10 min-w-[160px] rounded-lg border border-gray-200 dark:border-brand-mid-pink/30 bg-white dark:bg-gray-800 shadow-lg py-1 max-h-[200px] overflow-y-auto">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setAssigneeFilter(null);
-                        setShowAssigneeDropdown(false);
-                      }}
-                      className="w-full text-left px-3 py-1.5 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                    >
-                      Any
-                    </button>
-                    {assignees.map((assignee) => (
-                      <button
-                        key={assignee}
-                        type="button"
-                        onClick={() => {
-                          setAssigneeFilter(assignee);
-                          setShowAssigneeDropdown(false);
-                        }}
-                        className="w-full text-left px-3 py-1.5 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                      >
-                        {assignee}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
-
-              {/* Priority Filter */}
-              <div className="relative">
-                <button
-                  type="button"
-                  onClick={() => {
-                    setShowPriorityDropdown(!showPriorityDropdown);
-                    setShowStatusDropdown(false);
-                    setShowAssigneeDropdown(false);
-                  }}
-                  className="inline-flex items-center gap-1.5 rounded-lg border border-gray-200 dark:border-brand-mid-pink/20 bg-white/80 dark:bg-gray-900/60 px-2.5 py-1.5 text-[11px] font-medium text-gray-600 dark:text-gray-300 hover:border-brand-light-pink/40 transition-colors"
-                >
-                  Priority: {priorityFilter || 'All'}
-                  <ChevronDown className="h-3 w-3" />
-                </button>
-                {showPriorityDropdown && (
-                  <div className="absolute top-full mt-1 z-10 min-w-[140px] rounded-lg border border-gray-200 dark:border-brand-mid-pink/30 bg-white dark:bg-gray-800 shadow-lg py-1">
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setPriorityFilter(null);
-                        setShowPriorityDropdown(false);
-                      }}
-                      className="w-full text-left px-3 py-1.5 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                    >
-                      All
-                    </button>
-                    {['Low', 'Medium', 'High'].map((priority) => (
-                      <button
-                        key={priority}
-                        type="button"
-                        onClick={() => {
-                          setPriorityFilter(priority);
-                          setShowPriorityDropdown(false);
-                        }}
-                        className="w-full text-left px-3 py-1.5 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                      >
-                        {priority}
-                      </button>
-                    ))}
-                  </div>
-                )}
-              </div>
-
-              {hasActiveFilters && (
-                <button
-                  type="button"
-                  onClick={clearFilters}
-                  className="text-[11px] font-medium text-gray-400 hover:text-brand-light-pink transition-colors"
-                >
-                  Clear All
-                </button>
-              )}
-            </>
+          {/* My Tasks toggle */}
+          {currentUserId && (
+            <button
+              type="button"
+              onClick={() => setMyTasksOnly(!myTasksOnly)}
+              className={[
+                'inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[11px] font-medium transition-colors',
+                myTasksOnly
+                  ? 'bg-brand-light-pink/15 text-brand-light-pink'
+                  : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800/60',
+              ].join(' ')}
+            >
+              <User className="h-3 w-3" />
+              <span className="hidden sm:inline">My Tasks</span>
+            </button>
           )}
+
+          {/* Filters button with expandable dropdowns */}
+          <div className="relative">
+            <button
+              type="button"
+              onClick={() => {
+                setFiltersOpen(!filtersOpen);
+                if (filtersOpen) closeAllDropdowns();
+              }}
+              className={[
+                'inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[11px] font-medium transition-colors',
+                filtersOpen || hasActiveFilters
+                  ? 'bg-brand-light-pink/15 text-brand-light-pink'
+                  : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800/60',
+              ].join(' ')}
+            >
+              <SlidersHorizontal className="h-3 w-3" />
+              <span className="hidden sm:inline">Filters</span>
+              {activeFilterCount > 0 && (
+                <span className="h-4 min-w-4 rounded-full bg-brand-light-pink text-white text-[9px] font-bold flex items-center justify-center px-1">
+                  {activeFilterCount}
+                </span>
+              )}
+            </button>
+
+            {/* Filter panel dropdown */}
+            {filtersOpen && (
+              <div className="absolute right-0 top-full mt-1.5 z-20 w-[280px] rounded-xl border border-gray-200 dark:border-brand-mid-pink/20 bg-white dark:bg-gray-900 shadow-xl overflow-hidden">
+                <div className="p-3 space-y-3">
+                  <div className="flex items-center justify-between">
+                    <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">Filters</span>
+                    {hasActiveFilters && (
+                      <button type="button" onClick={clearFilters} className="text-[10px] font-medium text-brand-light-pink hover:text-brand-mid-pink transition-colors">
+                        Clear all
+                      </button>
+                    )}
+                  </div>
+
+                  {/* Status */}
+                  <div>
+                    <label className="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-1 block">Status</label>
+                    <div className="flex flex-wrap gap-1">
+                      <button
+                        type="button"
+                        onClick={() => setStatusFilter(null)}
+                        className={[
+                          'rounded-md px-2 py-1 text-[10px] font-medium transition-colors',
+                          !statusFilter
+                            ? 'bg-brand-light-pink/15 text-brand-light-pink'
+                            : 'bg-gray-100 dark:bg-gray-800/60 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700',
+                        ].join(' ')}
+                      >
+                        All
+                      </button>
+                      {columns.map((col) => (
+                        <button
+                          key={col.id}
+                          type="button"
+                          onClick={() => setStatusFilter(statusFilter === col.id ? null : col.id)}
+                          className={[
+                            'rounded-md px-2 py-1 text-[10px] font-medium transition-colors truncate max-w-[100px]',
+                            statusFilter === col.id
+                              ? 'bg-brand-light-pink/15 text-brand-light-pink'
+                              : 'bg-gray-100 dark:bg-gray-800/60 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700',
+                          ].join(' ')}
+                          title={col.name}
+                        >
+                          {col.name}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  {/* Priority */}
+                  <div>
+                    <label className="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-1 block">Priority</label>
+                    <div className="flex flex-wrap gap-1">
+                      <button
+                        type="button"
+                        onClick={() => setPriorityFilter(null)}
+                        className={[
+                          'rounded-md px-2 py-1 text-[10px] font-medium transition-colors',
+                          !priorityFilter
+                            ? 'bg-brand-light-pink/15 text-brand-light-pink'
+                            : 'bg-gray-100 dark:bg-gray-800/60 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700',
+                        ].join(' ')}
+                      >
+                        All
+                      </button>
+                      {['Low', 'Medium', 'High'].map((p) => (
+                        <button
+                          key={p}
+                          type="button"
+                          onClick={() => setPriorityFilter(priorityFilter === p ? null : p)}
+                          className={[
+                            'rounded-md px-2 py-1 text-[10px] font-medium transition-colors',
+                            priorityFilter === p
+                              ? p === 'High' ? 'bg-red-500/15 text-red-400' : p === 'Medium' ? 'bg-yellow-500/15 text-yellow-500' : 'bg-emerald-500/15 text-emerald-400'
+                              : 'bg-gray-100 dark:bg-gray-800/60 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700',
+                          ].join(' ')}
+                        >
+                          {p}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  {/* Assignee */}
+                  {assignees.length > 0 && (
+                    <div>
+                      <label className="text-[10px] font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-1 block">Assignee</label>
+                      <div className="flex flex-wrap gap-1 max-h-[100px] overflow-y-auto">
+                        <button
+                          type="button"
+                          onClick={() => setAssigneeFilter(null)}
+                          className={[
+                            'rounded-md px-2 py-1 text-[10px] font-medium transition-colors',
+                            !assigneeFilter
+                              ? 'bg-brand-light-pink/15 text-brand-light-pink'
+                              : 'bg-gray-100 dark:bg-gray-800/60 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700',
+                          ].join(' ')}
+                        >
+                          Any
+                        </button>
+                        {assignees.map((a) => (
+                          <button
+                            key={a}
+                            type="button"
+                            onClick={() => setAssigneeFilter(assigneeFilter === a ? null : a)}
+                            className={[
+                              'rounded-md px-2 py-1 text-[10px] font-medium transition-colors truncate max-w-[120px]',
+                              assigneeFilter === a
+                                ? 'bg-brand-light-pink/15 text-brand-light-pink'
+                                : 'bg-gray-100 dark:bg-gray-800/60 text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-700',
+                            ].join(' ')}
+                            title={a}
+                          >
+                            {a}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Columns visibility toggle */}
+          <div className="relative">
+            <button
+              type="button"
+              onClick={() => {
+                setShowColumnsDropdown(!showColumnsDropdown);
+                setShowSortDropdown(false);
+                setFiltersOpen(false);
+              }}
+              className={[
+                'inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[11px] font-medium transition-colors',
+                showColumnsDropdown
+                  ? 'bg-brand-light-pink/15 text-brand-light-pink'
+                  : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800/60',
+              ].join(' ')}
+            >
+              <Columns3 className="h-3 w-3" />
+              <span className="hidden sm:inline">Columns</span>
+            </button>
+            {showColumnsDropdown && (
+              <div className="absolute right-0 top-full mt-1.5 z-20 min-w-[180px] rounded-xl border border-gray-200 dark:border-brand-mid-pink/20 bg-white dark:bg-gray-900 shadow-xl overflow-hidden">
+                <div className="p-2 space-y-0.5">
+                  <span className="text-[10px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 px-2 py-1 block">Show / Hide</span>
+                  {columns.map((col) => (
+                    <label key={col.id} className="flex items-center gap-2 px-2 py-1.5 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800/60 cursor-pointer transition-colors">
+                      <input
+                        type="checkbox"
+                        checked={!hiddenColumns.has(col.id)}
+                        onChange={() => {
+                          setHiddenColumns((prev) => {
+                            const next = new Set(prev);
+                            if (next.has(col.id)) next.delete(col.id);
+                            else next.add(col.id);
+                            return next;
+                          });
+                        }}
+                        className="rounded border-gray-300 dark:border-gray-600 text-brand-light-pink focus:ring-brand-light-pink/50 h-3 w-3"
+                      />
+                      <span className="text-xs text-gray-700 dark:text-gray-300 truncate">{col.name}</span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Divider */}
+          <div className="h-5 w-px bg-gray-200 dark:bg-brand-mid-pink/15 shrink-0" />
+
+          {/* Task count badge */}
+          <div className="inline-flex items-center gap-1.5 rounded-lg bg-gray-100/80 dark:bg-gray-800/50 px-2.5 py-1.5 text-[11px] font-medium text-gray-500 dark:text-gray-400 shrink-0">
+            <Sparkles className="h-3 w-3 text-brand-light-pink" />
+            <span className="tabular-nums">
+              {displayedCount !== totalTaskCount ? (
+                <><span className="text-brand-light-pink">{displayedCount}</span> / {totalTaskCount}</>
+              ) : (
+                totalTaskCount
+              )}
+            </span>
+          </div>
         </div>
       </div>
 

--- a/app/[tenant]/(dashboard)/spaces/board/BoardTaskCard.tsx
+++ b/app/[tenant]/(dashboard)/spaces/board/BoardTaskCard.tsx
@@ -24,6 +24,8 @@ export interface BoardTaskCardProps {
   index: number;
   onClick?: (task: BoardTask) => void;
   onTitleUpdate?: (task: BoardTask, newTitle: string) => void;
+  columnTitle?: string;
+  onMarkFinal?: (taskId: string) => void;
 }
 
 const PRIORITY_STYLES: Record<string, string> = {

--- a/app/[tenant]/(dashboard)/spaces/board/index.ts
+++ b/app/[tenant]/(dashboard)/spaces/board/index.ts
@@ -1,6 +1,6 @@
 export { BoardTaskCard, type BoardTask, type BoardTaskCardProps } from './BoardTaskCard';
 export { BoardColumn, type BoardColumnData } from './BoardColumn';
-export { BoardLayout, type BoardTab, type BoardFilters } from './BoardLayout';
+export { BoardLayout, type BoardTab, type BoardFilters, type SortOption } from './BoardLayout';
 export { TaskDetailModal } from './TaskDetailModal';
 export { EditableField } from './EditableField';
 export { SelectField } from './SelectField';

--- a/app/api/spaces/[spaceId]/boards/[boardId]/items/[itemId]/mark-final/route.ts
+++ b/app/api/spaces/[spaceId]/boards/[boardId]/items/[itemId]/mark-final/route.ts
@@ -1,0 +1,187 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+import { prisma } from '@/lib/database';
+import { publishBoardEvent } from '@/lib/ably';
+
+type Params = {
+  params: Promise<{ spaceId: string; boardId: string; itemId: string }>;
+};
+
+/* ------------------------------------------------------------------ */
+/*  POST /api/spaces/:spaceId/boards/:boardId/items/:itemId/mark-final */
+/* ------------------------------------------------------------------ */
+
+export async function POST(req: NextRequest, { params }: Params) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const { spaceId, boardId, itemId } = await params;
+
+    // 1. Fetch the board item with media and column info
+    const item = await prisma.boardItem.findUnique({
+      where: { id: itemId },
+      include: {
+        media: true,
+        column: {
+          include: {
+            board: {
+              include: {
+                columns: { orderBy: { position: 'asc' } },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    if (!item) {
+      return NextResponse.json({ error: 'Item not found' }, { status: 404 });
+    }
+
+    // 2. Validate item is in a "Ready to Deploy"-named column
+    const currentColumnName = item.column.name.toLowerCase();
+    if (!currentColumnName.includes('ready to deploy')) {
+      return NextResponse.json(
+        { error: 'Item must be in a "Ready to Deploy" column' },
+        { status: 400 },
+      );
+    }
+
+    // 3. Find the "Posted" column in the same board
+    const postedColumn = item.column.board.columns.find(
+      (c) => c.name.toLowerCase() === 'posted',
+    );
+
+    if (!postedColumn) {
+      return NextResponse.json(
+        { error: 'No "Posted" column found in this board' },
+        { status: 400 },
+      );
+    }
+
+    // 4. Check if a gallery item already exists for this board item
+    const existingGallery = await prisma.gallery_items.findFirst({
+      where: { boardItemId: itemId },
+    });
+
+    if (existingGallery) {
+      return NextResponse.json(
+        { error: 'This item has already been marked as final' },
+        { status: 409 },
+      );
+    }
+
+    // 5. Extract metadata for gallery entry
+    const meta = (item.metadata ?? {}) as Record<string, unknown>;
+    const firstMedia = item.media[0];
+    const previewUrl =
+      firstMedia?.url ||
+      (meta.driveLink as string) ||
+      '';
+
+    // Build tags from metadata
+    const tags: string[] = [];
+    if (Array.isArray(meta.contentTags)) {
+      tags.push(...(meta.contentTags as string[]));
+    }
+    if (meta.requestType && typeof meta.requestType === 'string') {
+      tags.push(meta.requestType);
+    }
+    if (meta.contentStyle && typeof meta.contentStyle === 'string') {
+      tags.push(meta.contentStyle);
+    }
+
+    // Determine content type
+    const contentType =
+      (meta.contentType as string) ||
+      (meta.requestType as string) ||
+      'CUSTOM';
+
+    // Look up model by name if provided
+    let modelId: string | null = null;
+    if (meta.model && typeof meta.model === 'string') {
+      const model = await prisma.of_models.findFirst({
+        where: {
+          name: { equals: meta.model as string, mode: 'insensitive' },
+        },
+        select: { id: true },
+      });
+      modelId = model?.id ?? null;
+    }
+
+    // 6. Move item to "Posted" column and create gallery entry in a transaction
+    const [updatedItem, galleryItem] = await prisma.$transaction([
+      prisma.boardItem.update({
+        where: { id: itemId },
+        data: { columnId: postedColumn.id },
+      }),
+      prisma.gallery_items.create({
+        data: {
+          title: item.title,
+          contentType,
+          platform: 'OF',
+          pricingAmount: meta.price != null ? Number(meta.price) : null,
+          captionUsed: (meta.caption as string) ?? null,
+          tags,
+          previewUrl: previewUrl || '/placeholder-gallery.png',
+          originalAssetUrl: (meta.driveLink as string) ?? null,
+          postedAt: new Date(),
+          origin: 'board',
+          sourceId: item.id,
+          boardItemId: item.id,
+          organizationId: item.organizationId,
+          modelId,
+          createdBy: userId,
+        },
+      }),
+    ]);
+
+    // 7. Create history entry for the column move
+    await prisma.boardItemHistory.create({
+      data: {
+        itemId: item.id,
+        userId,
+        action: 'MOVED',
+        field: 'column',
+        oldValue: item.column.name,
+        newValue: postedColumn.name,
+      },
+    });
+
+    // Publish realtime event
+    const senderTab = req.headers.get('x-tab-id') ?? undefined;
+    try {
+      publishBoardEvent(boardId, 'item.updated', {
+        userId,
+        entityId: item.id,
+        tabId: senderTab,
+      });
+    } catch (_) {
+      // Ably not configured
+    }
+
+    return NextResponse.json({
+      item: {
+        id: updatedItem.id,
+        columnId: updatedItem.columnId,
+        title: updatedItem.title,
+      },
+      galleryItem: {
+        id: galleryItem.id,
+        title: galleryItem.title,
+        contentType: galleryItem.contentType,
+        platform: galleryItem.platform,
+        previewUrl: galleryItem.previewUrl,
+      },
+    });
+  } catch (error) {
+    console.error('Error marking item as final:', error);
+    return NextResponse.json(
+      { error: 'Failed to mark item as final' },
+      { status: 500 },
+    );
+  }
+}

--- a/components/content-submission/ContentStyleSelector.tsx
+++ b/components/content-submission/ContentStyleSelector.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FileText, BarChart3, Gamepad2, DollarSign, Package } from 'lucide-react';
+import { FileText, BarChart3, Gamepad2, DollarSign, Package, Crown, Disc3, HelpCircle } from 'lucide-react';
 
 const CONTENT_STYLES = [
   {
@@ -38,55 +38,168 @@ const CONTENT_STYLES = [
     icon: Package,
     color: 'from-indigo-500 to-purple-500',
   },
+  {
+    id: 'vip',
+    name: 'VIP',
+    description: 'Exclusive VIP content for top subscribers',
+    icon: Crown,
+    color: 'from-amber-500 to-orange-500',
+  },
 ] as const;
+
+export interface ContentStyleFields {
+  gameType: string;
+  gifUrl: string;
+  gameNotes: string;
+  originalPollReference: string;
+}
 
 interface ContentStyleSelectorProps {
   value: string;
   onChange: (value: string) => void;
   submissionType: 'otp' | 'ptr';
+  styleFields: ContentStyleFields;
+  onStyleFieldsChange: (fields: Partial<ContentStyleFields>) => void;
 }
 
-export function ContentStyleSelector({ value, onChange, submissionType }: ContentStyleSelectorProps) {
-  // Filter styles based on submission type (optional filtering)
-  const availableStyles = CONTENT_STYLES; // Show all for now
+export function ContentStyleSelector({
+  value,
+  onChange,
+  submissionType,
+  styleFields,
+  onStyleFieldsChange,
+}: ContentStyleSelectorProps) {
+  const availableStyles = CONTENT_STYLES;
+
+  const showGameFields = value === 'game';
+  const showPpvBundleFields = value === 'ppv' || value === 'bundle';
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-      {availableStyles.map((style) => {
-        const Icon = style.icon;
-        const isSelected = value === style.id;
+    <div className="space-y-6">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {availableStyles.map((style) => {
+          const Icon = style.icon;
+          const isSelected = value === style.id;
 
-        return (
-          <button
-            key={style.id}
-            type="button"
-            onClick={() => onChange(style.id)}
-            className={`
-              relative p-4 rounded-xl border-2 transition-all text-left
-              ${isSelected
-                ? 'border-brand-light-pink bg-brand-light-pink/10'
-                : 'border-gray-200 dark:border-gray-700 hover:border-brand-light-pink/50'
-              }
-            `}
-          >
-            <div className="flex items-start space-x-3">
-              <div className={`
-                w-10 h-10 rounded-lg bg-gradient-to-br ${style.color} flex items-center justify-center flex-shrink-0
-              `}>
-                <Icon className="w-5 h-5 text-white" />
+          return (
+            <button
+              key={style.id}
+              type="button"
+              onClick={() => onChange(style.id)}
+              className={`
+                relative p-4 rounded-xl border-2 transition-all text-left
+                ${isSelected
+                  ? 'border-brand-light-pink bg-brand-light-pink/10'
+                  : 'border-gray-200 dark:border-gray-700 hover:border-brand-light-pink/50'
+                }
+              `}
+            >
+              {isSelected && (
+                <div className="absolute top-2 right-2">
+                  <svg className="w-5 h-5 text-brand-light-pink" fill="currentColor" viewBox="0 0 20 20">
+                    <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                  </svg>
+                </div>
+              )}
+              <div className="flex items-start space-x-3">
+                <div className={`
+                  w-10 h-10 rounded-lg bg-gradient-to-br ${style.color} flex items-center justify-center flex-shrink-0
+                `}>
+                  <Icon className="w-5 h-5 text-white" />
+                </div>
+                <div className="flex-1">
+                  <h4 className="font-semibold text-gray-900 dark:text-white">
+                    {style.name}
+                  </h4>
+                  <p className="text-sm text-gray-600 dark:text-gray-400 mt-0.5">
+                    {style.description}
+                  </p>
+                </div>
               </div>
-              <div className="flex-1">
-                <h4 className="font-semibold text-gray-900 dark:text-white">
-                  {style.name}
-                </h4>
-                <p className="text-sm text-gray-600 dark:text-gray-400 mt-0.5">
-                  {style.description}
-                </p>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Game Post Specific Fields */}
+      {showGameFields && (
+        <div className="animate-fade-in-up rounded-xl border border-brand-dark-pink/30 bg-gradient-to-br from-zinc-900/80 to-zinc-800/40 p-6 space-y-5">
+          <div className="flex items-center gap-2.5">
+            <Disc3 className="w-5 h-5 text-brand-light-pink" />
+            <h3 className="text-lg font-semibold text-white">Game Post Specific Fields</h3>
+          </div>
+
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-white mb-1.5">Game Type</label>
+              <input
+                type="text"
+                value={styleFields.gameType}
+                onChange={(e) => onStyleFieldsChange({ gameType: e.target.value })}
+                placeholder="e.g. Spin the Wheel, Tip Game, Dice Roll..."
+                className="w-full px-4 py-2.5 bg-zinc-800/60 border border-zinc-700/50 rounded-lg text-white placeholder-zinc-500 focus:outline-none focus:border-brand-light-pink/50 focus:ring-1 focus:ring-brand-light-pink/30 transition-colors"
+              />
+              <p className="text-xs text-zinc-500 mt-1.5">Enter the type or name of the game</p>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-white mb-1.5">GIF URL</label>
+              <input
+                type="text"
+                value={styleFields.gifUrl}
+                onChange={(e) => onStyleFieldsChange({ gifUrl: e.target.value })}
+                placeholder="https://giphy.com/... or https://i.imgur.com/..."
+                className="w-full px-4 py-2.5 bg-zinc-800/60 border border-zinc-700/50 rounded-lg text-white placeholder-zinc-500 focus:outline-none focus:border-brand-light-pink/50 focus:ring-1 focus:ring-brand-light-pink/30 transition-colors"
+              />
+              <p className="text-xs text-zinc-500 mt-1.5">Link to a GIF for this game post</p>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-white mb-1.5">Notes</label>
+              <textarea
+                value={styleFields.gameNotes}
+                onChange={(e) => onStyleFieldsChange({ gameNotes: e.target.value })}
+                placeholder="Add any additional notes or context for the flyer team..."
+                rows={3}
+                className="w-full px-4 py-2.5 bg-zinc-800/60 border border-zinc-700/50 rounded-lg text-white placeholder-zinc-500 focus:outline-none focus:border-brand-light-pink/50 focus:ring-1 focus:ring-brand-light-pink/30 transition-colors resize-y"
+              />
+              <p className="text-xs text-zinc-500 mt-1.5">Additional notes or instructions for the team</p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* PPV/Bundle Specific Fields */}
+      {showPpvBundleFields && (
+        <div className="animate-fade-in-up rounded-xl border border-purple-500/30 bg-gradient-to-br from-purple-950/40 to-zinc-900/60 p-6 space-y-5">
+          <div className="flex items-center gap-2.5">
+            <DollarSign className="w-5 h-5 text-purple-400" />
+            <h3 className="text-lg font-semibold text-white">PPV/Bundle Specific Fields</h3>
+          </div>
+
+          <div>
+            <div className="flex items-center gap-1.5 mb-1.5">
+              <label className="block text-sm font-medium text-white">Original Poll Reference</label>
+              <div className="group relative">
+                <HelpCircle className="w-4 h-4 text-zinc-500 cursor-help" />
+                <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-2 bg-zinc-800 border border-zinc-700 rounded-lg text-xs text-zinc-300 w-56 opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity z-10">
+                  Reference the original poll this PPV/Bundle is based on to help the team track content lineage.
+                </div>
               </div>
             </div>
-          </button>
-        );
-      })}
+            <textarea
+              value={styleFields.originalPollReference}
+              onChange={(e) => onStyleFieldsChange({ originalPollReference: e.target.value })}
+              placeholder="Reference to original poll this PPV is based on"
+              rows={3}
+              className="w-full px-4 py-2.5 bg-purple-900/20 border border-purple-500/20 rounded-lg text-white placeholder-zinc-500 focus:outline-none focus:border-purple-400/50 focus:ring-1 focus:ring-purple-400/30 transition-colors resize-y"
+            />
+            <p className="text-xs text-zinc-500 mt-1.5">
+              Include any poll IDs, dates, or references that connect this PPV/Bundle to the original poll content
+            </p>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/components/content-submission/SubmissionForm.tsx
+++ b/components/content-submission/SubmissionForm.tsx
@@ -13,7 +13,8 @@ import { getMetadataDefaults } from '@/lib/spaces/template-metadata';
 import { generateSteps, ensureValidStep } from '@/lib/content-submission/step-generator';
 import { ProgressIndicator } from './ProgressIndicator';
 import { useKeyboardShortcut } from '@/lib/hooks/useKeyboardShortcut';
-import { Loader2, Check, ChevronRight, ChevronLeft, Sparkles, AlertTriangle, Upload, X, Image as ImageIcon, Video as VideoIcon, File as FileIcon, FileText } from 'lucide-react';
+import { Loader2, Check, ChevronRight, ChevronLeft, Sparkles, AlertTriangle, Upload, X, Image as ImageIcon, Video as VideoIcon, File as FileIcon, FileText, Gamepad2, DollarSign } from 'lucide-react';
+import type { ContentStyleFields } from './ContentStyleSelector';
 import { useSpaceMembers } from '@/lib/hooks/useSpaceMembers.query';
 import { useQuery } from '@tanstack/react-query';
 import type { UseFormWatch } from 'react-hook-form';
@@ -63,6 +64,16 @@ export const SubmissionForm = memo(function SubmissionForm({
   const [selectedSpaces, setSelectedSpaces] = useState<Map<string, Space>>(new Map());
   const [assigneeId, setAssigneeId] = useState<string | undefined>(undefined);
   const [contentStyle, setContentStyle] = useState<string>('normal');
+  const [styleFields, setStyleFields] = useState<ContentStyleFields>({
+    gameType: '',
+    gifUrl: '',
+    gameNotes: '',
+    originalPollReference: '',
+  });
+
+  const handleStyleFieldsChange = useCallback((fields: Partial<ContentStyleFields>) => {
+    setStyleFields((prev) => ({ ...prev, ...fields }));
+  }, []);
 
   const {
     register,
@@ -225,6 +236,16 @@ export const SubmissionForm = memo(function SubmissionForm({
         metadata: {
           submissionType: data.submissionType,
           contentStyle,
+          // Game-specific fields
+          ...(contentStyle === 'game' ? {
+            gameType: styleFields.gameType || undefined,
+            gifUrl: styleFields.gifUrl || undefined,
+            gameNotes: styleFields.gameNotes || undefined,
+          } : {}),
+          // PPV/Bundle-specific fields
+          ...(contentStyle === 'ppv' || contentStyle === 'bundle' ? {
+            originalPollReference: styleFields.originalPollReference || undefined,
+          } : {}),
           pricingCategory: data.pricingCategory,
           pageType: (meta as Record<string, unknown>).pageType || 'ALL_PAGES',
           contentType: data.contentType,
@@ -284,6 +305,16 @@ export const SubmissionForm = memo(function SubmissionForm({
           metadata: {
             ...meta,
             contentStyle,
+            // Game-specific fields
+            ...(contentStyle === 'game' ? {
+              gameType: styleFields.gameType || undefined,
+              gifUrl: styleFields.gifUrl || undefined,
+              gameNotes: styleFields.gameNotes || undefined,
+            } : {}),
+            // PPV/Bundle-specific fields
+            ...(contentStyle === 'ppv' || contentStyle === 'bundle' ? {
+              originalPollReference: styleFields.originalPollReference || undefined,
+            } : {}),
             boardItemId: primaryItem.itemId,
             targetSpaces: createdItems.map((i) => ({ spaceId: i.spaceId, boardId: i.boardId, itemId: i.itemId })),
             submitStatus: 'SUBMITTED',
@@ -453,7 +484,15 @@ export const SubmissionForm = memo(function SubmissionForm({
           allowStepNavigation={true}
         />
 
-        <form onSubmit={handleSubmit(onSubmit)}>
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          onKeyDown={(e) => {
+            // Prevent Enter key from auto-submitting when not on the final step
+            if (e.key === 'Enter' && currentStep < steps.length - 1 && !(e.target instanceof HTMLTextAreaElement)) {
+              e.preventDefault();
+            }
+          }}
+        >
           {/* Step Content — CSS transitions instead of spring physics */}
           <div
             key={currentStepInfo?.id}
@@ -482,6 +521,8 @@ export const SubmissionForm = memo(function SubmissionForm({
                     value={contentStyle}
                     onChange={setContentStyle}
                     submissionType={submissionType === 'OTP_PTR' ? 'otp' : 'ptr'}
+                    styleFields={styleFields}
+                    onStyleFieldsChange={handleStyleFieldsChange}
                   />
                 </StepContent>
               )}
@@ -521,6 +562,7 @@ export const SubmissionForm = memo(function SubmissionForm({
                     spaceId={primarySpace?.id}
                     pendingFilesCount={pendingFiles.length}
                     contentStyle={contentStyle}
+                    styleFields={styleFields}
                   />
                 </StepContent>
               )}
@@ -744,6 +786,7 @@ const ReviewStep = memo(function ReviewStep({
   spaceId,
   pendingFilesCount,
   contentStyle,
+  styleFields,
 }: {
   selectedSpaces: Space[];
   submissionType: string;
@@ -753,6 +796,7 @@ const ReviewStep = memo(function ReviewStep({
   spaceId?: string;
   pendingFilesCount: number;
   contentStyle: string;
+  styleFields: ContentStyleFields;
 }) {
   const { data: spaceMembers } = useSpaceMembers(spaceId);
   const { data: orgMembers } = useQuery({
@@ -863,6 +907,46 @@ const ReviewStep = memo(function ReviewStep({
               <p className="text-xs text-zinc-500 mb-1">Content Style</p>
               <p className="text-white font-medium capitalize">{contentStyle}</p>
             </div>
+            {/* Game-specific review fields */}
+            {contentStyle === 'game' && (styleFields.gameType || styleFields.gifUrl || styleFields.gameNotes) && (
+              <div className="col-span-2 bg-orange-500/5 border border-orange-500/20 rounded-lg p-4 space-y-2">
+                <div className="flex items-center gap-1.5 mb-2">
+                  <Gamepad2 className="w-3.5 h-3.5 text-orange-400" />
+                  <p className="text-xs font-medium text-orange-400">Game Post Details</p>
+                </div>
+                {styleFields.gameType && (
+                  <div>
+                    <p className="text-xs text-zinc-500">Game Type</p>
+                    <p className="text-white text-sm">{styleFields.gameType}</p>
+                  </div>
+                )}
+                {styleFields.gifUrl && (
+                  <div>
+                    <p className="text-xs text-zinc-500">GIF URL</p>
+                    <p className="text-brand-blue text-sm truncate">{styleFields.gifUrl}</p>
+                  </div>
+                )}
+                {styleFields.gameNotes && (
+                  <div>
+                    <p className="text-xs text-zinc-500">Notes</p>
+                    <p className="text-white text-sm">{styleFields.gameNotes}</p>
+                  </div>
+                )}
+              </div>
+            )}
+            {/* PPV/Bundle-specific review fields */}
+            {(contentStyle === 'ppv' || contentStyle === 'bundle') && styleFields.originalPollReference && (
+              <div className="col-span-2 bg-purple-500/5 border border-purple-500/20 rounded-lg p-4">
+                <div className="flex items-center gap-1.5 mb-2">
+                  <DollarSign className="w-3.5 h-3.5 text-purple-400" />
+                  <p className="text-xs font-medium text-purple-400">PPV/Bundle Details</p>
+                </div>
+                <div>
+                  <p className="text-xs text-zinc-500">Original Poll Reference</p>
+                  <p className="text-white text-sm">{styleFields.originalPollReference}</p>
+                </div>
+              </div>
+            )}
             <div>
               <p className="text-xs text-zinc-500 mb-1">Pricing Tier</p>
               <p className="text-white font-medium">

--- a/components/ui/SearchableDropdown.tsx
+++ b/components/ui/SearchableDropdown.tsx
@@ -253,7 +253,7 @@ export const SearchableDropdown = memo(function SearchableDropdown({
                   const isActive = idx === activeIndex;
                   return (
                     <button
-                      key={option}
+                      key={`${option}-${idx}`}
                       type="button"
                       data-option
                       role="option"

--- a/lib/constants/gallery.ts
+++ b/lib/constants/gallery.ts
@@ -49,6 +49,7 @@ export type GalleryPlatform = (typeof GALLERY_PLATFORMS)[number];
  */
 export const GALLERY_ORIGINS = [
   "pipeline", // Created through Content Flow pipeline
+  "board", // Created from board item (Mark as Final)
   "manual", // Manually entered
   "import", // Imported from external source
   "migration", // Migrated from another system

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1564,6 +1564,7 @@ model BoardItem {
   comments       BoardItemComment[]
   history        BoardItemHistory[]
   media          BoardItemMedia[]
+  galleryItem    gallery_items?
   column         BoardColumn        @relation(fields: [columnId], references: [id], onDelete: Cascade)
   organization   Organization?      @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 
@@ -1914,6 +1915,7 @@ model gallery_items {
   pricingAmount    Decimal?      @db.Decimal(10, 2)
   modelId          String?
   pipelineItemId   String?       @unique
+  boardItemId      String?       @unique
   captionUsed      String?
   revenue          Decimal       @default(0) @db.Decimal(12, 2)
   salesCount       Int           @default(0)
@@ -1927,6 +1929,7 @@ model gallery_items {
   createdAt        DateTime      @default(now())
   updatedAt        DateTime      @updatedAt
   createdBy        String?
+  boardItem        BoardItem?    @relation(fields: [boardItemId], references: [id])
   model            of_models?    @relation(fields: [modelId], references: [id])
   organization     Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
 


### PR DESCRIPTION
Adds a "Mark as Final" button on board cards in the "Ready to Deploy" column that moves items to "Posted" and creates a linked gallery entry with mapped metadata (content type, price, tags, media preview).

- New API route: mark-final with gallery item creation and duplicate prevention
- Board card/column props for column-aware actions
- Drag-to-scroll on board view, SearchableDropdown key fix
- Content style selector and submission form OTP field improvements
- Prisma schema: boardItemId on gallery_items for board-gallery linking