### PR TITLE
feat: redesign board cards and OTP/PTR task detail modal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,103 @@
-# Creative Ink AI - Development Guidelines
+# CLAUDE.md
 
-**No Need to add another guidelines unless stated**
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 **CRITICAL: Always reference these guidelines when creating or updating UI components.**
 
 ---
 
-## 📦 Data Fetching with TanStack Query
+## Commands
+
+| Command | Description |
+|---|---|
+| `npm run dev` | Next.js dev server with Turbopack |
+| `npm run build` | `prisma generate && next build` |
+| `npm run lint` | ESLint |
+| `npm run remotion:studio` | Launch Remotion Studio UI |
+| `npm run remotion:render` | Render Remotion compositions |
+| `npx prisma generate` | Regenerate Prisma client (after schema changes) |
+| `npx prisma db push` | Push schema changes to database |
+
+---
+
+## Architecture
+
+### Tech Stack
+
+- **Framework**: Next.js (App Router) with React 19, TypeScript
+- **Styling**: Tailwind CSS v4 (CSS-based config in `globals.css`, NO `tailwind.config.ts`)
+- **Auth**: Clerk (`@clerk/nextjs` v6)
+- **Database**: PostgreSQL via Neon (`@neondatabase/serverless`) + Prisma ORM
+- **Data fetching**: TanStack Query (React Query) — all hooks in `lib/hooks/*.query.ts`
+- **Client state**: Zustand (UI state in `stores/`, editor state in `stores/video-editor-store.ts`)
+- **UI components**: shadcn/ui (Radix primitives, configured in `components.json`)
+- **Video/GIF**: Remotion (`remotion/` compositions, `@remotion/player`)
+- **Storage**: AWS S3 (CDN at `cdn.tastycreative.xyz`), Cloudinary for thumbnails
+- **AI compute**: RunPod serverless (generation + training), SeeDream API, Kling API
+- **Payments**: Stripe (subscriptions, credits, add-on slots)
+- **tRPC**: Used only for training job procedures; REST API routes are the primary pattern
+- **Email**: Resend with React Email templates
+- **Path alias**: `@/` maps to project root
+
+### Multi-Tenancy & Routing
+
+Routes are structured as `app/[tenant]/(dashboard)/...` where `[tenant]` is either an **org slug** or **personal username**.
+
+**Flow**: Clerk middleware protects `/:tenant/*` routes → `app/[tenant]/layout.tsx` verifies access via `/api/organizations/verify-slug` → redirects if unauthorized. The `/dashboard` page resolves the current org and redirects to `/${slug}/dashboard`.
+
+**Key files**:
+- `middleware.ts` — Clerk route protection; public API routes (webhooks, RunPod callbacks, cron, onboarding-public) bypass auth
+- `app/[tenant]/layout.tsx` — client-side tenant guard
+- `lib/organizationAuth.ts` — server-side org membership/role checks
+- `lib/adminAuth.ts` — super-admin checks (`User.role === 'SUPER_ADMIN'`)
+
+### Permission System
+
+`lib/hooks/usePermissions.query.ts` defines 80+ feature flags fetched from `/api/features`. Permissions derive from `SubscriptionPlan.features` (JSON) merged with `CustomOrganizationPermission.permissions`.
+
+- `lib/planFeatures.ts` — central `PLAN_FEATURES` array (key, label, category, type, defaultValue)
+- `lib/permissions/routePermissions.ts` — maps URL paths to permission keys
+- `components/PermissionGuard.tsx` — conditional UI rendering wrapper
+
+### Database
+
+- **Schema**: `prisma/schema.prisma`
+- **Generated client**: `lib/generated/prisma/`
+- **Singleton**: `lib/database.ts` — `globalForPrisma.prisma` with exponential-backoff retry wrapper
+- Always call `ensureUserExists(clerkId)` before user-scoped DB operations
+
+### Major Feature Areas
+
+| Feature | Route | Key Components |
+|---|---|---|
+| AI Generation | `workspace/generate-content/*` | RunPod/SeeDream/Kling endpoints, SSE progress |
+| GIF Maker | `gif-maker/` | Remotion player, Zustand editor store, canvas export |
+| OF Models | `of-models/` | Model profiles, stats, assets |
+| Spaces (Kanban) | `spaces/` | Workspaces, boards, columns, items with history/comments |
+| Content Submissions | `submissions/` | Multi-step form, S3 uploads, space linking |
+| Content Studio | `workspace/content-studio/*` | Calendar, feed posts, stories, reels, pipeline |
+| Vault | `workspace/vault/` | Hierarchical folders, S3-backed media |
+| LoRA Training | `workspace/train-lora/` | RunPod training, job tracking, model sharing |
+| Billing | `billing/` | Stripe subscriptions, credits, add-on slots |
+| Admin | `admin/*` | Super-admin panel (analytics, orgs, users, plans) |
+
+### GIF Maker Specifics
+
+- **Clip types**: `VideoClip | ImageClip` discriminated union via `type: "video" | "image"`
+- **Collage system**: 12 `CollageLayout` presets (split, grid, PiP); clips use `slotIndex` for slot assignment
+- **Store**: `stores/video-editor-store.ts` — full editor state (clips, overlays, transitions, playback, export)
+- **Remotion**: `ClipEditor` composition renders multi-clip timelines; `VideoToGif` for simple conversions
+- **Export**: `lib/gif-maker/gif-renderer.ts` — canvas-based capture for collage/mixed, fast video path for video-only
+
+### API Routes
+
+REST routes live in `app/api/`. Major groups: `billing/`, `organizations/`, `spaces/`, `content-submissions/`, `generate/`, `webhook/` (RunPod callbacks), `webhooks/` (Stripe), `models/`, `of-models/`, `vault/`, `captions/`, `feed/`, `admin/`.
+
+Public API routes bypass Clerk: webhooks, RunPod callbacks, proxy routes, cron (protected by `CRON_SECRET`), onboarding-public.
+
+---
+
+## Data Fetching with TanStack Query
 
 ### Source of Truth
 
@@ -14,7 +105,7 @@
 
 This project uses **TanStack Query (React Query)** for all data fetching and state management.
 
-### ✅ Correct Usage
+### Correct Usage
 
 Always create custom hooks in `lib/hooks/` with the `.query.ts` suffix:
 
@@ -62,7 +153,7 @@ function MyComponent() {
 }
 ```
 
-### ❌ Wrong Usage
+### Wrong Usage
 
 ```tsx
 // DON'T use useState + useEffect for API calls
@@ -96,7 +187,6 @@ export function useUpdateData() {
       return response.json();
     },
     onSuccess: () => {
-      // Invalidate and refetch related queries
       queryClient.invalidateQueries({ queryKey: ['data'] });
     },
   });
