### PR TITLE
feat: redesign OTP/PTR board cards and detail modal with glassmorphism

### DIFF
--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/OtpPtrTaskCard.tsx
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/OtpPtrTaskCard.tsx
@@ -31,15 +31,15 @@ interface OtpPtrTaskCardProps {
 const TYPE_BADGE: Record<string, { bg: string; text: string }> = {
   OTP: { bg: 'bg-blue-500/15 border-blue-500/25', text: 'text-blue-400' },
   PTR: { bg: 'bg-brand-light-pink/15 border-brand-light-pink/25', text: 'text-brand-light-pink' },
-  CUSTOM: { bg: 'bg-amber-500/15 border-amber-500/25', text: 'text-amber-400' },
-};
-
-const STYLE_LABEL: Record<string, string> = {
-  GAME: 'Game',
-  PPV: 'PPV',
-  POLL: 'Poll',
-  BUNDLE: 'Bundle',
-  NORMAL: '',
+  OTM: { bg: 'bg-violet-500/15 border-violet-500/25', text: 'text-violet-400' },
+  PPV: { bg: 'bg-emerald-500/15 border-emerald-500/25', text: 'text-emerald-400' },
+  GAME: { bg: 'bg-amber-500/15 border-amber-500/25', text: 'text-amber-400' },
+  LIVE: { bg: 'bg-red-500/15 border-red-500/25', text: 'text-red-400' },
+  TIP_ME: { bg: 'bg-cyan-500/15 border-cyan-500/25', text: 'text-cyan-400' },
+  VIP: { bg: 'bg-yellow-500/15 border-yellow-500/25', text: 'text-yellow-400' },
+  DM_FUNNEL: { bg: 'bg-indigo-500/15 border-indigo-500/25', text: 'text-indigo-400' },
+  RENEW_ON: { bg: 'bg-teal-500/15 border-teal-500/25', text: 'text-teal-400' },
+  CUSTOM: { bg: 'bg-gray-500/15 border-gray-500/25', text: 'text-gray-400' },
 };
 
 const PRIORITY_BORDER: Record<string, string> = {
@@ -105,13 +105,10 @@ export const OtpPtrTaskCard = memo(function OtpPtrTaskCard({
     else setDraft(task.title);
   };
 
-  const requestType = (meta.requestType as string) ?? '';
-  const contentStyle = (meta.contentStyle as string) ?? 'NORMAL';
-  const styleLabel = STYLE_LABEL[contentStyle] ?? '';
+  // Backward compat: read postOrigin, fall back to old requestType
+  const postOrigin = (meta.postOrigin as string) ?? (meta.requestType as string) ?? '';
   const price = meta.price as number | undefined;
-  const isPaid = meta.isPaid as boolean | undefined;
   const model = (meta.model as string) ?? '';
-  const buyer = (meta.buyer as string) ?? '';
   const platforms = Array.isArray(meta.platforms) ? (meta.platforms as string[]) : [];
   const deadline = (meta.deadline as string) ?? '';
   const createdAt = typeof meta._createdAt === 'string' ? meta._createdAt : '';
@@ -126,7 +123,7 @@ export const OtpPtrTaskCard = memo(function OtpPtrTaskCard({
   })();
 
   const assigneeInitial = assigneeName?.charAt(0)?.toUpperCase() ?? null;
-  const typeBadge = TYPE_BADGE[requestType] ?? { bg: 'bg-gray-500/15 border-gray-500/25', text: 'text-gray-400' };
+  const typeBadge = TYPE_BADGE[postOrigin] ?? { bg: 'bg-gray-500/15 border-gray-500/25', text: 'text-gray-400' };
   const priorityBorder = PRIORITY_BORDER[task.priority ?? ''] ?? 'border-l-transparent';
 
   return (
@@ -142,25 +139,20 @@ export const OtpPtrTaskCard = memo(function OtpPtrTaskCard({
               'group/card relative rounded-xl cursor-pointer select-none',
               'border-l-[3px]',
               priorityBorder,
-              'bg-white/[0.03] dark:bg-[#1a2237]/80 backdrop-blur-sm border border-[#2a3450]/60',
+              'bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 shadow-sm',
               snapshot.isDragging
-                ? 'shadow-2xl shadow-black/40 border-brand-mid-pink/50 ring-1 ring-brand-light-pink/20 scale-[1.02]'
-                : 'hover:bg-white/[0.06] dark:hover:bg-[#1a2237] hover:border-[#2a3450] hover:shadow-lg hover:shadow-black/20 hover:-translate-y-0.5',
+                ? 'shadow-2xl shadow-black/40 border-brand-mid-pink/40 ring-1 ring-brand-light-pink/20 scale-[1.02]'
+                : 'hover:shadow-xl dark:hover:shadow-2xl hover:border-pink-200 dark:hover:border-pink-700 hover:-translate-y-0.5',
               'transition-all duration-200',
             ].join(' ')}
           >
             <div className="px-3.5 pt-3 pb-2.5">
-              {/* Row 1: ticket badge + style + caption status */}
+              {/* Row 1: ticket badge + post origin + caption status */}
               <div className="flex items-center gap-1.5 mb-2.5">
                 <span className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-0.5 text-[11px] font-bold tracking-wide ${typeBadge.bg} ${typeBadge.text}`}>
                   <span className="font-mono">{task.taskKey}</span>
-                  {requestType && <span>{requestType}</span>}
+                  {postOrigin && <span>{postOrigin.replace(/_/g, ' ')}</span>}
                 </span>
-                {styleLabel && (
-                  <span className="text-[10px] font-medium text-gray-500 dark:text-gray-500 px-1.5 py-0.5 rounded bg-white/5">
-                    {styleLabel}
-                  </span>
-                )}
 
                 <span className="flex-1" />
 
@@ -212,30 +204,24 @@ export const OtpPtrTaskCard = memo(function OtpPtrTaskCard({
                 </p>
               )}
 
-              {/* Row 3: Price, paid status, buyer, model, deadline */}
+              {/* Row 3: Price, model, platforms, deadline */}
               <div className="flex items-center gap-2 flex-wrap text-xs mb-2.5">
                 {price != null && price > 0 && (
                   <span className="font-bold text-brand-light-pink">
                     ${price}
                   </span>
                 )}
-                {isPaid != null && (
-                  <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold border ${
-                    isPaid
-                      ? 'bg-emerald-500/10 text-emerald-400 border-emerald-500/20'
-                      : 'bg-red-500/10 text-red-400 border-red-500/20'
-                  }`}>
-                    {isPaid ? 'paid' : 'unpaid'}
-                  </span>
-                )}
-                {buyer && (
-                  <span className="text-gray-500 dark:text-gray-500 truncate max-w-[90px]">@{buyer}</span>
-                )}
                 {model && (
                   <span className="text-gray-500 dark:text-gray-500 truncate max-w-[90px]">{model}</span>
                 )}
                 {platforms.length > 0 && platforms.map((p) => (
-                  <span key={p} className="text-[10px] font-medium text-gray-500 dark:text-gray-500 px-1.5 py-0.5 rounded bg-white/5 border border-white/[0.06]">
+                  <span key={p} className={`text-[10px] font-bold px-1.5 py-0.5 rounded-md border ${
+                    p === 'onlyfans'
+                      ? 'bg-brand-blue/10 text-brand-blue border-brand-blue/25'
+                      : p === 'fansly'
+                      ? 'bg-cyan-500/10 text-cyan-400 border-cyan-500/25'
+                      : 'bg-gray-500/10 text-gray-400 border-gray-500/25'
+                  }`}>
                     {p === 'onlyfans' ? 'OF' : p === 'fansly' ? 'Fansly' : p}
                   </span>
                 ))}
@@ -264,7 +250,7 @@ export const OtpPtrTaskCard = memo(function OtpPtrTaskCard({
               )}
 
               {/* Footer: priority + timestamp + assignee */}
-              <div className="flex items-center gap-2.5 pt-2.5 border-t border-white/[0.06]">
+              <div className="flex items-center gap-2.5 pt-2.5 border-t border-white/[0.04]">
                 {task.priority && (
                   <span className="inline-flex items-center gap-1 text-[11px] text-gray-500 dark:text-gray-400 font-medium">
                     <span className={`h-2 w-2 rounded-full ${PRIORITY_DOT[task.priority] ?? ''}`} />

--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/OtpPtrTaskDetailModal.tsx
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/OtpPtrTaskDetailModal.tsx
@@ -10,19 +10,16 @@ import {
   DollarSign,
   User,
   CalendarDays,
-  Package,
   ClipboardList,
   FileText,
   Tag,
   History,
   MessageSquare,
   Plus,
-  CreditCard,
   Info,
   Clock,
   ExternalLink,
   Film,
-  Users,
   Link2,
   ChevronDown,
   Image as ImageIcon,
@@ -30,7 +27,7 @@ import {
   Workflow,
   type LucideIcon,
 } from 'lucide-react';
-// Note: All icons above are used across the component's sections and sidebar
+// Note: Icons above are used across the component's sections and sidebar
 import type { BoardTask } from '../../board/BoardTaskCard';
 import { EditableField } from '../../board/EditableField';
 import { SelectField } from '../../board/SelectField';
@@ -71,8 +68,7 @@ type ModalTab = 'details' | 'workflow' | 'history' | 'comments';
 
 /* ── Constants ───────────────────────────────────────────── */
 
-const REQUEST_TYPE_OPTIONS = ['OTP', 'PTR', 'CUSTOM'];
-const CONTENT_STYLE_OPTIONS = ['NORMAL', 'PPV', 'GAME', 'POLL', 'BUNDLE'];
+const POST_ORIGIN_OPTIONS = ['PTR', 'OTP', 'OTM', 'PPV', 'GAME', 'LIVE', 'TIP_ME', 'VIP', 'DM_FUNNEL', 'RENEW_ON', 'CUSTOM'];
 
 const PRIORITY_PILL: Record<string, string> = {
   High: 'text-red-400',
@@ -89,7 +85,15 @@ const PRIORITY_DOT: Record<string, string> = {
 const TYPE_DOT: Record<string, string> = {
   OTP: 'bg-brand-blue',
   PTR: 'bg-brand-light-pink',
-  CUSTOM: 'bg-amber-400',
+  OTM: 'bg-violet-400',
+  PPV: 'bg-emerald-400',
+  GAME: 'bg-amber-400',
+  LIVE: 'bg-red-400',
+  TIP_ME: 'bg-cyan-400',
+  VIP: 'bg-yellow-400',
+  DM_FUNNEL: 'bg-indigo-400',
+  RENEW_ON: 'bg-teal-400',
+  CUSTOM: 'bg-gray-400',
 };
 
 const FIELD_LABELS: Record<string, string> = {
@@ -143,7 +147,26 @@ function getAvatarColor(name: string): string {
   return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length];
 }
 
-/* ── Section — collapsible flat section ──────────────────── */
+/* ── Section color themes for glassmorphism cards ──────── */
+
+const SECTION_THEMES: Record<string, { border: string; iconBg: string; iconColor: string; gradientFrom: string }> = {
+  'Basic Information': { border: 'border-brand-blue/30', iconBg: 'bg-brand-blue/15', iconColor: 'text-brand-blue', gradientFrom: 'from-brand-blue/[0.06]' },
+  'Description & Content': { border: 'border-emerald-500/30', iconBg: 'bg-emerald-500/15', iconColor: 'text-emerald-400', gradientFrom: 'from-emerald-500/[0.06]' },
+  'Google Drive': { border: 'border-amber-500/30', iconBg: 'bg-amber-500/15', iconColor: 'text-amber-400', gradientFrom: 'from-amber-500/[0.06]' },
+  'Notes': { border: 'border-violet-500/30', iconBg: 'bg-violet-500/15', iconColor: 'text-violet-400', gradientFrom: 'from-violet-500/[0.06]' },
+  'Tags': { border: 'border-brand-light-pink/30', iconBg: 'bg-brand-light-pink/15', iconColor: 'text-brand-light-pink', gradientFrom: 'from-brand-light-pink/[0.06]' },
+  'Timestamps': { border: 'border-gray-500/30', iconBg: 'bg-gray-500/15', iconColor: 'text-gray-400', gradientFrom: 'from-gray-500/[0.06]' },
+  'PGT Team': { border: 'border-brand-light-pink/30', iconBg: 'bg-brand-light-pink/15', iconColor: 'text-brand-light-pink', gradientFrom: 'from-brand-light-pink/[0.06]' },
+  'Flyer Team': { border: 'border-brand-blue/30', iconBg: 'bg-brand-blue/15', iconColor: 'text-brand-blue', gradientFrom: 'from-brand-blue/[0.06]' },
+  'PPV/Bundle Details': { border: 'border-amber-500/30', iconBg: 'bg-amber-500/15', iconColor: 'text-amber-400', gradientFrom: 'from-amber-500/[0.06]' },
+  'QA': { border: 'border-emerald-500/30', iconBg: 'bg-emerald-500/15', iconColor: 'text-emerald-400', gradientFrom: 'from-emerald-500/[0.06]' },
+  'Deploy': { border: 'border-brand-blue/30', iconBg: 'bg-brand-blue/15', iconColor: 'text-brand-blue', gradientFrom: 'from-brand-blue/[0.06]' },
+  'Attachments': { border: 'border-emerald-500/30', iconBg: 'bg-emerald-500/15', iconColor: 'text-emerald-400', gradientFrom: 'from-emerald-500/[0.06]' },
+};
+
+const DEFAULT_THEME = { border: 'border-white/[0.08]', iconBg: 'bg-white/[0.06]', iconColor: 'text-gray-400', gradientFrom: 'from-white/[0.03]' };
+
+/* ── Section — collapsible glassmorphism card ──────────── */
 
 function Section({
   icon: Icon,
@@ -159,29 +182,32 @@ function Section({
   badge?: React.ReactNode;
 }) {
   const [open, setOpen] = useState(defaultOpen);
+  const themeKey = Object.keys(SECTION_THEMES).find(k => title.startsWith(k)) ?? '';
+  const theme = SECTION_THEMES[themeKey] ?? DEFAULT_THEME;
 
   return (
-    <div className="mb-0.5">
+    <div className={`mb-3 rounded-xl border ${theme.border} bg-gradient-to-br ${theme.gradientFrom} to-transparent backdrop-blur-sm overflow-hidden transition-all duration-200`}>
       <button
         type="button"
         onClick={() => setOpen(!open)}
-        className="flex items-center w-full gap-2.5 py-2.5 px-1 text-left group/section hover:bg-white/[0.02] rounded-lg transition-colors"
+        className="flex items-center w-full gap-2.5 py-3 px-4 text-left group/section hover:bg-white/[0.02] transition-colors"
       >
-        <Icon className="h-3.5 w-3.5 text-gray-500 shrink-0" />
-        <span className="text-[11px] font-semibold text-gray-400 tracking-[0.08em] flex-1 uppercase">
+        <span className={`inline-flex h-6 w-6 items-center justify-center rounded-lg ${theme.iconBg} shrink-0`}>
+          <Icon className={`h-3.5 w-3.5 ${theme.iconColor}`} />
+        </span>
+        <span className="text-[12px] font-semibold text-gray-300 tracking-wide flex-1">
           {title}
         </span>
         {badge}
         <ChevronDown
-          className={`h-3 w-3 text-gray-600 transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
+          className={`h-3.5 w-3.5 text-gray-500 transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
         />
       </button>
       {open && (
-        <div className="pb-3 pl-6 pr-1">
+        <div className="px-4 pb-4 pt-0.5 pl-[52px]">
           {children}
         </div>
       )}
-      <div className="border-t border-white/[0.04] mx-1" />
     </div>
   );
 }
@@ -335,15 +361,19 @@ export function OtpPtrTaskDetailModal({
   /* ── Metadata ────────────────────────────────────────── */
 
   const meta = task.metadata ?? {};
-  const requestType = (meta.requestType as string) ?? 'OTP';
-  const contentStyle = (meta.contentStyle as string) ?? 'NORMAL';
+  // Backward compat: read postOrigin, fall back to old requestType
+  const postOrigin = (meta.postOrigin as string) ?? (meta.requestType as string) ?? 'OTP';
   const price = (meta.price as number) ?? 0;
-  const buyer = (meta.buyer as string) ?? '';
   const model = (meta.model as string) ?? '';
-  const deliverables = Array.isArray(meta.deliverables) ? (meta.deliverables as string[]) : [];
   const deadline = (meta.deadline as string) ?? '';
-  const isPaid = (meta.isPaid as boolean) ?? false;
-  const fulfillmentNotes = (meta.fulfillmentNotes as string) ?? '';
+  const notes = (meta.fulfillmentNotes as string) ?? '';  // keep reading old field name for backward compat
+  const campaignOrUnlock = (meta.campaignOrUnlock as string) ?? '';
+  const totalSale = (meta.totalSale as number) ?? 0;
+  const qaNotes = (meta.qaNotes as string) ?? '';
+  const postLinkOnlyfans = (meta.postLinkOnlyfans as string) ?? '';
+  const postLinkFansly = (meta.postLinkFansly as string) ?? '';
+  const datePosted = (meta.datePosted as string) ?? '';
+  const gifUrlFansly = (meta.gifUrlFansly as string) ?? '';
   const pricingCategory = (meta.pricingCategory as string) ?? '';
   const pricingTier = (meta.pricingTier as string) ?? '';
   const pageType = (meta.pageType as string) ?? '';
@@ -367,7 +397,7 @@ export function OtpPtrTaskDetailModal({
   const workspaceCaptionText = (meta.captionText as string) ?? '';
   const tier = pricingCategory || pricingTier;
 
-  const [notesDraft, setNotesDraft] = useState(fulfillmentNotes);
+  const [notesDraft, setNotesDraft] = useState(notes);
   const [captionDraft, setCaptionDraft] = useState(caption);
   const [tagInputs, setTagInputs] = useState<Record<string, string>>({});
 
@@ -418,9 +448,9 @@ export function OtpPtrTaskDetailModal({
   useEffect(() => setMounted(true), []);
   useEffect(() => {
     setTitleDraft(task.title);
-    setNotesDraft(fulfillmentNotes);
+    setNotesDraft(notes);
     setCaptionDraft(caption);
-  }, [task, fulfillmentNotes, caption]);
+  }, [task, notes, caption]);
   useEffect(() => { if (editingTitle) titleRef.current?.focus(); }, [editingTitle]);
   useEffect(() => { if (editingNotes) notesRef.current?.focus(); }, [editingNotes]);
   useEffect(() => { if (editingCaption) captionRef.current?.focus(); }, [editingCaption]);
@@ -449,7 +479,7 @@ export function OtpPtrTaskDetailModal({
 
   const saveNotes = () => {
     setEditingNotes(false);
-    if (notesDraft !== fulfillmentNotes) updateMeta({ fulfillmentNotes: notesDraft });
+    if (notesDraft !== notes) updateMeta({ fulfillmentNotes: notesDraft });
   };
 
   const saveCaption = () => {
@@ -540,12 +570,12 @@ export function OtpPtrTaskDetailModal({
 
   return createPortal(
     <div
-      className="fixed inset-0 z-9999 flex items-start justify-center overflow-y-auto py-8 px-4"
+      className="fixed inset-0 z-9999 flex items-start justify-center overflow-y-auto py-4 px-4"
       onClick={onClose}
-      style={{ background: 'rgba(0,0,0,0.65)', backdropFilter: 'blur(12px)' }}
+      style={{ background: 'rgba(0,0,0,0.5)', backdropFilter: 'blur(20px)' }}
     >
       <div
-        className="relative w-full max-w-5xl rounded-2xl shadow-2xl shadow-black/60 bg-[#0f1729]/95 backdrop-blur-xl border border-white/[0.08] overflow-hidden"
+        className="relative w-full max-w-7xl rounded-2xl shadow-2xl shadow-black/40 bg-[#0d1321]/80 backdrop-blur-2xl border border-white/[0.06] overflow-hidden"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Pink gradient top strip */}
@@ -561,13 +591,13 @@ export function OtpPtrTaskDetailModal({
                   {task.taskKey}
                 </span>
                 <span className={`inline-flex items-center gap-1.5 text-[11px] font-bold rounded-full px-2.5 py-1 ${
-                  requestType === 'OTP'
+                  postOrigin === 'OTP'
                     ? 'bg-brand-blue/15 text-brand-blue'
-                    : requestType === 'PTR'
+                    : postOrigin === 'PTR'
                     ? 'bg-brand-light-pink/15 text-brand-light-pink'
-                    : 'bg-amber-500/15 text-amber-400'
+                    : `bg-white/[0.06] ${(TYPE_DOT[postOrigin] ?? '').replace('bg-', 'text-')}`
                 }`}>
-                  {requestType}
+                  {postOrigin.replace(/_/g, ' ')}
                 </span>
                 <span className="text-[11px] text-gray-500 bg-white/[0.04] px-2.5 py-1 rounded-full">
                   {columnTitle}
@@ -608,19 +638,10 @@ export function OtpPtrTaskDetailModal({
               </div>
 
               {/* Quick info bar */}
-              {(buyer || model || deadline || price > 0 || platforms.length > 0) && (
-                <div className="flex items-center gap-3 mt-3 text-xs text-gray-400 rounded-xl bg-[#1a2237]/80 border border-white/[0.06] px-4 py-2.5">
+              {(model || deadline || price > 0 || platforms.length > 0) && (
+                <div className="flex items-center gap-3 mt-3 text-xs text-gray-400 rounded-xl bg-white/[0.04] backdrop-blur-sm border border-white/[0.06] px-4 py-2.5">
                   {price > 0 && (
                     <span className="text-brand-light-pink font-bold text-sm">${price}</span>
-                  )}
-                  {(meta.isPaid as boolean) != null && (
-                    <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide ${
-                      (meta.isPaid as boolean)
-                        ? 'bg-emerald-500/12 text-emerald-400'
-                        : 'bg-red-500/12 text-red-400'
-                    }`}>
-                      {(meta.isPaid as boolean) ? 'PAID' : 'UNPAID'}
-                    </span>
                   )}
                   {model && (
                     <span className="inline-flex items-center gap-1.5">
@@ -702,7 +723,7 @@ export function OtpPtrTaskDetailModal({
         {/* ═══ Body ═════════════════════════════════════ */}
         <div className="grid grid-cols-1 lg:grid-cols-[1fr_280px]">
           {/* ── Left: Tab Content ──────────────────────── */}
-          <div className="px-6 py-5 min-h-[50vh] max-h-[62vh] overflow-y-auto custom-scrollbar border-r border-white/[0.04]">
+          <div className="px-6 py-5 min-h-[70vh] max-h-[82vh] overflow-y-auto custom-scrollbar border-r border-white/[0.04] bg-white/[0.01]">
 
             {/* ── Details Tab ────────────────────────────── */}
             {activeTab === 'details' && (
@@ -823,7 +844,7 @@ export function OtpPtrTaskDetailModal({
                           <button type="button" onClick={saveNotes} className="px-3 py-1.5 rounded-lg text-xs font-semibold text-white bg-brand-light-pink/80 hover:bg-brand-light-pink transition-colors">
                             Save
                           </button>
-                          <button type="button" onClick={() => { setNotesDraft(fulfillmentNotes); setEditingNotes(false); }} className="px-3 py-1.5 rounded-lg text-xs text-gray-500 hover:text-gray-300 transition-colors">
+                          <button type="button" onClick={() => { setNotesDraft(notes); setEditingNotes(false); }} className="px-3 py-1.5 rounded-lg text-xs text-gray-500 hover:text-gray-300 transition-colors">
                             Cancel
                           </button>
                         </div>
@@ -831,7 +852,7 @@ export function OtpPtrTaskDetailModal({
                     ) : (
                       <button type="button" onClick={() => setEditingNotes(true)} className="flex items-start gap-2 w-full text-left">
                         <p className="text-[13px] text-gray-400 whitespace-pre-wrap flex-1 leading-relaxed">
-                          {fulfillmentNotes || <span className="text-gray-600 italic">Click to add notes...</span>}
+                          {notes || <span className="text-gray-600 italic">Click to add notes...</span>}
                         </p>
                         <Pencil className="h-3 w-3 text-gray-700 opacity-0 group-hover/notes:opacity-100 transition-opacity shrink-0 mt-0.5" />
                       </button>
@@ -869,11 +890,20 @@ export function OtpPtrTaskDetailModal({
                 {/* Timestamps */}
                 <Section icon={Clock} title="Timestamps" defaultOpen={false}>
                   <div className="grid grid-cols-2 gap-x-6 gap-y-2 text-xs">
-                    {typeof meta.createdAt === 'string' && (
-                      <div><SideLabel>Created</SideLabel><span className="text-gray-400">{formatFullDate(meta.createdAt)}</span></div>
+                    {typeof meta._createdAt === 'string' && (
+                      <div>
+                        <SideLabel>Created</SideLabel>
+                        <span className="text-gray-400">{formatFullDate(meta._createdAt as string)}</span>
+                        {typeof meta.createdBy === 'string' && (
+                          <span className="text-gray-500 ml-1">by {getMemberName(meta.createdBy as string) ?? 'Unknown'}</span>
+                        )}
+                      </div>
                     )}
-                    {typeof meta.updatedAt === 'string' && (
-                      <div><SideLabel>Updated</SideLabel><span className="text-gray-400">{formatFullDate(meta.updatedAt)}</span></div>
+                    {typeof meta._updatedAt === 'string' && (
+                      <div>
+                        <SideLabel>Updated</SideLabel>
+                        <span className="text-gray-400">{formatFullDate(meta._updatedAt as string)}</span>
+                      </div>
                     )}
                   </div>
                 </Section>
@@ -892,16 +922,6 @@ export function OtpPtrTaskDetailModal({
                       {captionCfg.label}
                       {captionTicketId && <span className="ml-auto text-[10px] opacity-50">Ticket linked</span>}
                     </div>
-
-                    {driveLink && (
-                      <div>
-                        <SideLabel>Drive Content</SideLabel>
-                        <a href={driveLink} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1.5 text-xs text-brand-blue hover:text-brand-blue/80 transition-colors">
-                          <ExternalLink className="h-3 w-3 shrink-0" />
-                          <span className="underline underline-offset-2 break-all">{driveLink.length > 55 ? driveLink.slice(0, 52) + '...' : driveLink}</span>
-                        </a>
-                      </div>
-                    )}
 
                     <div>
                       <SideLabel>Caption</SideLabel>
@@ -1011,32 +1031,117 @@ export function OtpPtrTaskDetailModal({
 
                 {/* Flyer Team */}
                 <Section icon={Film} title="Flyer Team">
-                  <div className="grid grid-cols-3 gap-x-4 gap-y-3">
-                    <div>
-                      <SideLabel>Game Type</SideLabel>
-                      <EditableField value={gameType} placeholder="Wheel, Dice..." onSave={(v) => updateMeta({ gameType: v })} />
+                  <div className="space-y-3">
+                    <div className="grid grid-cols-3 gap-x-4">
+                      <div>
+                        <SideLabel>Game Type</SideLabel>
+                        <EditableField value={gameType} placeholder="Wheel, Dice..." onSave={(v) => updateMeta({ gameType: v })} />
+                      </div>
+                      <div className="col-span-2">
+                        <SideLabel>Game Notes</SideLabel>
+                        <EditableField value={gameNotes} placeholder="Notes..." onSave={(v) => updateMeta({ gameNotes: v })} />
+                      </div>
                     </div>
-                    <div>
-                      <SideLabel>GIF URL</SideLabel>
-                      <EditableField value={gifUrl} placeholder="https://..." onSave={(v) => updateMeta({ gifUrl: v })} />
-                      {gifUrl && (
-                        <a href={gifUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-brand-blue hover:underline mt-0.5 inline-block">Open</a>
+
+                    {/* GIF URLs — show per platform */}
+                    <div className="pt-2 border-t border-white/[0.04]">
+                      <SideLabel>GIF URL{platforms.length > 1 ? 's' : ''}</SideLabel>
+                      {platforms.length <= 1 ? (
+                        <div>
+                          <EditableField value={gifUrl} placeholder="https://..." onSave={(v) => updateMeta({ gifUrl: v })} />
+                          {gifUrl && (
+                            <a href={gifUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-brand-blue hover:underline mt-0.5 inline-block">Open</a>
+                          )}
+                        </div>
+                      ) : (
+                        <div className="space-y-2">
+                          <div>
+                            <span className="text-[10px] font-medium text-brand-blue">OnlyFans</span>
+                            <EditableField value={gifUrl} placeholder="OF GIF URL..." onSave={(v) => updateMeta({ gifUrl: v })} />
+                            {gifUrl && (
+                              <a href={gifUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-brand-blue hover:underline mt-0.5 inline-block">Open</a>
+                            )}
+                          </div>
+                          <div>
+                            <span className="text-[10px] font-medium text-brand-light-pink">Fansly</span>
+                            <EditableField value={gifUrlFansly} placeholder="Fansly GIF URL..." onSave={(v) => updateMeta({ gifUrlFansly: v })} />
+                            {gifUrlFansly && (
+                              <a href={gifUrlFansly} target="_blank" rel="noopener noreferrer" className="text-xs text-brand-blue hover:underline mt-0.5 inline-block">Open</a>
+                            )}
+                          </div>
+                        </div>
                       )}
-                    </div>
-                    <div>
-                      <SideLabel>Game Notes</SideLabel>
-                      <EditableField value={gameNotes} placeholder="Notes..." onSave={(v) => updateMeta({ gameNotes: v })} />
                     </div>
                   </div>
                 </Section>
 
                 {/* PPV/Bundle Details */}
-                {(contentStyle.toLowerCase() === 'ppv' || contentStyle.toLowerCase() === 'bundle') && (
+                {(postOrigin === 'PPV') && (
                   <Section icon={Film} title="PPV/Bundle Details">
                     <SideLabel>Original Poll Reference</SideLabel>
                     <EditableField value={originalPollReference} placeholder="Reference..." onSave={(v) => updateMeta({ originalPollReference: v })} />
                   </Section>
                 )}
+
+                {/* QA */}
+                <Section icon={ClipboardList} title="QA">
+                  <div className="space-y-3">
+                    <div>
+                      <SideLabel>Campaign / Unlock</SideLabel>
+                      <SelectField
+                        value={campaignOrUnlock}
+                        options={['', 'Campaign', 'Unlock']}
+                        onSave={(v) => updateMeta({ campaignOrUnlock: v })}
+                      />
+                    </div>
+                    <div>
+                      <SideLabel>QA Notes</SideLabel>
+                      <EditableField value={qaNotes} placeholder="QA feedback..." onSave={(v) => updateMeta({ qaNotes: v })} />
+                    </div>
+                    <div>
+                      <SideLabel>Total Sale ($)</SideLabel>
+                      <EditableField value={totalSale ? String(totalSale) : ''} placeholder="0.00" onSave={(v) => updateMeta({ totalSale: Number(v) || 0 })} />
+                    </div>
+                  </div>
+                </Section>
+
+                {/* Deploy */}
+                <Section icon={ExternalLink} title="Deploy" defaultOpen={false}>
+                  <div className="space-y-3">
+                    {platforms.includes('onlyfans') && (
+                      <div>
+                        <SideLabel>OnlyFans Post Link</SideLabel>
+                        <EditableField value={postLinkOnlyfans} placeholder="https://onlyfans.com/..." onSave={(v) => updateMeta({ postLinkOnlyfans: v })} />
+                        {postLinkOnlyfans && (
+                          <a href={postLinkOnlyfans} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-xs text-brand-blue hover:underline mt-1">
+                            <ExternalLink className="h-3 w-3" />Open
+                          </a>
+                        )}
+                      </div>
+                    )}
+                    {platforms.includes('fansly') && (
+                      <div>
+                        <SideLabel>Fansly Post Link</SideLabel>
+                        <EditableField value={postLinkFansly} placeholder="https://fansly.com/..." onSave={(v) => updateMeta({ postLinkFansly: v })} />
+                        {postLinkFansly && (
+                          <a href={postLinkFansly} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-xs text-brand-blue hover:underline mt-1">
+                            <ExternalLink className="h-3 w-3" />Open
+                          </a>
+                        )}
+                      </div>
+                    )}
+                    {platforms.length === 0 && (
+                      <div>
+                        <SideLabel>Post Link</SideLabel>
+                        <EditableField value={postLinkOnlyfans} placeholder="https://..." onSave={(v) => updateMeta({ postLinkOnlyfans: v })} />
+                      </div>
+                    )}
+                    <div>
+                      <SideLabel>Date Posted</SideLabel>
+                      <EditableField value={datePosted} type="date" placeholder="Not set" onSave={(v) => updateMeta({ datePosted: v })} />
+                    </div>
+                  </div>
+                </Section>
 
                 {/* Attachments / Media */}
                 {mediaData.length > 0 && (
@@ -1077,28 +1182,6 @@ export function OtpPtrTaskDetailModal({
                   </Section>
                 )}
 
-                {/* Deliverables */}
-                <Section
-                  icon={Package}
-                  title="Deliverables"
-                  badge={deliverables.length > 0 ? <span className="text-xs font-mono text-gray-500">{deliverables.length}</span> : undefined}
-                >
-                  {deliverables.length > 0 && (
-                    <div className="space-y-1 mb-2">
-                      {deliverables.map((d, i) => (
-                        <div key={i} className="flex items-center gap-2 text-[13px] text-gray-300 group/del">
-                          <span className="h-1 w-1 rounded-full bg-brand-blue shrink-0" />
-                          <span className="flex-1">{d}</span>
-                          <button type="button" onClick={() => removeFromArray('deliverables', d)} className="opacity-0 group-hover/del:opacity-100 text-gray-600 hover:text-red-400 transition-all">
-                            <X className="h-3 w-3" />
-                          </button>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                  {deliverables.length === 0 && <p className="text-xs text-gray-600 italic mb-2">None</p>}
-                  <TagInput value={getTagInput('deliverables')} onChange={(v) => setTagInput('deliverables', v)} onAdd={() => addToArray('deliverables', getTagInput('deliverables'))} placeholder="Add deliverable..." />
-                </Section>
               </>
             )}
 
@@ -1196,7 +1279,7 @@ export function OtpPtrTaskDetailModal({
           </div>
 
           {/* ═══ Right Sidebar — Properties ═══════════════ */}
-          <div className="px-4 py-4 max-h-[62vh] overflow-y-auto custom-scrollbar bg-[#111827]/50">
+          <div className="px-4 py-4 max-h-[82vh] overflow-y-auto custom-scrollbar bg-white/[0.02]">
             <div className="flex items-center gap-2 mb-3">
               <Settings className="h-3.5 w-3.5 text-gray-500" />
               <h3 className="text-[11px] font-semibold uppercase tracking-[0.1em] text-gray-400">Properties</h3>
@@ -1223,41 +1306,18 @@ export function OtpPtrTaskDetailModal({
               />
             </SideRow>
 
-            <div className="grid grid-cols-2 gap-2 py-2.5 border-b border-white/[0.04]">
-              <div>
-                <SideLabel>Type</SideLabel>
-                <SelectField
-                  value={requestType}
-                  options={REQUEST_TYPE_OPTIONS}
-                  onSave={(v) => updateMeta({ requestType: v })}
-                  renderOption={(v) => (
-                    <span className="flex items-center gap-1.5 text-sm font-semibold text-brand-off-white">
-                      <span className={`h-2 w-2 rounded-full ${TYPE_DOT[v] ?? 'bg-gray-500'}`} />
-                      {v}
-                    </span>
-                  )}
-                />
-              </div>
-              <div>
-                <SideLabel>Style</SideLabel>
-                <SelectField value={contentStyle} options={CONTENT_STYLE_OPTIONS} onSave={(v) => updateMeta({ contentStyle: v })} />
-              </div>
-            </div>
-
-            <SideRow label="Payment">
-              <button
-                type="button"
-                onClick={() => updateMeta({ isPaid: !isPaid })}
-                className={`w-full flex items-center gap-2 rounded-lg px-2.5 py-2 text-xs font-semibold transition-all duration-200 border ${
-                  isPaid
-                    ? 'bg-emerald-500/[0.08] border-emerald-500/20 text-emerald-400 hover:bg-emerald-500/[0.12]'
-                    : 'bg-red-500/[0.08] border-red-500/20 text-red-400 hover:bg-red-500/[0.12]'
-                }`}
-              >
-                <CreditCard className="h-3.5 w-3.5 shrink-0" />
-                <span className="flex-1 text-left">{isPaid ? 'Paid' : 'Unpaid'}</span>
-                <span className={`h-2 w-2 rounded-full ${isPaid ? 'bg-emerald-400' : 'bg-red-400'}`} />
-              </button>
+            <SideRow label="Post Origin">
+              <SelectField
+                value={postOrigin}
+                options={POST_ORIGIN_OPTIONS}
+                onSave={(v) => updateMeta({ postOrigin: v })}
+                renderOption={(v) => (
+                  <span className="flex items-center gap-1.5 text-sm font-semibold text-brand-off-white">
+                    <span className={`h-2 w-2 rounded-full ${TYPE_DOT[v] ?? 'bg-gray-500'}`} />
+                    {v.replace(/_/g, ' ')}
+                  </span>
+                )}
+              />
             </SideRow>
 
             <SideRow label="Tier">
@@ -1278,33 +1338,17 @@ export function OtpPtrTaskDetailModal({
               </span>
             </SideRow>
 
-            <SideRow label="Buyer">
-              <span className="text-sm font-semibold text-brand-off-white">
-                <EditableField value={buyer} placeholder="@username" onSave={(v) => updateMeta({ buyer: v })} />
-              </span>
-            </SideRow>
-
             <SideRow label="Price">
               <span className="text-sm font-semibold text-brand-light-pink">
                 <EditableField value={price ? String(price) : ''} placeholder="0.00" onSave={(v) => updateMeta({ price: Number(v) || 0 })} />
               </span>
             </SideRow>
 
-            <SideRow label="Deadline">
+            <SideRow label="Target Date">
               <span className="text-sm font-semibold text-brand-off-white">
                 <EditableField value={deadline} type="date" placeholder="Not set" onSave={(v) => updateMeta({ deadline: v })} />
               </span>
             </SideRow>
-
-            {deliverables.length > 0 && (
-              <SideRow label="Deliverables">
-                <div className="flex flex-wrap gap-1">
-                  {deliverables.map((d) => (
-                    <span key={d} className="text-[11px] font-medium text-brand-blue bg-brand-blue/10 rounded-md px-1.5 py-0.5 border border-brand-blue/15">{d}</span>
-                  ))}
-                </div>
-              </SideRow>
-            )}
 
             {(externalCreatorTags.length > 0 || internalModelTags.length > 0) && (
               <SideRow label="People">
@@ -1315,32 +1359,21 @@ export function OtpPtrTaskDetailModal({
               </SideRow>
             )}
 
-            {driveLink && (
-              <SideRow label="Drive">
-                <a href={driveLink} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-xs text-brand-blue hover:underline break-all">
-                  <ExternalLink className="h-3 w-3 shrink-0" />
-                  {driveLink.length > 30 ? driveLink.slice(0, 27) + '...' : driveLink}
-                </a>
-              </SideRow>
-            )}
-
-            {/* Created / Updated footer */}
-            {(typeof meta.createdAt === 'string' || typeof meta.updatedAt === 'string') && (
+            {/* Created / Updated footer with "Created by" */}
+            {(typeof meta._createdAt === 'string' || typeof meta._updatedAt === 'string') && (
               <div className="mt-4 pt-3 border-t border-white/[0.06]">
-                {typeof meta.createdAt === 'string' && (
+                {typeof meta._createdAt === 'string' && (
                   <div className="flex items-center gap-2 text-[11px] text-gray-500 mb-1.5">
                     <span className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-white/[0.04] text-[8px] font-bold text-gray-500 shrink-0">
-                      {(getMemberName(task.assignee) ?? 'U').charAt(0).toUpperCase()}
+                      {(getMemberName(meta.createdBy as string) ?? 'U').charAt(0).toUpperCase()}
                     </span>
-                    Created {formatDate(meta.createdAt)}
+                    Created by {getMemberName(meta.createdBy as string) ?? 'Unknown'} · {formatDate(meta._createdAt as string)}
                   </div>
                 )}
-                {typeof meta.updatedAt === 'string' && (
+                {typeof meta._updatedAt === 'string' && (
                   <div className="flex items-center gap-2 text-[11px] text-gray-500">
-                    <span className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-white/[0.04] text-[8px] font-bold text-gray-500 shrink-0">
-                      {(getMemberName(task.assignee) ?? 'U').charAt(0).toUpperCase()}
-                    </span>
-                    Updated {formatDate(meta.updatedAt)}
+                    <Clock className="h-3 w-3 shrink-0" />
+                    Updated {formatDate(meta._updatedAt as string)}
                   </div>
                 )}
               </div>

--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/template-config.ts
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/template-config.ts
@@ -83,24 +83,19 @@ const modelOnboardingItemToTask: ItemToTaskFn = (item: BoardItem, spaceKey: stri
 const otpPtrItemToTask: ItemToTaskFn = (item: BoardItem, spaceKey: string): BoardTask => {
   const meta = (item.metadata ?? {}) as Record<string, unknown>;
   const priceTag = meta.price ? `$${meta.price}` : undefined;
-  const requestType = (meta.requestType as string) ?? '';
-  const contentStyle = (meta.contentStyle as string) ?? '';
-  const typeTag = requestType
-    ? contentStyle && contentStyle !== 'NORMAL'
-      ? `${requestType}-${contentStyle.replace(/_/g, ' ')}`
-      : requestType
-    : undefined;
+  // Backward compat: read postOrigin, fall back to old requestType
+  const postOrigin = (meta.postOrigin as string) ?? (meta.requestType as string) ?? '';
+  const typeTag = postOrigin || undefined;
   return {
     id: item.id,
     taskKey: spaceKey ? `${spaceKey}-${item.itemNo}` : item.id.slice(-6).toUpperCase(),
     title: item.title,
     description: (item.description as string) ?? undefined,
     assignee: (item.assigneeId as string) ?? undefined,
-    priority: meta.isPaid ? ('Low' as const) : ('High' as const),
+    priority: item.priority === 'HIGH' ? 'High' : item.priority === 'LOW' ? 'Low' : 'Medium',
     tags: [
       ...(typeTag ? [typeTag] : []),
       ...(priceTag ? [priceTag] : []),
-      ...(meta.buyer ? [`@${meta.buyer}`] : []),
     ],
     dueDate: (meta.deadline as string) ?? item.dueDate ?? undefined,
     metadata: { ...meta, _createdAt: item.createdAt, _updatedAt: item.updatedAt },

--- a/app/[tenant]/(dashboard)/spaces/board/BoardColumn.tsx
+++ b/app/[tenant]/(dashboard)/spaces/board/BoardColumn.tsx
@@ -122,9 +122,9 @@ export function BoardColumn({
 
   return (
     <div className="w-[290px] shrink-0 flex flex-col">
-      <div className="rounded-2xl bg-gray-50/90 dark:bg-[#1a2237]/30 border border-gray-200/80 dark:border-[#2a3450]/50 backdrop-blur-sm shadow-sm flex flex-col overflow-hidden h-full">
+      <div className="rounded-2xl bg-gray-50/90 dark:bg-gray-800/90 border border-gray-200/80 dark:border-gray-700 backdrop-blur-xl shadow-sm dark:shadow-xl dark:shadow-black/30 flex flex-col overflow-hidden h-full">
         {/* Column header */}
-        <div className="px-4 py-3 flex items-center justify-between gap-2 border-b border-gray-200/70 dark:border-[#2a3450]/60 bg-white/60 dark:bg-[#1a2237]/40">
+        <div className="px-4 py-3 flex items-center justify-between gap-2 border-b border-gray-200/70 dark:border-gray-700 bg-white/60 dark:bg-gray-800/50">
           <div className="flex items-center gap-2 min-w-0 flex-1">
             {/* Color picker */}
             <div className="relative" ref={colorPickerRef}>

--- a/components/caption-workspace/CaptionWorkspace.tsx
+++ b/components/caption-workspace/CaptionWorkspace.tsx
@@ -173,7 +173,10 @@ export default function CaptionWorkspace() {
       videoUrl: item.workflowType === 'otp_ptr' ? null : (item.contentSourceType === 'upload' ? (item.contentUrl || null) : null),
       contentUrl: item.contentUrl,
       contentSourceType: (item.workflowType === 'otp_ptr' ? 'gdrive' : item.contentSourceType) as 'upload' | 'gdrive' | null,
-      contentItems: (item.contentItems || []).map(ci => ({
+      contentItems: (item.contentItems || [])
+        // OTP/PTR tickets only need the Google Drive link — filter out uploaded reference images
+        .filter(ci => item.workflowType === 'otp_ptr' ? ci.sourceType === 'gdrive' : true)
+        .map(ci => ({
         id: ci.id,
         url: ci.url,
         sourceType: ci.sourceType as 'upload' | 'gdrive',

--- a/components/content-submission/SubmissionForm.tsx
+++ b/components/content-submission/SubmissionForm.tsx
@@ -214,39 +214,58 @@ export const SubmissionForm = memo(function SubmissionForm({
     SEXTING_SETS: 'SET',
   };
 
+  // Map contentStyle → postOrigin for the new unified field
+  // 'normal'/'poll' keep the metadata's postOrigin (user-selected, default 'OTP')
+  // Others map directly to their postOrigin equivalent
+  const CONTENT_STYLE_TO_POST_ORIGIN: Record<string, string> = {
+    game: 'GAME',
+    ppv: 'PPV',
+    bundle: 'PPV',
+    vip: 'VIP',
+  };
+
   const buildMetadata = useCallback((
     data: FormData,
     meta: Record<string, unknown>,
     extraFields?: Record<string, unknown>,
-  ) => ({
-    // Spread raw metadata first so explicit fields below take priority
-    ...meta,
-    submissionType: data.submissionType,
-    contentStyle,
-    // Game-specific fields
-    ...(contentStyle === 'game' ? {
-      gameType: styleFields.gameType || undefined,
-      gifUrl: styleFields.gifUrl || undefined,
-      gameNotes: styleFields.gameNotes || undefined,
-    } : {}),
-    // PPV/Bundle-specific fields
-    ...(contentStyle === 'ppv' || contentStyle === 'bundle' ? {
-      originalPollReference: styleFields.originalPollReference || undefined,
-    } : {}),
-    pricingCategory: data.pricingCategory,
-    pageType: (meta as Record<string, unknown>).pageType || 'ALL_PAGES',
-    contentType: data.contentType,
-    contentTypeOptionId: data.contentTypeOptionId,
-    contentTags: data.contentTags,
-    internalModelTags: data.internalModelTags,
-    externalCreatorTags: data.externalCreatorTags,
-    // Hoist top-level form fields into metadata so board items can access them
-    modelId: data.modelId ?? null,
-    platforms: data.platform ?? ['onlyfans'],
-    // Wall post workflow: set initial status so it appears in Caption Workspace flow
-    ...(data.submissionType === 'WALL_POST' ? { wallPostStatus: 'PENDING_CAPTION' } : {}),
-    ...extraFields,
-  }), [contentStyle, styleFields]);
+  ) => {
+    // Derive postOrigin: contentStyle override takes priority, then metadata's postOrigin, then 'OTP'
+    const derivedPostOrigin =
+      CONTENT_STYLE_TO_POST_ORIGIN[contentStyle] ??
+      (meta.postOrigin as string) ??
+      'OTP';
+
+    return {
+      // Spread raw metadata first so explicit fields below take priority
+      ...meta,
+      submissionType: data.submissionType,
+      contentStyle,        // Keep for backward compat
+      postOrigin: derivedPostOrigin, // NEW: unified post origin field
+      // Game-specific fields
+      ...(contentStyle === 'game' ? {
+        gameType: styleFields.gameType || undefined,
+        gifUrl: styleFields.gifUrl || undefined,
+        gameNotes: styleFields.gameNotes || undefined,
+      } : {}),
+      // PPV/Bundle-specific fields
+      ...(contentStyle === 'ppv' || contentStyle === 'bundle' ? {
+        originalPollReference: styleFields.originalPollReference || undefined,
+      } : {}),
+      pricingCategory: data.pricingCategory,
+      pageType: (meta as Record<string, unknown>).pageType || 'ALL_PAGES',
+      contentType: data.contentType,
+      contentTypeOptionId: data.contentTypeOptionId,
+      contentTags: data.contentTags,
+      internalModelTags: data.internalModelTags,
+      externalCreatorTags: data.externalCreatorTags,
+      // Hoist top-level form fields into metadata so board items can access them
+      modelId: data.modelId ?? null,
+      platforms: data.platform ?? ['onlyfans'],
+      // Wall post workflow: set initial status so it appears in Caption Workspace flow
+      ...(data.submissionType === 'WALL_POST' ? { wallPostStatus: 'PENDING_CAPTION' } : {}),
+      ...extraFields,
+    };
+  }, [contentStyle, styleFields]);
 
   const onSubmit = async (data: FormData) => {
     setSubmitError(null);
@@ -259,10 +278,9 @@ export const SubmissionForm = memo(function SubmissionForm({
     try {
       const meta = (data.metadata ?? {}) as Record<string, unknown>;
 
-      // Title: use model/buyer from metadata, fall back to template label
+      // Title: use model name from metadata, fall back to template label
       const title =
         (meta.model as string)?.trim() ||
-        (meta.buyer as string)?.trim() ||
         TEMPLATE_LABELS[data.submissionType] ||
         data.submissionType;
 
@@ -661,20 +679,25 @@ export const SubmissionForm = memo(function SubmissionForm({
                     assigneeId={assigneeId}
                     onAssigneeChange={setAssigneeId}
                   />
-                </StepContent>
-              )}
 
-              {/* File Upload Step */}
-              {currentStepInfo?.id === 'files' && (
-                <StepContent title="Upload Files" subtitle="Add images or videos — they'll be attached when you submit">
-                  <FileUploadStep
-                    mode={uploadMode}
-                    onModeChange={setUploadMode}
-                    files={pendingFiles}
-                    onFilesChange={setPendingFiles}
-                    driveFiles={driveFiles}
-                    onDriveFilesChange={setDriveFiles}
-                  />
+                  {/* File Uploads section */}
+                  <div className="mt-8 pt-8 border-t border-zinc-700/50">
+                    <div className="mb-5">
+                      <h3 className="text-base font-semibold text-white flex items-center gap-2">
+                        <Upload className="w-4 h-4 text-brand-light-pink" />
+                        Attachments
+                      </h3>
+                      <p className="text-sm text-zinc-400 mt-1">Upload reference images or paste a Google Drive link</p>
+                    </div>
+                    <FileUploadStep
+                      mode={uploadMode}
+                      onModeChange={setUploadMode}
+                      files={pendingFiles}
+                      onFilesChange={setPendingFiles}
+                      driveFiles={driveFiles}
+                      onDriveFilesChange={setDriveFiles}
+                    />
+                  </div>
                 </StepContent>
               )}
 
@@ -850,10 +873,10 @@ const LocalFilePicker = memo(function LocalFilePicker({
         </div>
         <div className="text-center">
           <p className="text-sm font-medium text-zinc-300">
-            {dragActive ? 'Drop files here' : 'Drop files or click to browse'}
+            {dragActive ? 'Drop files here' : 'Drop files here or click to browse'}
           </p>
           <p className="text-xs text-zinc-600 mt-1">
-            Images & videos · Max {maxFileSizeMB} MB each · {files.length}/{maxFiles} files
+            Max {maxFiles} files, {maxFileSizeMB}MB each
           </p>
         </div>
       </div>
@@ -980,7 +1003,13 @@ const FileUploadStep = memo(function FileUploadStep({
 
       {/* Upload Files section */}
       {(mode === 'upload' || mode === 'both') && (
-        <LocalFilePicker files={files} onChange={onFilesChange} />
+        <div>
+          <p className="text-sm font-medium text-zinc-300 mb-2">Reference Images (screenshots from OF vault)</p>
+          <LocalFilePicker files={files} onChange={onFilesChange} />
+          <p className="text-xs text-zinc-600 mt-1.5">
+            Upload screenshots from OnlyFans vault for team reference
+          </p>
+        </div>
       )}
 
       {/* Google Drive Link section */}
@@ -1253,6 +1282,7 @@ const ReviewStep = memo(function ReviewStep({
       key !== 'submitStatus' &&
       key !== 'boardItemId' &&
       key !== 'contentStyle' &&
+      key !== 'postOrigin' &&
       key !== 'pageType' &&
       key !== 'contentType' &&
       v !== '' &&
@@ -1333,6 +1363,15 @@ const ReviewStep = memo(function ReviewStep({
         <div className="bg-zinc-800/30 rounded-xl p-6 border border-zinc-700/30">
           <h3 className="text-sm font-medium text-zinc-400 mb-3">Content Configuration</h3>
           <div className="grid grid-cols-2 gap-4">
+            <div>
+              <p className="text-xs text-zinc-500 mb-1">Post Origin</p>
+              <p className="text-white font-medium">
+                {(() => {
+                  const STYLE_TO_ORIGIN: Record<string, string> = { game: 'GAME', ppv: 'PPV', bundle: 'PPV', vip: 'VIP' };
+                  return (STYLE_TO_ORIGIN[contentStyle] ?? (metadata as Record<string, unknown>)?.postOrigin ?? 'OTP') as string;
+                })()}
+              </p>
+            </div>
             <div>
               <p className="text-xs text-zinc-500 mb-1">Content Style</p>
               <p className="text-white font-medium capitalize">{contentStyle}</p>

--- a/lib/content-submission/step-generator.ts
+++ b/lib/content-submission/step-generator.ts
@@ -20,7 +20,6 @@ export function generateSteps(submissionType?: string): WizardStep[] {
 
   steps.push(
     { id: 'details', title: 'Content Details' },
-    { id: 'files', title: 'File Uploads' },
     { id: 'review', title: 'Review & Submit' },
   );
 

--- a/lib/spaces/template-metadata.ts
+++ b/lib/spaces/template-metadata.ts
@@ -141,7 +141,8 @@ export const SEXTING_SETS_METADATA_FIELDS: MetadataFieldDescriptor[] = [
 /* ================================================================== */
 
 export interface OtpPtrItemMetadata {
-  requestType: 'OTP' | 'PTR' | 'CUSTOM';
+  // --- Submission fields (set at creation) ---
+  postOrigin: 'PTR' | 'OTP' | 'OTM' | 'PPV' | 'GAME' | 'LIVE' | 'TIP_ME' | 'VIP' | 'DM_FUNNEL' | 'RENEW_ON' | 'CUSTOM';
   price: number;
   model: string;
   pricingTier: string;
@@ -150,20 +151,29 @@ export interface OtpPtrItemMetadata {
   contentType: string;
   contentLength: string;
   contentCount: string;
-  deliverables: string[];
   externalCreatorTags: string[];
   internalModelTags: string[];
   contentTags: string[];
   deadline: string;
-  isPaid: boolean;
-  fulfillmentNotes: string;
+  platforms: string[];
+
+  // --- Workflow fields (filled by teams) ---
   caption: string;
   gameType: string;
-  gifUrl: string;
+  gifUrl: string;                    // Single GIF URL (or OnlyFans GIF when both platforms)
+  gifUrlFansly: string;              // NEW: Fansly-specific GIF URL (when both platforms selected)
+  gameNotes: string;
+  originalPollReference: string;     // PPV/Bundle reference
+  campaignOrUnlock: string;          // NEW: "Campaign", "Unlock", etc.
+  totalSale: number;                 // NEW: Revenue tracking (QA only)
+  qaNotes: string;                   // NEW: QA team notes
+  postLinkOnlyfans: string;          // NEW: OF post URL after deployment
+  postLinkFansly: string;            // NEW: Fansly post URL after deployment
+  datePosted: string;                // NEW: Actual post date (ISO string)
 }
 
 export const OTP_PTR_METADATA_DEFAULTS: OtpPtrItemMetadata = {
-  requestType: 'OTP',
+  postOrigin: 'OTP',
   price: 0,
   model: '',
   pricingTier: '',
@@ -172,43 +182,40 @@ export const OTP_PTR_METADATA_DEFAULTS: OtpPtrItemMetadata = {
   contentType: '',
   contentLength: '',
   contentCount: '',
-  deliverables: [],
   externalCreatorTags: [],
   internalModelTags: [],
   contentTags: [],
   deadline: '',
-  isPaid: false,
-  fulfillmentNotes: '',
+  platforms: [],
   caption: '',
   gameType: '',
   gifUrl: '',
+  gifUrlFansly: '',
+  gameNotes: '',
+  originalPollReference: '',
+  campaignOrUnlock: '',
+  totalSale: 0,
+  qaNotes: '',
+  postLinkOnlyfans: '',
+  postLinkFansly: '',
+  datePosted: '',
 };
 
 export const OTP_PTR_METADATA_FIELDS: MetadataFieldDescriptor[] = [
   {
-    key: 'requestType',
-    label: 'Request Type',
+    key: 'postOrigin',
+    label: 'Post Origin',
     type: 'select',
     required: true,
-    options: ['OTP', 'PTR', 'CUSTOM'],
+    options: ['PTR', 'OTP', 'OTM', 'PPV', 'GAME', 'LIVE', 'TIP_ME', 'VIP', 'DM_FUNNEL', 'RENEW_ON', 'CUSTOM'],
   },
   { key: 'price', label: 'Price ($)', type: 'number', placeholder: '0.00' },
-  // model — now a dedicated searchable dropdown in ContentDetailsFields
-  // pricingTier — now a dedicated dropdown in ContentDetailsFields
-  // pageType — now a dedicated dropdown in ContentDetailsFields
-  { key: 'driveLink', label: 'Drive Link', type: 'text', placeholder: 'https://drive.google.com/...' },
-  // contentType — now a dedicated pricing-aware dropdown in ContentDetailsFields
+  // driveLink — handled by the Google Drive attachment section in the submission form
   { key: 'contentLength', label: 'Content Length', type: 'text', placeholder: 'e.g. 8:43 or 8 mins 43 secs' },
   { key: 'contentCount', label: 'Content Count', type: 'text', placeholder: 'e.g. 1 Video, 3 Photos' },
-  { key: 'deliverables', label: 'Deliverables', type: 'tags', placeholder: 'e.g. 3 photos, 1 video' },
   { key: 'externalCreatorTags', label: 'Tags — External Creators', type: 'tags', placeholder: '@johndoe @janedoe' },
-  // internalModelTags — now a dedicated modal multi-select in ContentDetailsFields
-  // contentTags — now a dedicated multi-select in ContentDetailsFields
   { key: 'deadline', label: 'Deadline', type: 'date' },
-  { key: 'isPaid', label: 'Paid', type: 'boolean' },
-  { key: 'fulfillmentNotes', label: 'Fulfillment Notes', type: 'textarea', placeholder: 'Delivery instructions...' },
-  { key: 'caption', label: 'Caption', type: 'textarea', placeholder: 'PGT caption text...' },
-  // gameType, gifUrl, gameNotes — handled in Content Style step (ContentStyleSelector)
+  // caption, campaignOrUnlock, qaNotes, totalSale — workflow-only fields (board modal, not submission form)
 ];
 
 /* ================================================================== */

--- a/lib/validations/content-submission.ts
+++ b/lib/validations/content-submission.ts
@@ -16,6 +16,11 @@ export type ComponentModule = z.infer<typeof componentModuleSchema>;
 // Platform enum
 export const platformSchema = z.enum(['onlyfans', 'fansly']);
 
+// Post origin — unified type replacing requestType + contentStyle
+export const postOriginSchema = z.enum([
+  'PTR', 'OTP', 'OTM', 'PPV', 'GAME', 'LIVE', 'TIP_ME', 'VIP', 'DM_FUNNEL', 'RENEW_ON', 'CUSTOM',
+]);
+
 // Pricing category enum
 export const pricingCategorySchema = z.enum([
   'PORN_ACCURATE',
@@ -31,6 +36,9 @@ export const createSubmissionInputSchema = z.object({
 
   // Required fields
   submissionType: submissionTypeSchema,
+
+  // Post origin — unified type (optional; derived from contentStyle + metadata in form)
+  postOrigin: postOriginSchema.optional(),
 
   // Platform selection (optional — captured in metadata for WALL_POST)
   platform: z.array(platformSchema).optional().default(['onlyfans']),


### PR DESCRIPTION
- Board columns and cards updated to gray-800 dark theme
- Detail modal sections now use glassmorphism cards with color-coded borders
- Modal made wider (max-w-7xl) and taller (82vh)
- Platform badges (OF/Fansly) now prominently displayed with distinct colors
- Expanded post origin types (OTM, PPV, GAME, LIVE, TIP_ME, VIP, etc.)
- Simplified metadata by removing unused fields (buyer, isPaid, contentStyle)
- Added new fields: campaignOrUnlock, totalSale, qaNotes, postLinks, datePosted