### PR TITLE
feat: add status/tier/page-type dropdowns in task modal and improve s…

### DIFF
--- a/app/[tenant]/(dashboard)/spaces/[slug]/SpaceBoardView.tsx
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/SpaceBoardView.tsx
@@ -176,6 +176,7 @@ function TemplateBoardView({ slug }: { slug: string }) {
     handleColumnTitleUpdate,
     handleTaskClick,
     handleTaskUpdate,
+    handleColumnChange,
     handleTitleUpdate,
     handleDeleteTask,
     closeTaskModal,
@@ -362,6 +363,8 @@ function TemplateBoardView({ slug }: { slug: string }) {
         <DetailModal
           task={selectedTask}
           columnTitle={selectedColumnTitle}
+          columns={boardData?.columns.map((c) => ({ id: c.id, name: c.name })) ?? []}
+          onColumnChange={(colId) => handleColumnChange(selectedTask.id, colId)}
           isOpen={!!selectedTask}
           onClose={closeTaskModal}
           onUpdate={handleTaskUpdate}

--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/OtpPtrTaskDetailModal.tsx
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/OtpPtrTaskDetailModal.tsx
@@ -66,6 +66,8 @@ import { CONTENT_STYLES } from '@/components/content-submission/ContentStyleSele
 interface Props {
   task: BoardTask;
   columnTitle: string;
+  columns?: { id: string; name: string }[];
+  onColumnChange?: (columnId: string) => void;
   isOpen: boolean;
   onClose: () => void;
   onUpdate: (updated: BoardTask) => void;
@@ -76,6 +78,20 @@ type ModalTab = 'details' | 'workflow' | 'history' | 'comments';
 /* ── Constants ───────────────────────────────────────────── */
 
 const POST_ORIGIN_OPTIONS = ['PTR', 'OTP', 'OTM', 'PPV', 'GAME', 'LIVE', 'TIP_ME', 'VIP', 'DM_FUNNEL', 'RENEW_ON', 'CUSTOM'];
+
+const TIER_OPTIONS = [
+  { value: 'PORN_ACCURATE', label: 'Porn Accurate' },
+  { value: 'PORN_SCAM', label: 'Porn Scam' },
+  { value: 'GF_ACCURATE', label: 'GF Accurate' },
+  { value: 'GF_SCAM', label: 'GF Scam' },
+];
+
+const PAGE_TYPE_OPTIONS = [
+  { value: 'ALL_PAGES', label: 'All Pages' },
+  { value: 'FREE', label: 'Free' },
+  { value: 'PAID', label: 'Paid' },
+  { value: 'VIP', label: 'VIP' },
+];
 
 const PRIORITY_PILL: Record<string, string> = {
   High: 'text-red-400',
@@ -329,6 +345,8 @@ function RemovableTag({
 export function OtpPtrTaskDetailModal({
   task,
   columnTitle,
+  columns,
+  onColumnChange,
   isOpen,
   onClose,
   onUpdate,
@@ -1567,10 +1585,27 @@ export function OtpPtrTaskDetailModal({
             </div>
 
             <SideRow label="Status">
-              <span className="flex items-center gap-1.5 text-sm font-semibold text-brand-off-white">
-                <span className="h-2 w-2 rounded-full bg-brand-light-pink" />
-                {columnTitle}
-              </span>
+              {columns && columns.length > 0 && onColumnChange ? (
+                <SelectField
+                  value={columnTitle}
+                  options={columns.map((c) => c.name)}
+                  onSave={(name) => {
+                    const col = columns.find((c) => c.name === name);
+                    if (col) onColumnChange(col.id);
+                  }}
+                  renderOption={(name) => (
+                    <span className="flex items-center gap-1.5">
+                      <span className={`h-2 w-2 rounded-full ${name === columnTitle ? 'bg-brand-light-pink' : 'bg-gray-500'}`} />
+                      {name}
+                    </span>
+                  )}
+                />
+              ) : (
+                <span className="flex items-center gap-1.5 text-sm font-semibold text-brand-off-white">
+                  <span className="h-2 w-2 rounded-full bg-brand-light-pink" />
+                  {columnTitle}
+                </span>
+              )}
             </SideRow>
 
             <SideRow label="Priority">
@@ -1602,15 +1637,25 @@ export function OtpPtrTaskDetailModal({
             </SideRow>
 
             <SideRow label="Tier">
-              <span className="text-sm font-semibold text-brand-off-white">
-                <EditableField value={tier} placeholder="Set tier" onSave={(v) => updateMeta({ pricingCategory: v, pricingTier: v })} />
-              </span>
+              <SelectField
+                value={TIER_OPTIONS.find((o) => o.value === tier)?.label || tier || 'Set tier'}
+                options={TIER_OPTIONS.map((o) => o.label)}
+                onSave={(label) => {
+                  const opt = TIER_OPTIONS.find((o) => o.label === label);
+                  if (opt) updateMeta({ pricingCategory: opt.value, pricingTier: opt.value });
+                }}
+              />
             </SideRow>
 
             <SideRow label="Page Type">
-              <span className="text-sm font-semibold text-brand-off-white">
-                <EditableField value={pageType} placeholder="Set page type" onSave={(v) => updateMeta({ pageType: v })} />
-              </span>
+              <SelectField
+                value={PAGE_TYPE_OPTIONS.find((o) => o.value === pageType)?.label || pageType || 'Set page type'}
+                options={PAGE_TYPE_OPTIONS.map((o) => o.label)}
+                onSave={(label) => {
+                  const opt = PAGE_TYPE_OPTIONS.find((o) => o.label === label);
+                  if (opt) updateMeta({ pageType: opt.value });
+                }}
+              />
             </SideRow>
 
             <SideRow label="Model">

--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/template-config.ts
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/template-config.ts
@@ -12,6 +12,8 @@ import type { SummaryTabProps } from './summary';
 export interface TaskDetailModalProps {
   task: BoardTask;
   columnTitle: string;
+  columns?: { id: string; name: string }[];
+  onColumnChange?: (columnId: string) => void;
   isOpen: boolean;
   onClose: () => void;
   onUpdate: (task: BoardTask) => void;

--- a/app/[tenant]/(dashboard)/spaces/[slug]/useSpaceBoard.ts
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/useSpaceBoard.ts
@@ -309,6 +309,28 @@ export function useSpaceBoard({ space, itemToTask = defaultItemToTask }: UseSpac
     [effectiveTasks, updateItemMutation],
   );
 
+  const handleColumnChange = useCallback(
+    (taskId: string, newColumnId: string) => {
+      const oldCol = findColumnForTask(taskId);
+      if (!oldCol || oldCol.id === newColumnId) return;
+      const newCol = effectiveColumns[newColumnId];
+      if (!newCol) return;
+
+      // Optimistic: move task between columns
+      const newCols = { ...effectiveColumns };
+      newCols[oldCol.id] = { ...oldCol, taskIds: oldCol.taskIds.filter((id) => id !== taskId) };
+      newCols[newCol.id] = { ...newCol, taskIds: [...newCol.taskIds, taskId] };
+      setLocalColumns(newCols);
+
+      // Update column title shown in modal
+      setSelectedColumnTitle(newCol.title);
+
+      // Persist to server
+      updateItemMutation.mutate({ itemId: taskId, columnId: newColumnId });
+    },
+    [effectiveColumns, findColumnForTask, updateItemMutation],
+  );
+
   const handleTitleUpdate = useCallback(
     (task: BoardTask, newTitle: string) => {
       const updated = { ...task, title: newTitle };
@@ -444,6 +466,7 @@ export function useSpaceBoard({ space, itemToTask = defaultItemToTask }: UseSpac
     handleColumnTitleUpdate,
     handleTaskClick,
     handleTaskUpdate,
+    handleColumnChange,
     handleTitleUpdate,
     handleDeleteTask,
     closeTaskModal,

--- a/components/content-submission/SubmissionForm.tsx
+++ b/components/content-submission/SubmissionForm.tsx
@@ -278,11 +278,20 @@ export const SubmissionForm = memo(function SubmissionForm({
     try {
       const meta = (data.metadata ?? {}) as Record<string, unknown>;
 
-      // Title: use model name from metadata, fall back to template label
-      const title =
-        (meta.model as string)?.trim() ||
-        TEMPLATE_LABELS[data.submissionType] ||
-        data.submissionType;
+      // Title: combine model + postOrigin + contentType for a descriptive title
+      const modelName = (meta.model as string)?.trim();
+      const postOrigin = (meta.postOrigin as string)?.trim();
+      const contentType = (meta.contentType as string)?.trim();
+      const titleParts: string[] = [];
+      if (modelName) titleParts.push(modelName);
+      const detailParts: string[] = [];
+      if (postOrigin) detailParts.push(postOrigin.toUpperCase());
+      if (contentType) {
+        // contentType is a slug like "solo-video", convert to readable
+        detailParts.push(contentType.replace(/-/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase()));
+      }
+      if (detailParts.length > 0) titleParts.push(detailParts.join(' '));
+      const title = titleParts.join(' — ') || TEMPLATE_LABELS[data.submissionType] || data.submissionType;
 
       // Due date: pull from template metadata date fields
       const rawDue =


### PR DESCRIPTION
…ubmission titles

- Add status dropdown in sidebar to move tasks between board columns directly from the modal
- Replace free-text Tier and Page Type fields with selectable dropdowns matching submission form options
- Generate descriptive submission titles combining model, post origin, and content type (e.g. "ALANNA — PPV Solo Video")