@@ -123,42 +213,31 @@ export function useTransactions(enabled: boolean = true) {
 
 ---
 
-## 🎨 Color System
-
-## 🎨 Brand Colors
+## Color System & Brand Colors
 
 ### Source of Truth
 
-**Location**: [`lib/colors.ts`](lib/colors.ts)
+**Location**: [`lib/colors.ts`](lib/colors.ts) and [`app/globals.css`](app/globals.css) (lines 51-56)
 
 ```typescript
 const brandColors = {
-  'brand-light-pink': '#F774B9',  // Primary accent - vibrant and energetic
-  'brand-dark-pink': '#E1518E',   // Secondary accent - deeper and more intense
-  'brand-mid-pink': '#EC67A1',    // Balanced pink tone - versatile
-  'brand-blue': '#5DC3F8',        // Cool accent - fresh and modern
-  'brand-off-white': '#F8F8F8',   // Neutral background - soft and clean
+  'brand-light-pink': '#F774B9',  // Primary accent
+  'brand-dark-pink': '#E1518E',   // Secondary accent
+  'brand-mid-pink': '#EC67A1',    // Balanced pink
+  'brand-blue': '#5DC3F8',        // Cool accent
+  'brand-off-white': '#F8F8F8',   // Neutral background
 };
 ```
 
-### Tailwind Configuration
-
-**Location**: [`app/globals.css`](app/globals.css) (lines 46-51)
-
-This project uses **Tailwind CSS v4** with CSS-based configuration (NO `tailwind.config.ts`).
-
----
-
-## ✅ Correct Usage
+### Correct Usage
 
 ```tsx
 // Use Tailwind brand color classes
 <div className="bg-brand-light-pink text-brand-blue border-brand-dark-pink">
 <button className="hover:bg-brand-mid-pink text-brand-off-white">
-<span className="bg-brand-blue">
 ```
 
-## ❌ Wrong Usage
+### Wrong Usage
 
 ```tsx
 // DON'T use arbitrary hex values
@@ -168,35 +247,26 @@ This project uses **Tailwind CSS v4** with CSS-based configuration (NO `tailwind
 
 ---
 
-## 🌓 Dark Mode Support
+## Dark Mode Support
 
 Always add dark mode variants using brand colors:
 
 ```tsx
-// Use brand colors for dark backgrounds
 <div className="bg-white dark:bg-brand-dark-pink/10">
 <p className="text-gray-900 dark:text-brand-off-white">
 <div className="border-gray-200 dark:border-brand-mid-pink/30">
 
-// Brand color accents in dark mode
+// Interactive elements
 <button className="bg-brand-light-pink hover:bg-brand-mid-pink dark:bg-brand-dark-pink dark:hover:bg-brand-mid-pink">
-<span className="text-brand-blue dark:text-brand-light-pink">
-
-// Gradient overlays with brand colors
-<div className="bg-gradient-to-r from-brand-light-pink/10 via-brand-blue/10 to-brand-dark-pink/10
-                dark:from-brand-dark-pink/5 dark:via-brand-blue/5 dark:to-brand-mid-pink/5">
 
 // Cards and surfaces
 <div className="bg-white dark:bg-gray-900/50 border border-gray-200 dark:border-brand-mid-pink/20">
-<div className="bg-gray-50 dark:bg-brand-dark-pink/5">
 ```
 
 ### Dark Mode Brand Color Usage
 
-- **Backgrounds**: Use `brand-dark-pink/10` or `brand-dark-pink/5` for subtle brand presence
-- **Accents**: Use `brand-light-pink`, `brand-mid-pink`, `brand-blue` for interactive elements
-- **Text**: Use `brand-off-white` for primary text, `brand-light-pink` for highlights
-- **Borders**: Use `brand-mid-pink/20` or `brand-mid-pink/30` for subtle definition
+- **Backgrounds**: `brand-dark-pink/10` or `brand-dark-pink/5` for subtle brand presence
+- **Accents**: `brand-light-pink`, `brand-mid-pink`, `brand-blue` for interactive elements
+- **Text**: `brand-off-white` for primary text, `brand-light-pink` for highlights
+- **Borders**: `brand-mid-pink/20` or `brand-mid-pink/30` for subtle definition
 - **Gradients**: Combine brand colors with low opacity for ambient effects
-
----

--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/ModelOnboardingTaskCard.tsx
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/ModelOnboardingTaskCard.tsx
@@ -64,22 +64,22 @@ export const ModelOnboardingTaskCard = memo(function ModelOnboardingTaskCard({
             {...provided.dragHandleProps}
             onClick={() => { if (!editing) onClick?.(task); }}
             className={[
-              'group/card relative rounded-lg cursor-pointer select-none',
-              'bg-white dark:bg-[#111016] border',
+              'group/card relative rounded-xl cursor-pointer select-none',
+              'bg-white/[0.03] dark:bg-[#1a2237]/80 backdrop-blur-sm border border-[#2a3450]/60',
               snapshot.isDragging
-                ? 'shadow-2xl shadow-black/40 border-brand-mid-pink/50 ring-1 ring-brand-light-pink/20'
-                : 'border-gray-200 dark:border-white/[0.06] hover:border-gray-300 dark:hover:border-white/[0.12]',
-              'transition-colors duration-150',
+                ? 'shadow-2xl shadow-black/40 border-brand-mid-pink/50 ring-1 ring-brand-light-pink/20 scale-[1.02]'
+                : 'hover:bg-white/[0.06] dark:hover:bg-[#1a2237] hover:border-[#2a3450] hover:shadow-lg hover:shadow-black/20 hover:-translate-y-0.5',
+              'transition-all duration-200',
             ].join(' ')}
           >
             <div className="px-3.5 pt-3 pb-2.5">
               {/* Row 1: key + platform tag */}
               <div className="flex items-center gap-1.5 mb-2">
-                <span className="text-xs font-mono font-semibold text-gray-500 dark:text-gray-400 tracking-wide">
+                <span className="inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[11px] font-bold tracking-wide bg-teal-500/15 border-teal-500/25 text-teal-400 font-mono">
                   {task.taskKey}
                 </span>
                 {platform && (
-                  <span className="text-[10px] font-medium text-gray-500 dark:text-gray-400 capitalize bg-white/[0.04] border border-white/[0.06] rounded px-1.5 py-0.5">
+                  <span className="text-[10px] font-medium text-gray-500 dark:text-gray-500 px-1.5 py-0.5 rounded bg-white/5 border border-white/[0.06] capitalize">
                     {platform}
                   </span>
                 )}
@@ -116,7 +116,7 @@ export const ModelOnboardingTaskCard = memo(function ModelOnboardingTaskCard({
                       if (e.key === 'Enter') saveTitle();
                       if (e.key === 'Escape') { setDraft(task.title); setEditing(false); }
                     }}
-                    className="flex-1 min-w-0 rounded bg-transparent border border-brand-mid-pink/30 px-2 py-1 text-sm font-semibold text-gray-900 dark:text-white focus-visible:outline-none focus-visible:border-brand-light-pink/60"
+                    className="flex-1 min-w-0 rounded-lg bg-white/5 border border-brand-mid-pink/30 px-2 py-1 text-sm font-semibold text-gray-900 dark:text-white focus-visible:outline-none focus-visible:border-brand-light-pink/60"
                   />
                   <button type="button" onClick={saveTitle} className="p-0.5 text-brand-light-pink shrink-0">
                     <Check className="h-3.5 w-3.5" />
@@ -126,7 +126,7 @@ export const ModelOnboardingTaskCard = memo(function ModelOnboardingTaskCard({
                   </button>
                 </div>
               ) : (
-                <p className="text-sm font-semibold leading-snug text-gray-900 dark:text-white mb-2 line-clamp-2">
+                <p className="text-[13px] font-bold leading-snug text-gray-900 dark:text-white mb-2 line-clamp-2">
                   {task.title}
                   <button
                     type="button"
@@ -157,7 +157,7 @@ export const ModelOnboardingTaskCard = memo(function ModelOnboardingTaskCard({
                       {progress}%
                     </span>
                   </div>
-                  <div className="h-1.5 rounded-full bg-gray-200 dark:bg-white/[0.06] overflow-hidden">
+                  <div className="h-1.5 rounded-full bg-white/[0.06] overflow-hidden">
                     <div
                       className={`h-full rounded-full transition-all duration-300 ${progress === 100 ? 'bg-emerald-500' : 'bg-brand-light-pink'}`}
                       style={{ width: `${progress}%` }}
@@ -167,17 +167,17 @@ export const ModelOnboardingTaskCard = memo(function ModelOnboardingTaskCard({
               )}
 
               {/* Footer: assignee */}
-              <div className="flex items-center gap-2.5 pt-2 border-t border-gray-100 dark:border-white/[0.06]">
+              <div className="flex items-center gap-2.5 pt-2.5 border-t border-white/[0.06]">
                 <span className="flex-1" />
                 {assigneeInitial ? (
                   <span
-                    className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-brand-mid-pink/15 text-brand-mid-pink text-[11px] font-bold"
+                    className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-brand-light-pink/15 text-brand-light-pink text-[11px] font-bold ring-1 ring-brand-light-pink/20 group-hover/card:ring-brand-light-pink/40 transition-all"
                     title={assigneeName ?? undefined}
                   >
                     {assigneeInitial}
                   </span>
                 ) : (
-                  <User className="h-3.5 w-3.5 text-gray-400 dark:text-gray-600" />
+                  <User className="h-3.5 w-3.5 text-gray-500 dark:text-gray-600" />
                 )}
               </div>
             </div>

--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/OtpPtrTaskDetailModal.tsx
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/OtpPtrTaskDetailModal.tsx
@@ -26,6 +26,8 @@ import {
   Link2,
   ChevronDown,
   Image as ImageIcon,
+  Settings,
+  Workflow,
   type LucideIcon,
 } from 'lucide-react';
 // Note: All icons above are used across the component's sections and sidebar
@@ -65,7 +67,7 @@ interface Props {
   onUpdate: (updated: BoardTask) => void;
 }
 
-type ModalTab = 'details' | 'history' | 'comments';
+type ModalTab = 'details' | 'workflow' | 'history' | 'comments';
 
 /* ── Constants ───────────────────────────────────────────── */
 
@@ -159,27 +161,27 @@ function Section({
   const [open, setOpen] = useState(defaultOpen);
 
   return (
-    <div className="mb-1">
+    <div className="mb-0.5">
       <button
         type="button"
         onClick={() => setOpen(!open)}
-        className="flex items-center w-full gap-2 py-2.5 text-left group/section"
+        className="flex items-center w-full gap-2.5 py-2.5 px-1 text-left group/section hover:bg-white/[0.02] rounded-lg transition-colors"
       >
         <Icon className="h-3.5 w-3.5 text-gray-500 shrink-0" />
-        <span className="text-[13px] font-semibold text-gray-200 tracking-wide flex-1 uppercase">
+        <span className="text-[11px] font-semibold text-gray-400 tracking-[0.08em] flex-1 uppercase">
           {title}
         </span>
         {badge}
         <ChevronDown
-          className={`h-3 w-3 text-gray-600 transition-transform duration-150 ${open ? 'rotate-180' : ''}`}
+          className={`h-3 w-3 text-gray-600 transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
         />
       </button>
       {open && (
-        <div className="pb-3 pl-5.5">
+        <div className="pb-3 pl-6 pr-1">
           {children}
         </div>
       )}
-      <div className="border-t border-white/[0.04]" />
+      <div className="border-t border-white/[0.04] mx-1" />
     </div>
   );
 }
@@ -188,7 +190,7 @@ function Section({
 
 function SideLabel({ children }: { children: React.ReactNode }) {
   return (
-    <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-gray-400 mb-1">
+    <div className="text-[11px] font-semibold uppercase tracking-[0.08em] text-gray-500 mb-1">
       {children}
     </div>
   );
@@ -196,9 +198,9 @@ function SideLabel({ children }: { children: React.ReactNode }) {
 
 function SideRow({ label, children }: { label: string; children: React.ReactNode }) {
   return (
-    <div className="py-2 border-b border-white/[0.03] last:border-0">
+    <div className="py-2.5 border-b border-white/[0.04] last:border-0">
       <SideLabel>{label}</SideLabel>
-      <div>{children}</div>
+      <div className="mt-0.5">{children}</div>
     </div>
   );
 }
@@ -250,12 +252,12 @@ function TagInput({
         onChange={(e) => onChange(e.target.value)}
         onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); onAdd(); } }}
         placeholder={placeholder}
-        className="flex-1 rounded px-2 py-1.5 text-xs text-gray-100 placeholder:text-gray-600 bg-white/[0.03] border border-white/[0.06] focus-visible:outline-none focus-visible:border-brand-mid-pink/30"
+        className="flex-1 rounded-lg px-2.5 py-1.5 text-xs text-gray-100 placeholder:text-gray-600 bg-white/[0.03] border border-white/[0.06] focus-visible:outline-none focus-visible:border-brand-mid-pink/30 transition-colors"
       />
       <button
         type="button"
         onClick={onAdd}
-        className="p-1 rounded text-gray-500 hover:text-brand-light-pink transition-colors"
+        className="p-1.5 rounded-lg text-gray-500 hover:text-brand-light-pink hover:bg-white/[0.04] transition-all"
       >
         <Plus className="h-3 w-3" />
       </button>
@@ -278,7 +280,7 @@ function RemovableTag({
     blue: 'bg-brand-blue/8 text-brand-blue border-brand-blue/12',
   };
   return (
-    <span className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] font-medium border ${colors[variant]}`}>
+    <span className={`inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[11px] font-medium border ${colors[variant]}`}>
       {children}
       <button type="button" onClick={onRemove} className="opacity-50 hover:opacity-100 transition-opacity">
         <X className="h-2.5 w-2.5" />
@@ -527,6 +529,7 @@ export function OtpPtrTaskDetailModal({
 
   const TABS: { id: ModalTab; label: string; icon: LucideIcon }[] = [
     { id: 'details', label: 'Details', icon: Info },
+    { id: 'workflow', label: 'Workflow', icon: Workflow },
     { id: 'history', label: 'History', icon: Clock },
     { id: 'comments', label: 'Comments', icon: MessageSquare },
   ];
@@ -539,36 +542,38 @@ export function OtpPtrTaskDetailModal({
     <div
       className="fixed inset-0 z-9999 flex items-start justify-center overflow-y-auto py-8 px-4"
       onClick={onClose}
-      style={{ background: 'rgba(0,0,0,0.6)', backdropFilter: 'blur(8px)' }}
+      style={{ background: 'rgba(0,0,0,0.65)', backdropFilter: 'blur(12px)' }}
     >
       <div
-        className="relative w-full max-w-[1080px] rounded-2xl shadow-2xl shadow-black/60 bg-[#0d0b14] border border-white/[0.08] overflow-hidden"
+        className="relative w-full max-w-5xl rounded-2xl shadow-2xl shadow-black/60 bg-[#0f1729]/95 backdrop-blur-xl border border-white/[0.08] overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
-        {/* Gradient header strip */}
-        <div className="h-1 w-full bg-gradient-to-r from-brand-light-pink via-brand-mid-pink to-brand-light-pink/40" />
+        {/* Pink gradient top strip */}
+        <div className="h-[3px] w-full bg-gradient-to-r from-brand-dark-pink via-brand-light-pink to-brand-mid-pink/40" />
 
         {/* ═══ Header ════════════════════════════════════ */}
         <div className="px-6 pt-5 pb-4">
           <div className="flex items-start justify-between gap-4">
             <div className="flex-1 min-w-0">
               {/* Badge row */}
-              <div className="flex items-center gap-2.5 mb-3 flex-wrap">
-                <span className="font-mono text-xs font-semibold text-gray-400 bg-white/[0.04] px-2 py-0.5 rounded-md border border-white/[0.06] tracking-wide">
+              <div className="flex items-center gap-2 mb-3 flex-wrap">
+                <span className="font-mono text-[11px] font-semibold text-gray-300 bg-white/[0.05] px-2.5 py-1 rounded-full border border-white/[0.08] tracking-wide">
                   {task.taskKey}
                 </span>
-                <span className={`inline-flex items-center gap-1.5 text-[11px] font-semibold rounded-full px-2.5 py-0.5 border ${
+                <span className={`inline-flex items-center gap-1.5 text-[11px] font-bold rounded-full px-2.5 py-1 ${
                   requestType === 'OTP'
-                    ? 'bg-blue-500/15 text-blue-400 border-blue-500/20'
+                    ? 'bg-brand-blue/15 text-brand-blue'
                     : requestType === 'PTR'
-                    ? 'bg-brand-light-pink/15 text-brand-light-pink border-brand-light-pink/20'
-                    : 'bg-amber-500/15 text-amber-400 border-amber-500/20'
+                    ? 'bg-brand-light-pink/15 text-brand-light-pink'
+                    : 'bg-amber-500/15 text-amber-400'
                 }`}>
                   {requestType}
                 </span>
-                <span className="text-[11px] text-gray-500 bg-white/[0.03] px-2 py-0.5 rounded-full">{columnTitle}</span>
+                <span className="text-[11px] text-gray-500 bg-white/[0.04] px-2.5 py-1 rounded-full">
+                  {columnTitle}
+                </span>
                 {/* Caption status */}
-                <span className={`inline-flex items-center gap-1.5 text-[11px] font-medium rounded-full px-2.5 py-0.5 bg-white/[0.04] border border-white/[0.06] ${captionCfg.color}`}>
+                <span className={`inline-flex items-center gap-1.5 text-[11px] font-medium rounded-full px-2.5 py-1 bg-white/[0.04] ${captionCfg.color}`}>
                   <span className={`h-1.5 w-1.5 rounded-full ${captionCfg.dotColor}`} />
                   {captionCfg.label}
                 </span>
@@ -586,7 +591,7 @@ export function OtpPtrTaskDetailModal({
                       if (e.key === 'Enter') saveTitle();
                       if (e.key === 'Escape') { setTitleDraft(task.title); setEditingTitle(false); }
                     }}
-                    className="w-full text-2xl font-bold text-white bg-transparent border-b border-brand-mid-pink/40 focus-visible:outline-none focus-visible:border-brand-light-pink/60 pb-0.5 transition-colors tracking-tight"
+                    className="w-full text-[22px] font-bold text-white bg-transparent border-b border-brand-mid-pink/40 focus-visible:outline-none focus-visible:border-brand-light-pink/60 pb-0.5 transition-colors tracking-tight"
                   />
                 ) : (
                   <button
@@ -594,7 +599,7 @@ export function OtpPtrTaskDetailModal({
                     onClick={() => setEditingTitle(true)}
                     className="flex items-center gap-2 w-full text-left"
                   >
-                    <h2 className="text-2xl font-bold text-white leading-snug tracking-tight">
+                    <h2 className="text-[22px] font-bold text-white leading-snug tracking-tight">
                       {task.title}
                     </h2>
                     <Pencil className="h-3 w-3 text-gray-700 opacity-0 group-hover/title:opacity-100 transition-opacity shrink-0" />
@@ -602,66 +607,80 @@ export function OtpPtrTaskDetailModal({
                 )}
               </div>
 
-              {/* Quick stats — glassmorphism card */}
+              {/* Quick info bar */}
               {(buyer || model || deadline || price > 0 || platforms.length > 0) && (
-                <div className="flex items-center gap-3 mt-3 text-xs text-gray-400 rounded-xl bg-white/[0.03] backdrop-blur-sm border border-white/[0.06] px-4 py-2.5">
+                <div className="flex items-center gap-3 mt-3 text-xs text-gray-400 rounded-xl bg-[#1a2237]/80 border border-white/[0.06] px-4 py-2.5">
                   {price > 0 && (
                     <span className="text-brand-light-pink font-bold text-sm">${price}</span>
                   )}
                   {(meta.isPaid as boolean) != null && (
-                    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold border ${
+                    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide ${
                       (meta.isPaid as boolean)
-                        ? 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20'
-                        : 'bg-red-500/10 text-red-400 border-red-500/20'
+                        ? 'bg-emerald-500/12 text-emerald-400'
+                        : 'bg-red-500/12 text-red-400'
                     }`}>
                       {(meta.isPaid as boolean) ? 'PAID' : 'UNPAID'}
                     </span>
                   )}
-                  {buyer && <span className="inline-flex items-center gap-1"><User className="h-3 w-3 text-gray-500" />@{buyer}</span>}
-                  {model && <span className="inline-flex items-center gap-1"><Users className="h-3 w-3 text-gray-500" />{model}</span>}
+                  {model && (
+                    <span className="inline-flex items-center gap-1.5">
+                      <User className="h-3 w-3 text-gray-500" />
+                      <span className="text-gray-300">{model}</span>
+                    </span>
+                  )}
                   {platforms.length > 0 && platforms.map((p) => (
-                    <span key={p} className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold border ${
+                    <span key={p} className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-bold ${
                       p === 'onlyfans'
-                        ? 'bg-brand-blue/10 text-brand-blue border-brand-blue/20'
-                        : 'bg-brand-light-pink/10 text-brand-light-pink border-brand-light-pink/20'
+                        ? 'bg-brand-blue/12 text-brand-blue'
+                        : 'bg-brand-light-pink/12 text-brand-light-pink'
                     }`}>
                       {p === 'onlyfans' ? 'OF' : 'Fansly'}
                     </span>
                   ))}
                   {deadline && (
-                    <span className="inline-flex items-center gap-1">
+                    <span className="inline-flex items-center gap-1.5">
                       <CalendarDays className="h-3 w-3 text-gray-500" />
-                      {new Date(deadline).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                      <span className="text-gray-300">{new Date(deadline).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}</span>
                     </span>
                   )}
                 </div>
               )}
             </div>
 
-            {/* Close */}
-            <button
-              type="button"
-              onClick={onClose}
-              className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-gray-500 hover:text-gray-300 hover:bg-white/[0.06] transition-colors shrink-0"
-            >
-              <X className="h-4 w-4" />
-            </button>
+            {/* Top-right actions */}
+            <div className="flex items-center gap-2 shrink-0">
+              <button
+                type="button"
+                onClick={() => setEditingTitle(true)}
+                className="inline-flex items-center gap-1.5 h-8 px-3.5 rounded-lg text-xs font-semibold text-white bg-brand-light-pink/90 hover:bg-brand-light-pink transition-all duration-200"
+              >
+                <Pencil className="h-3 w-3" />
+                Edit Task
+              </button>
+              <button
+                type="button"
+                onClick={onClose}
+                className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-gray-500 hover:text-gray-300 hover:bg-white/[0.06] transition-all duration-200"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
           </div>
         </div>
 
-        {/* ═══ Tab Bar — pill-shaped ═══════════════════ */}
-        <div className="px-6 py-2 border-b border-white/[0.06]">
-          <div className="inline-flex items-center gap-1 rounded-xl bg-white/[0.03] p-1 border border-white/[0.04]">
+        {/* ═══ Tab Bar ═══════════════════════════════════ */}
+        <div className="px-6 border-b border-white/[0.06]">
+          <div className="flex items-center gap-0.5">
             {TABS.map((t) => (
               <button
                 key={t.id}
                 type="button"
                 onClick={() => setActiveTab(t.id)}
                 className={[
-                  'flex items-center gap-1.5 px-4 py-2 text-sm font-medium rounded-lg transition-all duration-200',
+                  'relative flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium transition-all duration-200',
                   activeTab === t.id
-                    ? 'bg-white/[0.06] text-white shadow-sm ring-1 ring-brand-light-pink/15'
-                    : 'text-gray-500 hover:text-gray-300 hover:bg-white/[0.03]',
+                    ? 'text-white'
+                    : 'text-gray-500 hover:text-gray-300',
                 ].join(' ')}
               >
                 <t.icon className={`h-3.5 w-3.5 ${activeTab === t.id ? 'text-brand-light-pink' : ''}`} />
@@ -671,13 +690,17 @@ export function OtpPtrTaskDetailModal({
                     {comments.length}
                   </span>
                 )}
+                {/* Active indicator */}
+                {activeTab === t.id && (
+                  <span className="absolute bottom-0 left-2 right-2 h-[2px] bg-brand-light-pink rounded-full" />
+                )}
               </button>
             ))}
           </div>
         </div>
 
         {/* ═══ Body ═════════════════════════════════════ */}
-        <div className="grid grid-cols-1 lg:grid-cols-[1fr_260px]">
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr_280px]">
           {/* ── Left: Tab Content ──────────────────────── */}
           <div className="px-6 py-5 min-h-[50vh] max-h-[62vh] overflow-y-auto custom-scrollbar border-r border-white/[0.04]">
 
@@ -721,11 +744,150 @@ export function OtpPtrTaskDetailModal({
                   </div>
                 </Section>
 
+                {/* Description & Content */}
+                <Section icon={FileText} title="Description & Content">
+                  <div className="space-y-3">
+                    <EditableField value={task.description ?? ''} placeholder="Add description..." onSave={(v) => onUpdate({ ...task, description: v || undefined })} />
+
+                    <div className="grid grid-cols-3 gap-x-4 gap-y-2 pt-2 border-t border-white/[0.04]">
+                      <div><SideLabel>Content Type</SideLabel><EditableField value={contentType} placeholder="Set type" onSave={(v) => updateMeta({ contentType: v })} /></div>
+                      <div><SideLabel>Length</SideLabel><EditableField value={contentLength} placeholder="Set length" onSave={(v) => updateMeta({ contentLength: v })} /></div>
+                      <div><SideLabel>Count</SideLabel><EditableField value={contentCount} placeholder="Set count" onSave={(v) => updateMeta({ contentCount: v })} /></div>
+                    </div>
+
+                    {/* Platforms */}
+                    <div className="pt-2 border-t border-white/[0.04]">
+                      <SideLabel>Platforms</SideLabel>
+                      <div className="flex items-center gap-2 mt-1">
+                        {(['onlyfans', 'fansly'] as const).map((p) => {
+                          const isActive = platforms.includes(p);
+                          return (
+                            <button
+                              key={p}
+                              type="button"
+                              onClick={() => {
+                                const next = isActive
+                                  ? platforms.filter((x) => x !== p)
+                                  : [...platforms, p];
+                                if (next.length === 0) return;
+                                updateMeta({ platforms: next });
+                              }}
+                              className={`text-xs font-medium px-2.5 py-1 rounded-lg border transition-all duration-200 ${
+                                isActive
+                                  ? p === 'onlyfans'
+                                    ? 'bg-brand-blue/15 border-brand-blue/30 text-brand-blue'
+                                    : 'bg-brand-light-pink/15 border-brand-light-pink/30 text-brand-light-pink'
+                                  : 'bg-white/[0.03] border-white/[0.06] text-gray-500 hover:border-white/[0.12]'
+                              }`}
+                            >
+                              {p === 'onlyfans' ? 'OnlyFans' : 'Fansly'}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    </div>
+
+                    <div className="flex items-center gap-3 pt-2 border-t border-white/[0.04]">
+                      <DollarSign className="h-4 w-4 text-emerald-500 shrink-0" />
+                      <span className="text-sm font-medium text-gray-400">Price</span>
+                      <span className="flex-1" />
+                      <EditableField value={price ? String(price) : ''} placeholder="0.00" onSave={(v) => updateMeta({ price: Number(v) || 0 })} />
+                    </div>
+                  </div>
+                </Section>
+
+                {/* Drive Link */}
+                <Section icon={Link2} title="Google Drive">
+                  <EditableField value={rawDriveLink} placeholder="Paste Drive link..." onSave={(v) => updateMeta({ driveLink: v })} />
+                  {driveLink && (
+                    <a href={driveLink} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1.5 text-xs text-brand-blue hover:underline mt-1.5">
+                      <ExternalLink className="h-3 w-3" />Open in Drive
+                    </a>
+                  )}
+                </Section>
+
+                {/* Notes */}
+                <Section icon={ClipboardList} title="Notes">
+                  <div className="group/notes">
+                    {editingNotes ? (
+                      <div>
+                        <textarea
+                          ref={notesRef}
+                          value={notesDraft}
+                          onChange={(e) => setNotesDraft(e.target.value)}
+                          rows={4}
+                          placeholder="Delivery instructions, special requests..."
+                          className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-gray-200 placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-brand-mid-pink/30 resize-none"
+                        />
+                        <div className="flex items-center gap-2 mt-2">
+                          <button type="button" onClick={saveNotes} className="px-3 py-1.5 rounded-lg text-xs font-semibold text-white bg-brand-light-pink/80 hover:bg-brand-light-pink transition-colors">
+                            Save
+                          </button>
+                          <button type="button" onClick={() => { setNotesDraft(fulfillmentNotes); setEditingNotes(false); }} className="px-3 py-1.5 rounded-lg text-xs text-gray-500 hover:text-gray-300 transition-colors">
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <button type="button" onClick={() => setEditingNotes(true)} className="flex items-start gap-2 w-full text-left">
+                        <p className="text-[13px] text-gray-400 whitespace-pre-wrap flex-1 leading-relaxed">
+                          {fulfillmentNotes || <span className="text-gray-600 italic">Click to add notes...</span>}
+                        </p>
+                        <Pencil className="h-3 w-3 text-gray-700 opacity-0 group-hover/notes:opacity-100 transition-opacity shrink-0 mt-0.5" />
+                      </button>
+                    )}
+                  </div>
+                </Section>
+
+                {/* Tags */}
+                <Section icon={Tag} title="Tags">
+                  <div className="space-y-3">
+                    <div>
+                      <SideLabel>External Creators</SideLabel>
+                      <div className="flex flex-wrap gap-1 mb-1">
+                        {externalCreatorTags.map((t) => <RemovableTag key={t} variant="pink" onRemove={() => removeFromArray('externalCreatorTags', t)}>{t}</RemovableTag>)}
+                      </div>
+                      <TagInput value={getTagInput('externalCreatorTags')} onChange={(v) => setTagInput('externalCreatorTags', v)} onAdd={() => addToArray('externalCreatorTags', getTagInput('externalCreatorTags'))} placeholder="Add creator..." />
+                    </div>
+                    <div>
+                      <SideLabel>Internal Models</SideLabel>
+                      <div className="flex flex-wrap gap-1 mb-1">
+                        {internalModelTags.map((t) => <RemovableTag key={t} variant="blue" onRemove={() => removeFromArray('internalModelTags', t)}>{t}</RemovableTag>)}
+                      </div>
+                      <TagInput value={getTagInput('internalModelTags')} onChange={(v) => setTagInput('internalModelTags', v)} onAdd={() => addToArray('internalModelTags', getTagInput('internalModelTags'))} placeholder="Add model..." />
+                    </div>
+                    <div>
+                      <SideLabel>Content Tags</SideLabel>
+                      <div className="flex flex-wrap gap-1 mb-1">
+                        {contentTags.map((t) => <RemovableTag key={t} onRemove={() => removeFromArray('contentTags', t)}>{t}</RemovableTag>)}
+                      </div>
+                      <TagInput value={getTagInput('contentTags')} onChange={(v) => setTagInput('contentTags', v)} onAdd={() => addToArray('contentTags', getTagInput('contentTags'))} placeholder="Add tag..." />
+                    </div>
+                  </div>
+                </Section>
+
+                {/* Timestamps */}
+                <Section icon={Clock} title="Timestamps" defaultOpen={false}>
+                  <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-xs">
+                    {typeof meta.createdAt === 'string' && (
+                      <div><SideLabel>Created</SideLabel><span className="text-gray-400">{formatFullDate(meta.createdAt)}</span></div>
+                    )}
+                    {typeof meta.updatedAt === 'string' && (
+                      <div><SideLabel>Updated</SideLabel><span className="text-gray-400">{formatFullDate(meta.updatedAt)}</span></div>
+                    )}
+                  </div>
+                </Section>
+              </>
+            )}
+
+            {/* ── Workflow Tab ─────────────────────────────── */}
+            {activeTab === 'workflow' && (
+              <>
                 {/* PGT Team */}
                 <Section icon={FileText} title="PGT Team">
                   <div className="space-y-3">
                     {/* Caption Status */}
-                    <div className={`flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-medium ${captionCfg.bgColor} ${captionCfg.color}`}>
+                    <div className={`flex items-center gap-2 px-3 py-2.5 rounded-lg text-xs font-medium ${captionCfg.bgColor} ${captionCfg.color}`}>
                       <span className={`h-2 w-2 rounded-full shrink-0 ${captionCfg.dotColor}`} />
                       {captionCfg.label}
                       {captionTicketId && <span className="ml-auto text-[10px] opacity-50">Ticket linked</span>}
@@ -868,6 +1030,7 @@ export function OtpPtrTaskDetailModal({
                   </div>
                 </Section>
 
+                {/* PPV/Bundle Details */}
                 {(contentStyle.toLowerCase() === 'ppv' || contentStyle.toLowerCase() === 'bundle') && (
                   <Section icon={Film} title="PPV/Bundle Details">
                     <SideLabel>Original Poll Reference</SideLabel>
@@ -887,7 +1050,7 @@ export function OtpPtrTaskDetailModal({
                             href={m.url}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="group relative aspect-square rounded-lg overflow-hidden bg-black/20 border border-white/[0.06] hover:border-brand-light-pink/30 transition-all"
+                            className="group relative aspect-square rounded-lg overflow-hidden bg-black/20 border border-white/[0.06] hover:border-brand-light-pink/30 transition-all duration-200"
                           >
                             {isVideo ? (
                               <video
@@ -914,101 +1077,6 @@ export function OtpPtrTaskDetailModal({
                   </Section>
                 )}
 
-                {/* Description & Content */}
-                <Section icon={Info} title="Description & Content">
-                  <div className="space-y-3">
-                    <EditableField value={task.description ?? ''} placeholder="Add description..." onSave={(v) => onUpdate({ ...task, description: v || undefined })} />
-
-                    <div className="grid grid-cols-3 gap-x-4 gap-y-2 pt-2 border-t border-white/[0.04]">
-                      <div><SideLabel>Content Type</SideLabel><EditableField value={contentType} placeholder="Set type" onSave={(v) => updateMeta({ contentType: v })} /></div>
-                      <div><SideLabel>Length</SideLabel><EditableField value={contentLength} placeholder="Set length" onSave={(v) => updateMeta({ contentLength: v })} /></div>
-                      <div><SideLabel>Count</SideLabel><EditableField value={contentCount} placeholder="Set count" onSave={(v) => updateMeta({ contentCount: v })} /></div>
-                    </div>
-
-                    {/* Platforms */}
-                    <div className="pt-2 border-t border-white/[0.04]">
-                      <SideLabel>Platforms</SideLabel>
-                      <div className="flex items-center gap-2 mt-1">
-                        {(['onlyfans', 'fansly'] as const).map((p) => {
-                          const isActive = platforms.includes(p);
-                          return (
-                            <button
-                              key={p}
-                              type="button"
-                              onClick={() => {
-                                const next = isActive
-                                  ? platforms.filter((x) => x !== p)
-                                  : [...platforms, p];
-                                if (next.length === 0) return;
-                                updateMeta({ platforms: next });
-                              }}
-                              className={`text-xs font-medium px-2.5 py-1 rounded-lg border transition-all ${
-                                isActive
-                                  ? p === 'onlyfans'
-                                    ? 'bg-brand-blue/15 border-brand-blue/30 text-brand-blue'
-                                    : 'bg-brand-light-pink/15 border-brand-light-pink/30 text-brand-light-pink'
-                                  : 'bg-white/[0.03] border-white/[0.06] text-gray-500 hover:border-white/[0.12]'
-                              }`}
-                            >
-                              {p === 'onlyfans' ? 'OnlyFans' : 'Fansly'}
-                            </button>
-                          );
-                        })}
-                      </div>
-                    </div>
-
-                    <div className="flex items-center gap-3 pt-2 border-t border-white/[0.04]">
-                      <DollarSign className="h-4 w-4 text-emerald-500 shrink-0" />
-                      <span className="text-sm font-medium text-gray-400">Price</span>
-                      <span className="flex-1" />
-                      <EditableField value={price ? String(price) : ''} placeholder="0.00" onSave={(v) => updateMeta({ price: Number(v) || 0 })} />
-                    </div>
-                  </div>
-                </Section>
-
-                {/* Drive Link */}
-                <Section icon={Link2} title="Google Drive">
-                  <EditableField value={rawDriveLink} placeholder="Paste Drive link..." onSave={(v) => updateMeta({ driveLink: v })} />
-                  {driveLink && (
-                    <a href={driveLink} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1.5 text-xs text-brand-blue hover:underline mt-1.5">
-                      <ExternalLink className="h-3 w-3" />Open in Drive
-                    </a>
-                  )}
-                </Section>
-
-                {/* Notes */}
-                <Section icon={ClipboardList} title="Notes">
-                  <div className="group/notes">
-                    {editingNotes ? (
-                      <div>
-                        <textarea
-                          ref={notesRef}
-                          value={notesDraft}
-                          onChange={(e) => setNotesDraft(e.target.value)}
-                          rows={4}
-                          placeholder="Delivery instructions, special requests..."
-                          className="w-full rounded-lg border border-white/[0.06] bg-white/[0.02] px-3 py-2 text-sm text-gray-200 placeholder:text-gray-600 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-brand-mid-pink/30 resize-none"
-                        />
-                        <div className="flex items-center gap-2 mt-2">
-                          <button type="button" onClick={saveNotes} className="px-3 py-1 rounded-lg text-xs font-semibold text-brand-light-pink border border-brand-light-pink/20 hover:bg-brand-light-pink/[0.06] transition-colors">
-                            Save
-                          </button>
-                          <button type="button" onClick={() => { setNotesDraft(fulfillmentNotes); setEditingNotes(false); }} className="px-3 py-1 rounded-lg text-xs text-gray-500 hover:text-gray-300 transition-colors">
-                            Cancel
-                          </button>
-                        </div>
-                      </div>
-                    ) : (
-                      <button type="button" onClick={() => setEditingNotes(true)} className="flex items-start gap-2 w-full text-left">
-                        <p className="text-[13px] text-gray-400 whitespace-pre-wrap flex-1 leading-relaxed">
-                          {fulfillmentNotes || <span className="text-gray-600 italic">Click to add notes...</span>}
-                        </p>
-                        <Pencil className="h-3 w-3 text-gray-700 opacity-0 group-hover/notes:opacity-100 transition-opacity shrink-0 mt-0.5" />
-                      </button>
-                    )}
-                  </div>
-                </Section>
-
                 {/* Deliverables */}
                 <Section
                   icon={Package}
@@ -1030,45 +1098,6 @@ export function OtpPtrTaskDetailModal({
                   )}
                   {deliverables.length === 0 && <p className="text-xs text-gray-600 italic mb-2">None</p>}
                   <TagInput value={getTagInput('deliverables')} onChange={(v) => setTagInput('deliverables', v)} onAdd={() => addToArray('deliverables', getTagInput('deliverables'))} placeholder="Add deliverable..." />
-                </Section>
-
-                {/* Tags */}
-                <Section icon={Tag} title="Tags">
-                  <div className="space-y-3">
-                    <div>
-                      <SideLabel>External Creators</SideLabel>
-                      <div className="flex flex-wrap gap-1 mb-1">
-                        {externalCreatorTags.map((t) => <RemovableTag key={t} variant="pink" onRemove={() => removeFromArray('externalCreatorTags', t)}>{t}</RemovableTag>)}
-                      </div>
-                      <TagInput value={getTagInput('externalCreatorTags')} onChange={(v) => setTagInput('externalCreatorTags', v)} onAdd={() => addToArray('externalCreatorTags', getTagInput('externalCreatorTags'))} placeholder="Add creator..." />
-                    </div>
-                    <div>
-                      <SideLabel>Internal Models</SideLabel>
-                      <div className="flex flex-wrap gap-1 mb-1">
-                        {internalModelTags.map((t) => <RemovableTag key={t} variant="blue" onRemove={() => removeFromArray('internalModelTags', t)}>{t}</RemovableTag>)}
-                      </div>
-                      <TagInput value={getTagInput('internalModelTags')} onChange={(v) => setTagInput('internalModelTags', v)} onAdd={() => addToArray('internalModelTags', getTagInput('internalModelTags'))} placeholder="Add model..." />
-                    </div>
-                    <div>
-                      <SideLabel>Content Tags</SideLabel>
-                      <div className="flex flex-wrap gap-1 mb-1">
-                        {contentTags.map((t) => <RemovableTag key={t} onRemove={() => removeFromArray('contentTags', t)}>{t}</RemovableTag>)}
-                      </div>
-                      <TagInput value={getTagInput('contentTags')} onChange={(v) => setTagInput('contentTags', v)} onAdd={() => addToArray('contentTags', getTagInput('contentTags'))} placeholder="Add tag..." />
-                    </div>
-                  </div>
-                </Section>
-
-                {/* Metadata */}
-                <Section icon={Clock} title="Timestamps" defaultOpen={false}>
-                  <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-xs">
-                    {typeof meta.createdAt === 'string' && (
-                      <div><SideLabel>Created</SideLabel><span className="text-gray-400">{formatFullDate(meta.createdAt)}</span></div>
-                    )}
-                    {typeof meta.updatedAt === 'string' && (
-                      <div><SideLabel>Updated</SideLabel><span className="text-gray-400">{formatFullDate(meta.updatedAt)}</span></div>
-                    )}
-                  </div>
                 </Section>
               </>
             )}
@@ -1135,7 +1164,7 @@ export function OtpPtrTaskDetailModal({
                       />
                     )}
                     {newComment.trim() && (
-                      <button type="button" onClick={handleAddComment} className="mt-1.5 px-3.5 py-1.5 rounded-lg text-xs font-semibold text-brand-light-pink border border-brand-light-pink/20 hover:bg-brand-light-pink/[0.06] transition-colors">
+                      <button type="button" onClick={handleAddComment} className="mt-1.5 px-3.5 py-1.5 rounded-lg text-xs font-semibold text-white bg-brand-light-pink/80 hover:bg-brand-light-pink transition-colors">
                         Post
                       </button>
                     )}
@@ -1167,17 +1196,34 @@ export function OtpPtrTaskDetailModal({
           </div>
 
           {/* ═══ Right Sidebar — Properties ═══════════════ */}
-          <div className="px-4 py-4 max-h-[62vh] overflow-y-auto custom-scrollbar bg-white/[0.01]">
-            <h3 className="text-[11px] font-semibold uppercase tracking-[0.1em] text-gray-500 mb-3">Properties</h3>
+          <div className="px-4 py-4 max-h-[62vh] overflow-y-auto custom-scrollbar bg-[#111827]/50">
+            <div className="flex items-center gap-2 mb-3">
+              <Settings className="h-3.5 w-3.5 text-gray-500" />
+              <h3 className="text-[11px] font-semibold uppercase tracking-[0.1em] text-gray-400">Properties</h3>
+            </div>
 
             <SideRow label="Status">
-              <span className="flex items-center gap-1.5 text-xs text-gray-200">
-                <span className="h-1.5 w-1.5 rounded-full bg-brand-light-pink" />
+              <span className="flex items-center gap-1.5 text-sm font-semibold text-brand-off-white">
+                <span className="h-2 w-2 rounded-full bg-brand-light-pink" />
                 {columnTitle}
               </span>
             </SideRow>
 
-            <div className="grid grid-cols-2 gap-2 py-2 border-b border-white/[0.04]">
+            <SideRow label="Priority">
+              <SelectField
+                value={task.priority ?? 'Medium'}
+                options={['Low', 'Medium', 'High']}
+                onSave={(v) => onUpdate({ ...task, priority: v as BoardTask['priority'] })}
+                renderOption={(v) => (
+                  <span className={`inline-flex items-center gap-1.5 text-sm font-semibold ${PRIORITY_PILL[v] ?? 'text-gray-300'}`}>
+                    <span className={`h-2 w-2 rounded-full ${PRIORITY_DOT[v] ?? ''}`} />
+                    {v}
+                  </span>
+                )}
+              />
+            </SideRow>
+
+            <div className="grid grid-cols-2 gap-2 py-2.5 border-b border-white/[0.04]">
               <div>
                 <SideLabel>Type</SideLabel>
                 <SelectField
@@ -1185,8 +1231,8 @@ export function OtpPtrTaskDetailModal({
                   options={REQUEST_TYPE_OPTIONS}
                   onSave={(v) => updateMeta({ requestType: v })}
                   renderOption={(v) => (
-                    <span className="flex items-center gap-1.5 text-xs text-gray-200">
-                      <span className={`h-1.5 w-1.5 rounded-full ${TYPE_DOT[v] ?? 'bg-gray-500'}`} />
+                    <span className="flex items-center gap-1.5 text-sm font-semibold text-brand-off-white">
+                      <span className={`h-2 w-2 rounded-full ${TYPE_DOT[v] ?? 'bg-gray-500'}`} />
                       {v}
                     </span>
                   )}
@@ -1202,47 +1248,59 @@ export function OtpPtrTaskDetailModal({
               <button
                 type="button"
                 onClick={() => updateMeta({ isPaid: !isPaid })}
-                className={`w-full flex items-center gap-2 rounded-lg px-2.5 py-2 text-xs font-medium transition-all border ${
+                className={`w-full flex items-center gap-2 rounded-lg px-2.5 py-2 text-xs font-semibold transition-all duration-200 border ${
                   isPaid
                     ? 'bg-emerald-500/[0.08] border-emerald-500/20 text-emerald-400 hover:bg-emerald-500/[0.12]'
                     : 'bg-red-500/[0.08] border-red-500/20 text-red-400 hover:bg-red-500/[0.12]'
                 }`}
               >
-                <CreditCard className="h-3 w-3 shrink-0" />
+                <CreditCard className="h-3.5 w-3.5 shrink-0" />
                 <span className="flex-1 text-left">{isPaid ? 'Paid' : 'Unpaid'}</span>
-                <span className={`h-1.5 w-1.5 rounded-full ${isPaid ? 'bg-emerald-400' : 'bg-red-400'}`} />
+                <span className={`h-2 w-2 rounded-full ${isPaid ? 'bg-emerald-400' : 'bg-red-400'}`} />
               </button>
             </SideRow>
 
             <SideRow label="Tier">
-              <EditableField value={tier} placeholder="Set tier" onSave={(v) => updateMeta({ pricingCategory: v, pricingTier: v })} />
+              <span className="text-sm font-semibold text-brand-off-white">
+                <EditableField value={tier} placeholder="Set tier" onSave={(v) => updateMeta({ pricingCategory: v, pricingTier: v })} />
+              </span>
             </SideRow>
 
             <SideRow label="Page Type">
-              <EditableField value={pageType} placeholder="Set page type" onSave={(v) => updateMeta({ pageType: v })} />
+              <span className="text-sm font-semibold text-brand-off-white">
+                <EditableField value={pageType} placeholder="Set page type" onSave={(v) => updateMeta({ pageType: v })} />
+              </span>
             </SideRow>
 
             <SideRow label="Model">
-              <EditableField value={model} placeholder="Model name" onSave={(v) => updateMeta({ model: v })} />
+              <span className="text-sm font-semibold text-brand-off-white">
+                <EditableField value={model} placeholder="Model name" onSave={(v) => updateMeta({ model: v })} />
+              </span>
             </SideRow>
 
             <SideRow label="Buyer">
-              <EditableField value={buyer} placeholder="@username" onSave={(v) => updateMeta({ buyer: v })} />
+              <span className="text-sm font-semibold text-brand-off-white">
+                <EditableField value={buyer} placeholder="@username" onSave={(v) => updateMeta({ buyer: v })} />
+              </span>
             </SideRow>
 
             <SideRow label="Price">
-              <EditableField value={price ? String(price) : ''} placeholder="0.00" onSave={(v) => updateMeta({ price: Number(v) || 0 })} />
+              <span className="text-sm font-semibold text-brand-light-pink">
+                <EditableField value={price ? String(price) : ''} placeholder="0.00" onSave={(v) => updateMeta({ price: Number(v) || 0 })} />
+              </span>
             </SideRow>
 
             <SideRow label="Deadline">
-              <EditableField value={deadline} type="date" placeholder="Not set" onSave={(v) => updateMeta({ deadline: v })} />
+              <span className="text-sm font-semibold text-brand-off-white">
+                <EditableField value={deadline} type="date" placeholder="Not set" onSave={(v) => updateMeta({ deadline: v })} />
+              </span>
             </SideRow>
 
             {deliverables.length > 0 && (
               <SideRow label="Deliverables">
                 <div className="flex flex-wrap gap-1">
                   {deliverables.map((d) => (
-                    <span key={d} className="text-[11px] font-medium text-brand-blue bg-brand-blue/10 rounded px-1.5 py-0.5 border border-brand-blue/15">{d}</span>
+                    <span key={d} className="text-[11px] font-medium text-brand-blue bg-brand-blue/10 rounded-md px-1.5 py-0.5 border border-brand-blue/15">{d}</span>
                   ))}
                 </div>
               </SideRow>
@@ -1251,8 +1309,8 @@ export function OtpPtrTaskDetailModal({
             {(externalCreatorTags.length > 0 || internalModelTags.length > 0) && (
               <SideRow label="People">
                 <div className="flex flex-wrap gap-1">
-                  {externalCreatorTags.map((t) => <span key={`e-${t}`} className="text-[11px] font-medium text-brand-light-pink bg-brand-light-pink/10 rounded px-1.5 py-0.5 border border-brand-light-pink/15">{t}</span>)}
-                  {internalModelTags.map((t) => <span key={`i-${t}`} className="text-[11px] font-medium text-brand-blue bg-brand-blue/10 rounded px-1.5 py-0.5 border border-brand-blue/15">{t}</span>)}
+                  {externalCreatorTags.map((t) => <span key={`e-${t}`} className="text-[11px] font-medium text-brand-light-pink bg-brand-light-pink/10 rounded-md px-1.5 py-0.5 border border-brand-light-pink/15">{t}</span>)}
+                  {internalModelTags.map((t) => <span key={`i-${t}`} className="text-[11px] font-medium text-brand-blue bg-brand-blue/10 rounded-md px-1.5 py-0.5 border border-brand-blue/15">{t}</span>)}
                 </div>
               </SideRow>
             )}
@@ -1264,6 +1322,28 @@ export function OtpPtrTaskDetailModal({
                   {driveLink.length > 30 ? driveLink.slice(0, 27) + '...' : driveLink}
                 </a>
               </SideRow>
+            )}
+
+            {/* Created / Updated footer */}
+            {(typeof meta.createdAt === 'string' || typeof meta.updatedAt === 'string') && (
+              <div className="mt-4 pt-3 border-t border-white/[0.06]">
+                {typeof meta.createdAt === 'string' && (
+                  <div className="flex items-center gap-2 text-[11px] text-gray-500 mb-1.5">
+                    <span className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-white/[0.04] text-[8px] font-bold text-gray-500 shrink-0">
+                      {(getMemberName(task.assignee) ?? 'U').charAt(0).toUpperCase()}
+                    </span>
+                    Created {formatDate(meta.createdAt)}
+                  </div>
+                )}
+                {typeof meta.updatedAt === 'string' && (
+                  <div className="flex items-center gap-2 text-[11px] text-gray-500">
+                    <span className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-white/[0.04] text-[8px] font-bold text-gray-500 shrink-0">
+                      {(getMemberName(task.assignee) ?? 'U').charAt(0).toUpperCase()}
+                    </span>
+                    Updated {formatDate(meta.updatedAt)}
+                  </div>
+                )}
+              </div>
             )}
           </div>
         </div>

--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/WallPostTaskCard.tsx
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/WallPostTaskCard.tsx
@@ -1,12 +1,53 @@
-"use client";
+'use client';
 
-import { useState, useRef, useEffect } from "react";
-import { createPortal } from "react-dom";
-import { Draggable } from "@hello-pangea/dnd";
-import { Pencil, Check, X, Calendar, AtSign, Trash2 } from "lucide-react";
-import type { BoardTaskCardProps } from "../../board/BoardTaskCard";
+import { useState, useRef, useEffect, memo } from 'react';
+import { createPortal } from 'react-dom';
+import { Draggable } from '@hello-pangea/dnd';
+import {
+  Pencil,
+  Check,
+  X,
+  Clock,
+  User,
+  Calendar,
+  AtSign,
+} from 'lucide-react';
+import { useOrgMembers } from '@/lib/hooks/useOrgMembers.query';
+import type { BoardTaskCardProps } from '../../board/BoardTaskCard';
 
-export function WallPostTaskCard({
+const STATUS_DOT: Record<string, { color: string; label: string }> = {
+  awaitingCaption: { color: 'bg-gray-400', label: 'Awaiting' },
+  pending: { color: 'bg-amber-400', label: 'Pending' },
+  submitted: { color: 'bg-brand-blue', label: 'Submitted' },
+  approved: { color: 'bg-emerald-400', label: 'Approved' },
+  rejected: { color: 'bg-red-400', label: 'Rejected' },
+  posted: { color: 'bg-purple-400', label: 'Posted' },
+};
+
+function timeAgo(dateStr: string): string {
+  const then = new Date(dateStr).getTime();
+  if (isNaN(then)) return '';
+  const diff = Date.now() - then;
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return 'now';
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d`;
+  return `${Math.floor(days / 30)}mo`;
+}
+
+function formatDate(dateStr: string): string {
+  try {
+    const date = new Date(dateStr);
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  } catch {
+    return dateStr;
+  }
+}
+
+export const WallPostTaskCard = memo(function WallPostTaskCard({
   task,
   index,
   onClick,
@@ -16,14 +57,16 @@ export function WallPostTaskCard({
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(task.title);
   const inputRef = useRef<HTMLInputElement>(null);
+  const { data: orgMembers = [] } = useOrgMembers();
 
-  const meta = task.metadata ?? {};
+  const meta = (task.metadata ?? {}) as Record<string, unknown>;
   const platform = meta.platform as string | undefined;
   const scheduledDate =
     task.dueDate || (meta.scheduledDate as string | undefined);
   const hashtags = Array.isArray(meta.hashtags)
     ? (meta.hashtags as string[])
     : [];
+  const createdAt = typeof meta._createdAt === 'string' ? meta._createdAt : '';
 
   // Calculate photo status counts from captionItems
   const captionItems = Array.isArray(meta.captionItems)
@@ -47,7 +90,6 @@ export function WallPostTaskCard({
       } else if (item.captionStatus === 'rejected') {
         counts.rejected++;
       } else if (!hasCaption) {
-        // Awaiting caption: no caption text exists yet
         counts.awaitingCaption++;
       } else if (
         !item.captionStatus ||
@@ -57,37 +99,25 @@ export function WallPostTaskCard({
       }
       return counts;
     },
-    { pending: 0, submitted: 0, approved: 0, rejected: 0, posted: 0, awaitingCaption: 0 }
+    { pending: 0, submitted: 0, approved: 0, rejected: 0, posted: 0, awaitingCaption: 0 },
   );
 
-  useEffect(() => {
-    setDraft(task.title);
-  }, [task.title]);
+  const assigneeName = (() => {
+    if (!task.assignee) return null;
+    const m = orgMembers.find((mb) => mb.clerkId === task.assignee || mb.id === task.assignee);
+    if (!m) return task.assignee;
+    return m.name || `${m.firstName ?? ''} ${m.lastName ?? ''}`.trim() || m.email;
+  })();
+  const assigneeInitial = assigneeName?.charAt(0)?.toUpperCase() ?? null;
 
-  useEffect(() => {
-    if (editing) inputRef.current?.focus();
-  }, [editing]);
+  useEffect(() => { setDraft(task.title); }, [task.title]);
+  useEffect(() => { if (editing) inputRef.current?.focus(); }, [editing]);
 
   const saveTitle = () => {
     setEditing(false);
     const trimmed = draft.trim();
-    if (trimmed && trimmed !== task.title) {
-      onTitleUpdate?.(task, trimmed);
-    } else {
-      setDraft(task.title);
-    }
-  };
-
-  const formatDate = (dateStr: string) => {
-    try {
-      const date = new Date(dateStr);
-      return date.toLocaleDateString("en-US", {
-        month: "short",
-        day: "numeric",
-      });
-    } catch {
-      return dateStr;
-    }
+    if (trimmed && trimmed !== task.title) onTitleUpdate?.(task, trimmed);
+    else setDraft(task.title);
   };
 
   return (
@@ -98,206 +128,140 @@ export function WallPostTaskCard({
             ref={provided.innerRef}
             {...provided.draggableProps}
             {...provided.dragHandleProps}
-            onClick={() => {
-              if (!editing) onClick?.(task);
-            }}
+            onClick={() => { if (!editing) onClick?.(task); }}
             className={[
-            "group/card relative rounded-xl bg-white dark:bg-gray-900/90 border px-3.5 py-3 cursor-pointer select-none",
-            snapshot.isDragging
-              ? "shadow-xl border-brand-light-pink/70 ring-2 ring-brand-light-pink/30"
-              : "shadow-sm border-gray-200 dark:border-brand-mid-pink/20 hover:shadow-md hover:border-brand-light-pink/50",
-          ].join(" ")}
-        >
-          {/* Task key and delete button */}
-          <div className="flex items-center justify-between mb-1">
-            <span className="text-[10px] font-semibold tracking-wide text-brand-blue/80 dark:text-brand-blue/70">
-              {task.taskKey}
-            </span>
-            {onDelete && (
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  if (window.confirm(`Are you sure you want to delete "${task.title}"?`)) {
-                    onDelete(task.id);
-                  }
-                }}
-                className="opacity-0 group-hover/card:opacity-100 transition-opacity p-1 rounded hover:bg-red-500/10 text-gray-400 hover:text-red-500 dark:text-gray-500 dark:hover:text-red-400"
-                title="Delete task"
-              >
-                <Trash2 className="h-3 w-3" />
-              </button>
-            )}
-          </div>
-
-          {/* Title */}
-          {editing ? (
-            <div className="flex items-center gap-1.5 mb-2">
-              <input
-                ref={inputRef}
-                type="text"
-                value={draft}
-                onChange={(e) => setDraft(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") saveTitle();
-                  if (e.key === "Escape") {
-                    setEditing(false);
-                    setDraft(task.title);
-                  }
-                }}
-                onBlur={saveTitle}
-                className="flex-1 bg-white dark:bg-gray-800 border border-brand-light-pink/50 rounded-lg px-2 py-1 text-sm font-medium text-gray-900 dark:text-brand-off-white focus:outline-none focus:ring-2 focus:ring-brand-light-pink/60"
-                onClick={(e) => e.stopPropagation()}
-              />
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  saveTitle();
-                }}
-                className="p-1 rounded hover:bg-brand-light-pink/10 text-brand-light-pink"
-              >
-                <Check className="h-3.5 w-3.5" />
-              </button>
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setEditing(false);
-                  setDraft(task.title);
-                }}
-                className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-500 dark:text-gray-400"
-              >
-                <X className="h-3.5 w-3.5" />
-              </button>
-            </div>
-          ) : (
-            <div className="flex items-start justify-between gap-2 mb-2">
-              <h3 className="text-sm font-medium text-gray-900 dark:text-brand-off-white line-clamp-2 flex-1">
-                {task.title}
-              </h3>
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setEditing(true);
-                }}
-                className="opacity-0 group-hover/card:opacity-100 p-1 rounded hover:bg-brand-light-pink/10 text-brand-light-pink transition-opacity"
-              >
-                <Pencil className="h-3 w-3" />
-              </button>
-            </div>
-          )}
-
-          {/* Platform badge and assignee row */}
-          <div className="flex items-center justify-between mb-2">
-            <div className="flex items-center gap-2">
-              {platform && (
-                <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-brand-light-pink/10 text-brand-light-pink border border-brand-light-pink/20 capitalize">
-                  {platform}
+              'group/card relative rounded-xl cursor-pointer select-none',
+              'bg-white/[0.03] dark:bg-[#1a2237]/80 backdrop-blur-sm border border-[#2a3450]/60',
+              snapshot.isDragging
+                ? 'shadow-2xl shadow-black/40 border-brand-mid-pink/50 ring-1 ring-brand-light-pink/20 scale-[1.02]'
+                : 'hover:bg-white/[0.06] dark:hover:bg-[#1a2237] hover:border-[#2a3450] hover:shadow-lg hover:shadow-black/20 hover:-translate-y-0.5',
+              'transition-all duration-200',
+            ].join(' ')}
+          >
+            <div className="px-3.5 pt-3 pb-2.5">
+              {/* Row 1: Task key + platform badge */}
+              <div className="flex items-center gap-1.5 mb-2.5">
+                <span className="inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[11px] font-bold tracking-wide bg-purple-500/15 border-purple-500/25 text-purple-400">
+                  <span className="font-mono">{task.taskKey}</span>
+                  <span>WALL</span>
                 </span>
-              )}
-            </div>
-            {task.assignee && (
-              <div className="flex items-center gap-1 text-[11px] text-gray-500 dark:text-gray-400">
-                <AtSign className="h-3 w-3" />
-                <span className="truncate max-w-[100px] font-medium">{task.assignee}</span>
+                {platform && (
+                  <span className="text-[10px] font-medium text-gray-500 dark:text-gray-500 px-1.5 py-0.5 rounded bg-white/5 border border-white/[0.06] capitalize">
+                    {platform}
+                  </span>
+                )}
+                <span className="flex-1" />
+                {scheduledDate && (
+                  <span className="inline-flex items-center gap-1 text-[10px] font-medium text-gray-500 dark:text-gray-400">
+                    <Calendar className="h-3 w-3" />
+                    {formatDate(scheduledDate)}
+                  </span>
+                )}
               </div>
-            )}
-          </div>
 
-          {/* Photo status counts - Dynamic */}
-          {captionItems.length > 0 && (
-            <div className="flex items-center gap-2 mb-2">
-              {/* Awaiting Caption */}
-              {statusCounts.awaitingCaption > 0 && (
-                <div className="flex items-center gap-1">
-                  <div className="h-2 w-2 rounded-full bg-gray-400" />
-                  <span className="text-[10px] font-medium text-gray-600 dark:text-gray-400">
-                    {statusCounts.awaitingCaption}
-                  </span>
-                </div>
-              )}
-              {/* Pending */}
-              {statusCounts.pending > 0 && (
-                <div className="flex items-center gap-1">
-                  <div className="h-2 w-2 rounded-full bg-amber-500" />
-                  <span className="text-[10px] font-medium text-gray-600 dark:text-gray-400">
-                    {statusCounts.pending}
-                  </span>
-                </div>
-              )}
-              {/* Submitted */}
-              {statusCounts.submitted > 0 && (
-                <div className="flex items-center gap-1">
-                  <div className="h-2 w-2 rounded-full bg-brand-blue" />
-                  <span className="text-[10px] font-medium text-gray-600 dark:text-gray-400">
-                    {statusCounts.submitted}
-                  </span>
-                </div>
-              )}
-              {/* Approved */}
-              {statusCounts.approved > 0 && (
-                <div className="flex items-center gap-1">
-                  <div className="h-2 w-2 rounded-full bg-emerald-500" />
-                  <span className="text-[10px] font-medium text-gray-600 dark:text-gray-400">
-                    {statusCounts.approved}
-                  </span>
-                </div>
-              )}
-              {/* Rejected */}
-              {statusCounts.rejected > 0 && (
-                <div className="flex items-center gap-1">
-                  <div className="h-2 w-2 rounded-full bg-red-500" />
-                  <span className="text-[10px] font-medium text-gray-600 dark:text-gray-400">
-                    {statusCounts.rejected}
-                  </span>
-                </div>
-              )}
-              {/* Posted */}
-              {statusCounts.posted > 0 && (
-                <div className="flex items-center gap-1">
-                  <div className="h-2 w-2 rounded-full bg-purple-500" />
-                  <span className="text-[10px] font-medium text-gray-600 dark:text-gray-400">
-                    {statusCounts.posted}
-                  </span>
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* Metadata row */}
-          {scheduledDate && (
-            <div className="flex items-center gap-2 mb-2 text-[11px] text-gray-500 dark:text-gray-400">
-              <Calendar className="h-3 w-3" />
-              <span>{formatDate(scheduledDate)}</span>
-            </div>
-          )}
-
-          {/* Hashtags */}
-          {hashtags.length > 0 && (
-            <div className="mt-2 flex flex-wrap gap-1">
-              {hashtags.slice(0, 3).map((tag, i) => (
-                <span
-                  key={i}
-                  className="inline-block px-1.5 py-0.5 rounded text-[9px] font-medium bg-brand-blue/10 text-brand-blue dark:text-brand-blue/90 border border-brand-blue/20"
+              {/* Row 2: Title */}
+              {editing ? (
+                <div
+                  className="flex items-center gap-1 mb-2"
+                  onClick={(e) => e.stopPropagation()}
                 >
-                  #{String(tag)}
-                </span>
-              ))}
-              {hashtags.length > 3 && (
-                <span className="inline-block px-1.5 py-0.5 rounded text-[9px] font-medium text-gray-400">
-                  +{hashtags.length - 3}
-                </span>
+                  <input
+                    ref={inputRef}
+                    value={draft}
+                    onChange={(e) => setDraft(e.target.value)}
+                    onBlur={saveTitle}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') saveTitle();
+                      if (e.key === 'Escape') { setDraft(task.title); setEditing(false); }
+                    }}
+                    className="flex-1 min-w-0 rounded-lg bg-white/5 border border-brand-mid-pink/30 px-2 py-1 text-sm font-semibold text-gray-900 dark:text-white focus-visible:outline-none focus-visible:border-brand-light-pink/60"
+                  />
+                  <button type="button" onClick={saveTitle} className="p-0.5 text-brand-light-pink shrink-0">
+                    <Check className="h-3.5 w-3.5" />
+                  </button>
+                  <button type="button" onClick={() => { setDraft(task.title); setEditing(false); }} className="p-0.5 text-gray-500 shrink-0">
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              ) : (
+                <p className="text-[13px] font-bold leading-snug text-gray-900 dark:text-white mb-2 line-clamp-2">
+                  {task.title}
+                  <button
+                    type="button"
+                    onClick={(e) => { e.stopPropagation(); setEditing(true); }}
+                    className="inline-block ml-1 opacity-0 group-hover/card:opacity-100 transition-opacity rounded p-0.5 align-middle hover:bg-white/[0.08]"
+                  >
+                    <Pencil className="h-3 w-3 text-gray-400 dark:text-gray-500" />
+                  </button>
+                </p>
               )}
+
+              {/* Row 3: Caption status indicators */}
+              {captionItems.length > 0 && (
+                <div className="flex items-center gap-2 mb-2.5 flex-wrap">
+                  {(Object.entries(statusCounts) as [keyof typeof statusCounts, number][])
+                    .filter(([, count]) => count > 0)
+                    .map(([key, count]) => {
+                      const cfg = STATUS_DOT[key];
+                      if (!cfg) return null;
+                      return (
+                        <span key={key} className="inline-flex items-center gap-1 text-[10px] font-medium text-gray-500 dark:text-gray-400">
+                          <span className={`h-2 w-2 rounded-full ${cfg.color}`} />
+                          {count} {cfg.label}
+                        </span>
+                      );
+                    })}
+                </div>
+              )}
+
+              {/* Hashtags */}
+              {hashtags.length > 0 && (
+                <div className="flex flex-wrap gap-1 mb-2.5">
+                  {hashtags.slice(0, 3).map((tag, i) => (
+                    <span
+                      key={i}
+                      className="inline-block px-1.5 py-0.5 rounded text-[9px] font-medium bg-brand-blue/10 text-brand-blue dark:text-brand-blue/90 border border-brand-blue/20"
+                    >
+                      #{String(tag)}
+                    </span>
+                  ))}
+                  {hashtags.length > 3 && (
+                    <span className="inline-block px-1.5 py-0.5 rounded text-[9px] font-medium text-gray-500">
+                      +{hashtags.length - 3}
+                    </span>
+                  )}
+                </div>
+              )}
+
+              {/* Footer: timestamp + assignee */}
+              <div className="flex items-center gap-2.5 pt-2.5 border-t border-white/[0.06]">
+                {createdAt && (
+                  <span className="text-[11px] text-gray-500 dark:text-gray-500 inline-flex items-center gap-1">
+                    <Clock className="h-3 w-3" />
+                    {timeAgo(createdAt)}
+                  </span>
+                )}
+
+                <span className="flex-1" />
+
+                {assigneeInitial ? (
+                  <span
+                    className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-brand-light-pink/15 text-brand-light-pink text-[11px] font-bold ring-1 ring-brand-light-pink/20 group-hover/card:ring-brand-light-pink/40 transition-all"
+                    title={assigneeName ?? undefined}
+                  >
+                    {assigneeInitial}
+                  </span>
+                ) : (
+                  <User className="h-3.5 w-3.5 text-gray-500 dark:text-gray-600" />
+                )}
+              </div>
             </div>
-          )}
           </div>
         );
 
-        if (snapshot.isDragging) {
-          return createPortal(card, document.body);
-        }
-
+        if (snapshot.isDragging) return createPortal(card, document.body);
         return card;
       }}
     </Draggable>
   );
-}
+});

--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/template-config.ts
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/template-config.ts
@@ -53,7 +53,7 @@ const sextingSetsItemToTask: ItemToTaskFn = (item: BoardItem, spaceKey: string):
       ...(Array.isArray(meta.tags) ? (meta.tags as string[]) : []),
     ],
     dueDate: item.dueDate ?? undefined,
-    metadata: meta,
+    metadata: { ...meta, _createdAt: item.createdAt, _updatedAt: item.updatedAt },
   };
 };
 

--- a/app/[tenant]/(dashboard)/spaces/board/BoardTaskCard.tsx
+++ b/app/[tenant]/(dashboard)/spaces/board/BoardTaskCard.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, memo } from 'react';
 import { createPortal } from 'react-dom';
 import { Draggable } from '@hello-pangea/dnd';
-import { Pencil, Check, X } from 'lucide-react';
+import { Pencil, Check, X, Clock, User } from 'lucide-react';
 
 export interface BoardTask {
   id: string;
@@ -29,33 +29,54 @@ export interface BoardTaskCardProps {
   onDelete?: (taskId: string) => void;
 }
 
-const PRIORITY_STYLES: Record<string, string> = {
-  High: 'bg-red-500/10 text-red-500 dark:text-red-400',
-  Medium: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
-  Low: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+const PRIORITY_BORDER: Record<string, string> = {
+  High: 'border-l-red-400',
+  Medium: 'border-l-amber-400',
+  Low: 'border-l-emerald-400',
 };
 
-export function BoardTaskCard({ task, index, onClick, onTitleUpdate }: BoardTaskCardProps) {
+const PRIORITY_DOT: Record<string, string> = {
+  High: 'bg-red-400',
+  Medium: 'bg-amber-400',
+  Low: 'bg-emerald-400',
+};
+
+function timeAgo(dateStr: string): string {
+  const then = new Date(dateStr).getTime();
+  if (isNaN(then)) return '';
+  const diff = Date.now() - then;
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return 'now';
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d`;
+  return `${Math.floor(days / 30)}mo`;
+}
+
+export const BoardTaskCard = memo(function BoardTaskCard({
+  task,
+  index,
+  onClick,
+  onTitleUpdate,
+}: BoardTaskCardProps) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(task.title);
   const inputRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
-    setDraft(task.title);
-  }, [task.title]);
+  const meta = (task.metadata ?? {}) as Record<string, unknown>;
+  const createdAt = typeof meta._createdAt === 'string' ? meta._createdAt : '';
+  const priorityBorder = PRIORITY_BORDER[task.priority ?? ''] ?? 'border-l-transparent';
 
-  useEffect(() => {
-    if (editing) inputRef.current?.focus();
-  }, [editing]);
+  useEffect(() => { setDraft(task.title); }, [task.title]);
+  useEffect(() => { if (editing) inputRef.current?.focus(); }, [editing]);
 
   const saveTitle = () => {
     setEditing(false);
     const trimmed = draft.trim();
-    if (trimmed && trimmed !== task.title) {
-      onTitleUpdate?.(task, trimmed);
-    } else {
-      setDraft(task.title);
-    }
+    if (trimmed && trimmed !== task.title) onTitleUpdate?.(task, trimmed);
+    else setDraft(task.title);
   };
 
   return (
@@ -66,109 +87,115 @@ export function BoardTaskCard({ task, index, onClick, onTitleUpdate }: BoardTask
             ref={provided.innerRef}
             {...provided.draggableProps}
             {...provided.dragHandleProps}
-            onClick={() => {
-              if (!editing) onClick?.(task);
-            }}
+            onClick={() => { if (!editing) onClick?.(task); }}
             className={[
-              'group/card relative rounded-xl bg-white dark:bg-gray-900/90 border px-3.5 py-3 cursor-pointer select-none',
+              'group/card relative rounded-xl cursor-pointer select-none',
+              'border-l-[3px]',
+              priorityBorder,
+              'bg-white/[0.03] dark:bg-[#1a2237]/80 backdrop-blur-sm border border-[#2a3450]/60',
               snapshot.isDragging
-                ? 'shadow-xl border-brand-light-pink/70 ring-2 ring-brand-light-pink/30'
-                : 'shadow-sm border-gray-200 dark:border-brand-mid-pink/20 hover:shadow-md hover:border-brand-light-pink/50',
+                ? 'shadow-2xl shadow-black/40 border-brand-mid-pink/50 ring-1 ring-brand-light-pink/20 scale-[1.02]'
+                : 'hover:bg-white/[0.06] dark:hover:bg-[#1a2237] hover:border-[#2a3450] hover:shadow-lg hover:shadow-black/20 hover:-translate-y-0.5',
+              'transition-all duration-200',
             ].join(' ')}
           >
-            {/* Task key */}
-            <span className="text-[10px] font-semibold tracking-wide text-brand-blue/80 dark:text-brand-blue/70 mb-1 block">
-              {task.taskKey}
-            </span>
+            <div className="px-3.5 pt-3 pb-2.5">
+              {/* Row 1: Task key + priority badge */}
+              <div className="flex items-center gap-1.5 mb-2.5">
+                <span className="inline-flex items-center rounded-md border px-2 py-0.5 text-[11px] font-bold tracking-wide bg-gray-500/15 border-gray-500/25 text-gray-400 font-mono">
+                  {task.taskKey}
+                </span>
 
-            {task.priority && (
-              <span
-                className={`inline-block rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider mb-1.5 ${PRIORITY_STYLES[task.priority] ?? ''}`}
-              >
-                {task.priority}
-              </span>
-            )}
+                <span className="flex-1" />
 
-            {/* Title row with inline edit */}
-            {editing ? (
-              <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
-                <input
-                  ref={inputRef}
-                  value={draft}
-                  onChange={(e) => setDraft(e.target.value)}
-                  onBlur={saveTitle}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') saveTitle();
-                    if (e.key === 'Escape') {
-                      setDraft(task.title);
-                      setEditing(false);
-                    }
-                  }}
-                  className="flex-1 min-w-0 rounded-lg border border-brand-light-pink/50 bg-white dark:bg-gray-900 px-2 py-0.5 text-[13px] font-medium text-gray-800 dark:text-brand-off-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-light-pink/60"
-                />
-                <button type="button" onClick={saveTitle} className="p-0.5 text-brand-light-pink shrink-0">
-                  <Check className="h-3.5 w-3.5" />
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    setDraft(task.title);
-                    setEditing(false);
-                  }}
-                  className="p-0.5 text-gray-400 hover:text-gray-600 shrink-0"
-                >
-                  <X className="h-3.5 w-3.5" />
-                </button>
-              </div>
-            ) : (
-              <p className="text-[13px] font-medium leading-snug text-gray-800 dark:text-brand-off-white wrap-break-word">
-                {task.title}
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setEditing(true);
-                  }}
-                  className="inline-block ml-1 opacity-0 group-hover/card:opacity-100 transition-opacity hover:bg-gray-100 dark:hover:bg-gray-800 rounded p-0.5 align-middle"
-                >
-                  <Pencil className="h-3 w-3 text-gray-400 hover:text-brand-light-pink" />
-                </button>
-              </p>
-            )}
-
-            {(task.tags?.length || task.assignee) && (
-              <div className="mt-2.5 flex items-center justify-between gap-2">
-                {task.tags && task.tags.length > 0 && (
-                  <div className="flex items-center gap-1.5 flex-wrap min-w-0">
-                    {task.tags.map((tag) => (
-                      <span
-                        key={tag}
-                        className="inline-flex items-center rounded-full bg-brand-light-pink/10 text-brand-light-pink px-2 py-0.5 text-[10px] font-medium truncate"
-                      >
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
-                )}
-                {task.assignee && (
-                  <span
-                    className="shrink-0 inline-flex h-6 w-6 items-center justify-center rounded-full bg-brand-blue/15 text-brand-blue text-[10px] font-bold uppercase"
-                    title={task.assignee}
-                  >
-                    {task.assignee.charAt(0)}
+                {task.priority && (
+                  <span className="inline-flex items-center gap-1 text-[11px] text-gray-500 dark:text-gray-400 font-medium">
+                    <span className={`h-2 w-2 rounded-full ${PRIORITY_DOT[task.priority] ?? ''}`} />
+                    {task.priority}
                   </span>
                 )}
               </div>
-            )}
+
+              {/* Row 2: Title */}
+              {editing ? (
+                <div
+                  className="flex items-center gap-1 mb-2"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <input
+                    ref={inputRef}
+                    value={draft}
+                    onChange={(e) => setDraft(e.target.value)}
+                    onBlur={saveTitle}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') saveTitle();
+                      if (e.key === 'Escape') { setDraft(task.title); setEditing(false); }
+                    }}
+                    className="flex-1 min-w-0 rounded-lg bg-white/5 border border-brand-mid-pink/30 px-2 py-1 text-sm font-semibold text-gray-900 dark:text-white focus-visible:outline-none focus-visible:border-brand-light-pink/60"
+                  />
+                  <button type="button" onClick={saveTitle} className="p-0.5 text-brand-light-pink shrink-0">
+                    <Check className="h-3.5 w-3.5" />
+                  </button>
+                  <button type="button" onClick={() => { setDraft(task.title); setEditing(false); }} className="p-0.5 text-gray-500 shrink-0">
+                    <X className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              ) : (
+                <p className="text-[13px] font-bold leading-snug text-gray-900 dark:text-white mb-2 line-clamp-2">
+                  {task.title}
+                  <button
+                    type="button"
+                    onClick={(e) => { e.stopPropagation(); setEditing(true); }}
+                    className="inline-block ml-1 opacity-0 group-hover/card:opacity-100 transition-opacity rounded p-0.5 align-middle hover:bg-white/[0.08]"
+                  >
+                    <Pencil className="h-3 w-3 text-gray-400 dark:text-gray-500" />
+                  </button>
+                </p>
+              )}
+
+              {/* Row 3: Tags */}
+              {task.tags && task.tags.length > 0 && (
+                <div className="flex items-center gap-1.5 flex-wrap mb-2.5">
+                  {task.tags.map((tag) => (
+                    <span
+                      key={tag}
+                      className="inline-flex items-center rounded-md bg-brand-light-pink/10 text-brand-light-pink px-1.5 py-0.5 text-[10px] font-medium border border-brand-light-pink/15 truncate"
+                    >
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              )}
+
+              {/* Footer: timestamp + assignee */}
+              <div className="flex items-center gap-2.5 pt-2.5 border-t border-white/[0.06]">
+                {createdAt && (
+                  <span className="text-[11px] text-gray-500 dark:text-gray-500 inline-flex items-center gap-1">
+                    <Clock className="h-3 w-3" />
+                    {timeAgo(createdAt)}
+                  </span>
+                )}
+
+                <span className="flex-1" />
+
+                {task.assignee ? (
+                  <span
+                    className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-brand-blue/15 text-brand-blue text-[11px] font-bold ring-1 ring-brand-blue/20 group-hover/card:ring-brand-blue/40 transition-all"
+                    title={task.assignee}
+                  >
+                    {task.assignee.charAt(0).toUpperCase()}
+                  </span>
+                ) : (
+                  <User className="h-3.5 w-3.5 text-gray-500 dark:text-gray-600" />
+                )}
+              </div>
+            </div>
           </div>
         );
 
-        if (snapshot.isDragging) {
-          return createPortal(card, document.body);
-        }
-
+        if (snapshot.isDragging) return createPortal(card, document.body);
         return card;
       }}
     </Draggable>
   );
-}
+});

--- a/components/content-submission/ContentDetailsFields.tsx
+++ b/components/content-submission/ContentDetailsFields.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState, useMemo, useRef, useEffect } from 'react';
+import { useCallback, useState, useMemo, useRef, useEffect, memo } from 'react';
 import { createPortal } from 'react-dom';
 import {
   Image,
@@ -108,6 +108,21 @@ const PAGE_TYPE_OPTIONS = [
   { value: 'VIP', label: 'VIP' },
 ];
 
+function useOutsideClick(
+  ref: React.RefObject<HTMLElement | null>,
+  onOutside: () => void
+) {
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onOutside();
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [ref, onOutside]);
+}
+
 interface ContentDetailsFieldsProps {
   register: UseFormRegister<CreateSubmissionWithComponents>;
   setValue: UseFormSetValue<CreateSubmissionWithComponents>;
@@ -164,28 +179,18 @@ export function ContentDetailsFields({
   const { data: influencerProfiles, isLoading: influencerProfilesLoading } = useInstagramProfiles();
 
   // Close content type dropdown on outside click
-  useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      if (contentTypeRef.current && !contentTypeRef.current.contains(e.target as Node)) {
-        setContentTypeOpen(false);
-        setContentTypeSearch('');
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
+  const closeContentType = useCallback(() => {
+    setContentTypeOpen(false);
+    setContentTypeSearch('');
   }, []);
+  useOutsideClick(contentTypeRef, closeContentType);
 
   // Close content tags dropdown on outside click
-  useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      if (contentTagsRef.current && !contentTagsRef.current.contains(e.target as Node)) {
-        setContentTagsOpen(false);
-        setContentTagsSearch('');
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
+  const closeContentTags = useCallback(() => {
+    setContentTagsOpen(false);
+    setContentTagsSearch('');
   }, []);
+  useOutsideClick(contentTagsRef, closeContentTags);
 
   // Filtered content type options
   const filteredContentTypeOptions = useMemo(() => {
@@ -229,21 +234,26 @@ export function ContentDetailsFields({
     );
   }, [sortedProfiles, internalModelsSearch]);
 
+  // Keep a ref to watch so handleMetadataChange doesn't depend on it directly
+  const watchRef = useRef(watch);
+  watchRef.current = watch;
+
   const handleTemplateChange = useCallback(
     (type: SubmissionTemplateType) => {
       setValue('submissionType', type);
       const defaults = getMetadataDefaults(type);
-      setValue('metadata', { ...defaults, ...metadata });
+      const current = watchRef.current('metadata') || {};
+      setValue('metadata', { ...defaults, ...current });
     },
-    [setValue, metadata]
+    [setValue]
   );
 
   const handleMetadataChange = useCallback(
     (key: string, value: any) => {
-      const current = watch('metadata') || {};
+      const current = watchRef.current('metadata') || {};
       setValue('metadata', { ...current, [key]: value }, { shouldDirty: true });
     },
-    [setValue, watch]
+    [setValue]
   );
 
   const handleContentTypeSelect = useCallback(
@@ -1080,7 +1090,7 @@ export function ContentDetailsFields({
 }
 
 // Dynamic metadata field renderer
-function MetadataFieldInput({
+const MetadataFieldInput = memo(function MetadataFieldInput({
   field,
   value,
   onChange,
@@ -1211,7 +1221,7 @@ function MetadataFieldInput({
       />
     </div>
   );
-}
+});
 
 // ─── Assignee Picker ─────────────────────────────────────────────────────────
 
@@ -1269,7 +1279,7 @@ function useAssignableMembers(spaceId: string) {
   return { members, isLoading, source };
 }
 
-function AssigneePicker({
+const AssigneePicker = memo(function AssigneePicker({
   spaceId,
   assigneeId,
   onAssigneeChange,
@@ -1465,9 +1475,9 @@ function AssigneePicker({
       )}
     </div>
   );
-}
+});
 
-function TagInput({
+const TagInput = memo(function TagInput({
   tags,
   onChange,
   placeholder,
@@ -1531,4 +1541,4 @@ function TagInput({
       )}
     </div>
   );
-}
+});

--- a/components/content-submission/SubmissionForm.tsx
+++ b/components/content-submission/SubmissionForm.tsx
@@ -203,6 +203,40 @@ export const SubmissionForm = memo(function SubmissionForm({
     SEXTING_SETS: 'SET',
   };
 
+  const buildMetadata = useCallback((
+    data: FormData,
+    meta: Record<string, unknown>,
+    extraFields?: Record<string, unknown>,
+  ) => ({
+    // Spread raw metadata first so explicit fields below take priority
+    ...meta,
+    submissionType: data.submissionType,
+    contentStyle,
+    // Game-specific fields
+    ...(contentStyle === 'game' ? {
+      gameType: styleFields.gameType || undefined,
+      gifUrl: styleFields.gifUrl || undefined,
+      gameNotes: styleFields.gameNotes || undefined,
+    } : {}),
+    // PPV/Bundle-specific fields
+    ...(contentStyle === 'ppv' || contentStyle === 'bundle' ? {
+      originalPollReference: styleFields.originalPollReference || undefined,
+    } : {}),
+    pricingCategory: data.pricingCategory,
+    pageType: (meta as Record<string, unknown>).pageType || 'ALL_PAGES',
+    contentType: data.contentType,
+    contentTypeOptionId: data.contentTypeOptionId,
+    contentTags: data.contentTags,
+    internalModelTags: data.internalModelTags,
+    externalCreatorTags: data.externalCreatorTags,
+    // Hoist top-level form fields into metadata so board items can access them
+    modelId: data.modelId ?? null,
+    platforms: data.platform ?? ['onlyfans'],
+    // Wall post workflow: set initial status so it appears in Caption Workspace flow
+    ...(data.submissionType === 'WALL_POST' ? { wallPostStatus: 'PENDING_CAPTION' } : {}),
+    ...extraFields,
+  }), [contentStyle, styleFields]);
+
   const onSubmit = async (data: FormData) => {
     setSubmitError(null);
 
@@ -233,34 +267,7 @@ export const SubmissionForm = memo(function SubmissionForm({
         priority: PRIORITY_MAP[data.priority ?? 'normal'] ?? 'MEDIUM',
         dueDate: rawDue ? new Date(rawDue).toISOString() : undefined,
         assigneeId: assigneeId || undefined,
-        metadata: {
-          // Spread raw metadata first so explicit fields below take priority
-          ...meta,
-          submissionType: data.submissionType,
-          contentStyle,
-          // Game-specific fields
-          ...(contentStyle === 'game' ? {
-            gameType: styleFields.gameType || undefined,
-            gifUrl: styleFields.gifUrl || undefined,
-            gameNotes: styleFields.gameNotes || undefined,
-          } : {}),
-          // PPV/Bundle-specific fields
-          ...(contentStyle === 'ppv' || contentStyle === 'bundle' ? {
-            originalPollReference: styleFields.originalPollReference || undefined,
-          } : {}),
-          pricingCategory: data.pricingCategory,
-          pageType: (meta as Record<string, unknown>).pageType || 'ALL_PAGES',
-          contentType: data.contentType,
-          contentTypeOptionId: data.contentTypeOptionId,
-          contentTags: data.contentTags,
-          internalModelTags: data.internalModelTags,
-          externalCreatorTags: data.externalCreatorTags,
-          // Hoist top-level form fields into metadata so board items can access them
-          modelId: data.modelId ?? null,
-          platforms: data.platform ?? ['onlyfans'],
-          // Wall post workflow: set initial status so it appears in Caption Workspace flow
-          ...(data.submissionType === 'WALL_POST' ? { wallPostStatus: 'PENDING_CAPTION' } : {}),
-        },
+        metadata: buildMetadata(data, meta),
       };
 
       // 1. Create BoardItem in EACH selected space
@@ -304,37 +311,28 @@ export const SubmissionForm = memo(function SubmissionForm({
         const submission = await createSubmission.mutateAsync({
           ...data,
           workspaceId: primaryItem.spaceId,
-          metadata: {
-            ...meta,
-            contentStyle,
-            // Game-specific fields
-            ...(contentStyle === 'game' ? {
-              gameType: styleFields.gameType || undefined,
-              gifUrl: styleFields.gifUrl || undefined,
-              gameNotes: styleFields.gameNotes || undefined,
-            } : {}),
-            // PPV/Bundle-specific fields
-            ...(contentStyle === 'ppv' || contentStyle === 'bundle' ? {
-              originalPollReference: styleFields.originalPollReference || undefined,
-            } : {}),
+          metadata: buildMetadata(data, meta, {
             boardItemId: primaryItem.itemId,
             targetSpaces: createdItems.map((i) => ({ spaceId: i.spaceId, boardId: i.boardId, itemId: i.itemId })),
             submitStatus: 'SUBMITTED',
-          },
+          }),
         });
         contentSubmissionId = submission?.id ?? null;
       } catch (err) {
         console.error('Content submission record creation failed:', err);
       }
 
-      // 3. Upload files once, create media records in ALL board items
+      // 3. Upload files in parallel, create media records in ALL board items
       if (pendingFiles.length > 0) {
-        for (let i = 0; i < pendingFiles.length; i++) {
-          const file = pendingFiles[i];
-          setFileUploadStep({ current: i + 1, total: pendingFiles.length });
-          try {
+        const totalFiles = pendingFiles.length;
+        let completedFiles = 0;
+        setFileUploadStep({ current: 0, total: totalFiles });
+
+        const primaryMediaBase = `/api/spaces/${primaryItem.spaceId}/boards/${primaryItem.boardId}/items/${primaryItem.itemId}/media`;
+
+        const uploadResults = await Promise.allSettled(
+          pendingFiles.map(async (file, i) => {
             // Presign via the primary item
-            const primaryMediaBase = `/api/spaces/${primaryItem.spaceId}/boards/${primaryItem.boardId}/items/${primaryItem.itemId}/media`;
             const presignRes = await fetch(primaryMediaBase, {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
@@ -343,44 +341,45 @@ export const SubmissionForm = memo(function SubmissionForm({
             if (!presignRes.ok) throw new Error('Failed to get upload URL');
             const presigned = await presignRes.json();
 
-            // Upload directly to S3 (once)
-            await fetch(presigned.uploadUrl, {
-              method: 'PUT',
-              body: file,
-              headers: { 'Content-Type': file.type },
-            });
-
-            // Create media record in primary item
-            await fetch(primaryMediaBase, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
-                action: 'record',
-                url: presigned.fileUrl,
-                type: file.type,
-                name: file.name,
-                size: file.size,
+            // Upload to S3 and create primary media record concurrently
+            await Promise.all([
+              fetch(presigned.uploadUrl, {
+                method: 'PUT',
+                body: file,
+                headers: { 'Content-Type': file.type },
               }),
-            });
+              fetch(primaryMediaBase, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                  action: 'record',
+                  url: presigned.fileUrl,
+                  type: file.type,
+                  name: file.name,
+                  size: file.size,
+                }),
+              }),
+            ]);
 
             // Create media records in additional items (link same S3 URL)
-            for (let j = 1; j < createdItems.length; j++) {
-              const item = createdItems[j];
-              try {
-                await fetch(`/api/spaces/${item.spaceId}/boards/${item.boardId}/items/${item.itemId}/media`, {
-                  method: 'POST',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({
-                    action: 'record',
-                    url: presigned.fileUrl,
-                    type: file.type,
-                    name: file.name,
-                    size: file.size,
-                  }),
-                });
-              } catch (linkErr) {
-                console.error(`Media link failed for space ${item.spaceId}:`, file.name, linkErr);
-              }
+            if (createdItems.length > 1) {
+              await Promise.allSettled(
+                createdItems.slice(1).map((item) =>
+                  fetch(`/api/spaces/${item.spaceId}/boards/${item.boardId}/items/${item.itemId}/media`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                      action: 'record',
+                      url: presigned.fileUrl,
+                      type: file.type,
+                      name: file.name,
+                      size: file.size,
+                    }),
+                  }).catch((linkErr) => {
+                    console.error(`Media link failed for space ${item.spaceId}:`, file.name, linkErr);
+                  })
+                )
+              );
             }
 
             // Dual-write to content_submission_files
@@ -411,10 +410,20 @@ export const SubmissionForm = memo(function SubmissionForm({
                 console.error('Dual-write to content_submission_files failed:', file.name, dualWriteErr);
               }
             }
-          } catch (err) {
-            console.error('File upload failed:', file.name, err);
+
+            // Update progress as each file completes
+            completedFiles++;
+            setFileUploadStep({ current: completedFiles, total: totalFiles });
+          })
+        );
+
+        // Log any failed uploads
+        uploadResults.forEach((result, i) => {
+          if (result.status === 'rejected') {
+            console.error('File upload failed:', pendingFiles[i].name, result.reason);
           }
-        }
+        });
+
         setFileUploadStep(null);
       }
 
@@ -774,12 +783,6 @@ const LocalFilePicker = memo(function LocalFilePicker({
 
 // ─── Review Step ─────────────────────────────────────────────────────────────
 
-const TEMPLATE_LABELS_REVIEW: Record<string, string> = {
-  OTP_PTR: 'OTP / PTR',
-  WALL_POST: 'Wall Post',
-  SEXTING_SETS: 'Sexting Sets',
-};
-
 const ReviewStep = memo(function ReviewStep({
   selectedSpaces,
   submissionType,
@@ -813,6 +816,14 @@ const ReviewStep = memo(function ReviewStep({
     refetchOnWindowFocus: false,
   });
 
+  // Destructure watched fields once to avoid repeated watch() calls
+  const priority = watch('priority');
+  const contentTags = watch('contentTags') || [];
+  const internalModelTags = watch('internalModelTags') || [];
+  const contentType = watch('contentType');
+  const pricingCategory = watch('pricingCategory');
+  const metadata = watch('metadata') || {};
+
   const assignee = useMemo(() => {
     if (!assigneeId) return null;
     // Try space members first
@@ -828,8 +839,7 @@ const ReviewStep = memo(function ReviewStep({
     return null;
   }, [assigneeId, spaceMembers, orgMembers]);
 
-  const meta = watch('metadata') || {};
-  const entries = Object.entries(meta).filter(
+  const entries = Object.entries(metadata).filter(
     ([key, v]) =>
       key !== 'submitStatus' &&
       key !== 'boardItemId' &&
@@ -865,13 +875,13 @@ const ReviewStep = memo(function ReviewStep({
           <div>
             <p className="text-xs text-zinc-500 mb-1">Submission Type</p>
             <p className="text-white font-medium">
-              {TEMPLATE_LABELS_REVIEW[submissionType] ?? submissionType}
+              {TEMPLATE_LABELS[submissionType] ?? submissionType}
             </p>
           </div>
-          {watch('priority') && (
+          {priority && (
             <div>
               <p className="text-xs text-zinc-500 mb-1">Priority</p>
-              <p className="text-white font-medium capitalize">{watch('priority')}</p>
+              <p className="text-white font-medium capitalize">{priority}</p>
             </div>
           )}
           {assignee && (
@@ -953,25 +963,25 @@ const ReviewStep = memo(function ReviewStep({
             <div>
               <p className="text-xs text-zinc-500 mb-1">Pricing Tier</p>
               <p className="text-white font-medium">
-                {({'PORN_ACCURATE':'Porn Accurate','PORN_SCAM':'Porn Scam','GF_ACCURATE':'GF Accurate','GF_SCAM':'GF Scam'} as Record<string,string>)[watch('pricingCategory') || ''] || watch('pricingCategory') || 'Not set'}
+                {({'PORN_ACCURATE':'Porn Accurate','PORN_SCAM':'Porn Scam','GF_ACCURATE':'GF Accurate','GF_SCAM':'GF Scam'} as Record<string,string>)[pricingCategory || ''] || pricingCategory || 'Not set'}
               </p>
             </div>
             <div>
               <p className="text-xs text-zinc-500 mb-1">Page Type</p>
               <p className="text-white font-medium">
-                {({'ALL_PAGES':'All Pages','FREE':'Free','PAID':'Paid','VIP':'VIP'} as Record<string,string>)[(watch('metadata') as Record<string,any>)?.pageType || ''] || 'All Pages'}
+                {({'ALL_PAGES':'All Pages','FREE':'Free','PAID':'Paid','VIP':'VIP'} as Record<string,string>)[(metadata as Record<string,any>)?.pageType || ''] || 'All Pages'}
               </p>
             </div>
             <div>
               <p className="text-xs text-zinc-500 mb-1">Content Type</p>
-              <p className="text-white font-medium">{watch('contentType') || 'Not selected'}</p>
+              <p className="text-white font-medium">{contentType || 'Not selected'}</p>
             </div>
             {/* Content Tags */}
             <div className="col-span-2">
               <p className="text-xs text-zinc-500 mb-2">Content Tags</p>
-              {(watch('contentTags') || []).length > 0 ? (
+              {contentTags.length > 0 ? (
                 <div className="flex flex-wrap gap-1.5">
-                  {(watch('contentTags') || []).map((tag: string) => (
+                  {contentTags.map((tag: string) => (
                     <span key={tag} className="px-2 py-0.5 bg-brand-light-pink/10 border border-brand-light-pink/20 text-brand-light-pink rounded-md text-xs font-medium">
                       {tag}
                     </span>
@@ -985,8 +995,8 @@ const ReviewStep = memo(function ReviewStep({
             <div className="col-span-2">
               <p className="text-xs text-zinc-500 mb-1">Internal Models</p>
               <p className="text-white font-medium text-sm">
-                {(watch('internalModelTags') || []).length > 0
-                  ? (watch('internalModelTags') || []).join(', ')
+                {internalModelTags.length > 0
+                  ? internalModelTags.join(', ')
                   : 'None'}
               </p>
             </div>
@@ -998,7 +1008,7 @@ const ReviewStep = memo(function ReviewStep({
       {entries.length > 0 && (
         <div className="bg-zinc-800/30 rounded-xl p-6 border border-zinc-700/30">
           <h3 className="text-sm font-medium text-zinc-400 mb-3">
-            {TEMPLATE_LABELS_REVIEW[submissionType]} Details
+            {TEMPLATE_LABELS[submissionType]} Details
           </h3>
           <div className="grid grid-cols-2 gap-3">
             {entries.map(([key, val]) => (


### PR DESCRIPTION
Unify all board card designs (OTP/PTR, Wall Post, Sexting Sets, Model Onboarding, Kanban) with consistent dark glassmorphic styling. Redesign OTP/PTR task detail modal with new header layout, quick info bar, 4-tab structure (Details, Workflow, History, Comments), and refined properties sidebar.