### PR TITLE
feat: enhance gallery with board metadata, fix modal layout and image…

### DIFF
--- a/app/api/spaces/[spaceId]/boards/[boardId]/items/[itemId]/mark-final/route.ts
+++ b/app/api/spaces/[spaceId]/boards/[boardId]/items/[itemId]/mark-final/route.ts
@@ -127,7 +127,25 @@ export async function POST(req: NextRequest, { params }: Params) {
       modelId = model?.id ?? null;
     }
 
-    // 6. Move item to "Posted" column and create gallery entries in a transaction
+    // 6. Extract OTP/PTR-specific metadata for gallery
+    const postOrigin = (meta.postOrigin as string) ?? (meta.requestType as string) ?? null;
+    const pricingTier = (meta.pricingCategory as string) ?? (meta.pricingTier as string) ?? null;
+    const pageType = (meta.pageType as string) ?? null;
+
+    const boardMetadata: Record<string, string | string[]> = {};
+    if (meta.contentLength) boardMetadata.contentLength = String(meta.contentLength);
+    if (meta.contentCount) boardMetadata.contentCount = String(meta.contentCount);
+    if (meta.driveLink) boardMetadata.driveLink = String(meta.driveLink);
+    if (meta.postLinkOnlyfans) boardMetadata.postLinkOnlyfans = String(meta.postLinkOnlyfans);
+    if (meta.postLinkFansly) boardMetadata.postLinkFansly = String(meta.postLinkFansly);
+    if (meta.gifUrl) boardMetadata.gifUrl = String(meta.gifUrl);
+    if (meta.gifUrlFansly) boardMetadata.gifUrlFansly = String(meta.gifUrlFansly);
+    if (Array.isArray(meta.internalModelTags) && meta.internalModelTags.length > 0)
+      boardMetadata.internalModelTags = meta.internalModelTags as string[];
+    if (Array.isArray(meta.externalCreatorTags) && meta.externalCreatorTags.length > 0)
+      boardMetadata.externalCreatorTags = meta.externalCreatorTags as string[];
+
+    // Move item to "Posted" column and create gallery entries in a transaction
     const galleryBase = {
       title: item.title,
       contentType,
@@ -142,6 +160,10 @@ export async function POST(req: NextRequest, { params }: Params) {
       organizationId: item.organizationId,
       modelId,
       createdBy: userId,
+      postOrigin,
+      pricingTier,
+      pageType,
+      boardMetadata: Object.keys(boardMetadata).length > 0 ? boardMetadata : undefined,
     };
 
     const { updatedItem, galleryItem } = await prisma.$transaction(async (tx) => {

--- a/components/gallery/DetailModal.tsx
+++ b/components/gallery/DetailModal.tsx
@@ -1,14 +1,29 @@
 'use client';
 
 import React, { useState } from 'react';
+import { createPortal } from 'react-dom';
 import {
   X, ExternalLink, Calendar, DollarSign, Eye, ShoppingCart,
   Tag, User, Copy, Check, ChevronLeft, ChevronRight, Edit2,
-  Archive, BarChart3, Link2
+  Archive, BarChart3, Link2, Film, Images, Globe, Users
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { CONTENT_TYPE_LABELS, PLATFORM_LABELS, type GalleryContentType, type GalleryPlatform } from '@/lib/constants/gallery';
-import type { GalleryItemWithModel } from '@/types/gallery';
+import type { GalleryItemWithModel, GalleryBoardMetadata } from '@/types/gallery';
+
+const TIER_LABELS: Record<string, string> = {
+  PORN_ACCURATE: 'Porn Accurate',
+  PORN_SCAM: 'Porn Scam',
+  GF_ACCURATE: 'GF Accurate',
+  GF_SCAM: 'GF Scam',
+};
+
+const PAGE_TYPE_LABELS: Record<string, string> = {
+  ALL_PAGES: 'All Pages',
+  FREE: 'Free',
+  PAID: 'Paid',
+  VIP: 'VIP',
+};
 
 interface DetailModalProps {
   item: GalleryItemWithModel;
@@ -32,7 +47,9 @@ export function DetailModal({
   hasNext = false,
 }: DetailModalProps) {
   const [copied, setCopied] = useState<string | null>(null);
-  const [imageLoaded, setImageLoaded] = useState(false);
+  const hasValidImage = !!item.previewUrl && item.previewUrl.startsWith('http') && item.previewUrl !== '/placeholder-gallery.png';
+  const [imageLoaded, setImageLoaded] = useState(!hasValidImage);
+  const [imageError, setImageError] = useState(false);
 
   const copyToClipboard = async (text: string, label: string) => {
     try {
@@ -60,6 +77,13 @@ export function DetailModal({
     return `$${Number(amount).toFixed(2)}`;
   };
 
+  // Lock body scroll while modal is open
+  React.useEffect(() => {
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => { document.body.style.overflow = prev; };
+  }, []);
+
   // Handle keyboard navigation
   React.useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -71,8 +95,8 @@ export function DetailModal({
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [onClose, onNavigate, hasPrev, hasNext]);
 
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
+  return createPortal(
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center overflow-hidden" style={{ isolation: 'isolate' }}>
       {/* Backdrop */}
       <div
         className="absolute inset-0 bg-black/90 backdrop-blur-md"
@@ -98,24 +122,28 @@ export function DetailModal({
       )}
 
       {/* Modal */}
-      <div className="relative w-full max-w-5xl max-h-[90vh] bg-zinc-900 border border-zinc-800 rounded-2xl shadow-2xl overflow-hidden flex flex-col lg:flex-row">
+      <div className="relative w-full max-w-5xl mx-4 my-4 h-[calc(100vh-2rem)] bg-zinc-900 border border-zinc-800 rounded-2xl shadow-2xl overflow-hidden flex flex-col lg:flex-row">
         {/* Image Section */}
-        <div className="lg:w-1/2 bg-black flex items-center justify-center relative min-h-[300px] lg:min-h-0">
-          {!imageLoaded && (
+        <div className="lg:w-1/2 bg-black flex items-center justify-center relative min-h-[200px] max-h-[35vh] lg:max-h-none lg:min-h-0">
+          {!imageLoaded && !imageError && (
             <div className="absolute inset-0 flex items-center justify-center">
               <div className="w-12 h-12 border-2 border-violet-500 border-t-transparent rounded-full animate-spin" />
             </div>
           )}
-          {item.previewUrl ? (
+          {hasValidImage && !imageError ? (
             <img
               src={item.previewUrl}
               alt={item.title || 'Preview'}
               className={`max-w-full max-h-[90vh] object-contain transition-opacity ${imageLoaded ? 'opacity-100' : 'opacity-0'}`}
               onLoad={() => setImageLoaded(true)}
+              onError={() => { setImageError(true); setImageLoaded(true); }}
             />
           ) : (
-            <div className="w-full h-full flex items-center justify-center text-zinc-600">
-              <Tag className="w-16 h-16" />
+            <div className="w-full h-full flex flex-col items-center justify-center gap-4">
+              <div className="w-20 h-20 rounded-2xl bg-gradient-to-br from-brand-light-pink/20 to-brand-blue/20 flex items-center justify-center border border-white/[0.06]">
+                <BarChart3 className="w-10 h-10 text-brand-light-pink/50" />
+              </div>
+              <span className="text-sm text-zinc-500">{item.title || 'No Preview Available'}</span>
             </div>
           )}
 
@@ -143,9 +171,9 @@ export function DetailModal({
         {/* Details Section */}
         <div className="lg:w-1/2 flex flex-col overflow-hidden">
           {/* Header */}
-          <div className="flex items-center justify-between p-6 border-b border-zinc-800">
+          <div className="flex items-center justify-between px-5 py-3 border-b border-zinc-800">
             <div className="flex-1 min-w-0">
-              <h2 className="text-xl font-medium text-white truncate">
+              <h2 className="text-lg font-medium text-white truncate">
                 {item.title || 'Untitled Content'}
               </h2>
               <div className="flex items-center gap-2 mt-1">
@@ -171,21 +199,22 @@ export function DetailModal({
           </div>
 
           {/* Content - Scrollable */}
-          <div className="flex-1 overflow-y-auto p-6 space-y-6">
+          <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
             {/* Model Info */}
             {item.model && (
-              <div className="flex items-center gap-4 p-4 rounded-xl bg-zinc-800/50">
-                {item.model.profileImageUrl ? (
-                  <img
-                    src={item.model.profileImageUrl}
-                    alt={item.model.displayName || item.model.name}
-                    className="w-12 h-12 rounded-full object-cover border-2 border-zinc-700"
-                  />
-                ) : (
-                  <div className="w-12 h-12 rounded-full bg-gradient-to-br from-violet-500/20 to-fuchsia-500/20 border-2 border-zinc-700 flex items-center justify-center">
+              <div className="flex items-center gap-3 p-3 rounded-xl bg-zinc-800/50">
+                <div className="w-10 h-10 rounded-full bg-gradient-to-br from-violet-500/20 to-fuchsia-500/20 border-2 border-zinc-700 flex items-center justify-center shrink-0 overflow-hidden">
+                  {item.model.profileImageUrl?.startsWith('http') ? (
+                    <img
+                      src={item.model.profileImageUrl}
+                      alt={item.model.displayName || item.model.name}
+                      className="w-full h-full object-cover"
+                      onError={(e) => { e.currentTarget.style.display = 'none'; }}
+                    />
+                  ) : (
                     <User className="w-5 h-5 text-violet-400" />
-                  </div>
-                )}
+                  )}
+                </div>
                 <div>
                   <p className="text-white font-medium">{item.model.displayName || item.model.name}</p>
                   <p className="text-sm text-zinc-500">Model</p>
@@ -194,42 +223,42 @@ export function DetailModal({
             )}
 
             {/* Performance Stats */}
-            <div className="space-y-3">
-              <h3 className="text-sm font-medium text-zinc-400 uppercase tracking-wider">Performance</h3>
-              <div className="grid grid-cols-2 gap-3">
-                <div className="p-4 rounded-xl bg-zinc-800/50">
-                  <div className="flex items-center gap-2 text-emerald-400 mb-1">
-                    <DollarSign className="w-4 h-4" />
-                    <span className="text-xs font-medium uppercase">Revenue</span>
+            <div className="space-y-2">
+              <h3 className="text-xs font-medium text-zinc-400 uppercase tracking-wider">Performance</h3>
+              <div className="grid grid-cols-4 gap-2">
+                <div className="p-2.5 rounded-lg bg-zinc-800/50 text-center">
+                  <div className="flex items-center justify-center gap-1 text-emerald-400 mb-0.5">
+                    <DollarSign className="w-3.5 h-3.5" />
+                    <span className="text-[10px] font-medium uppercase">Revenue</span>
                   </div>
-                  <p className="text-2xl font-semibold text-white">
+                  <p className="text-base font-semibold text-white">
                     {formatCurrency(Number(item.revenue))}
                   </p>
                 </div>
-                <div className="p-4 rounded-xl bg-zinc-800/50">
-                  <div className="flex items-center gap-2 text-blue-400 mb-1">
-                    <ShoppingCart className="w-4 h-4" />
-                    <span className="text-xs font-medium uppercase">Sales</span>
+                <div className="p-2.5 rounded-lg bg-zinc-800/50 text-center">
+                  <div className="flex items-center justify-center gap-1 text-blue-400 mb-0.5">
+                    <ShoppingCart className="w-3.5 h-3.5" />
+                    <span className="text-[10px] font-medium uppercase">Sales</span>
                   </div>
-                  <p className="text-2xl font-semibold text-white">
+                  <p className="text-base font-semibold text-white">
                     {item.salesCount || 0}
                   </p>
                 </div>
-                <div className="p-4 rounded-xl bg-zinc-800/50">
-                  <div className="flex items-center gap-2 text-violet-400 mb-1">
-                    <Eye className="w-4 h-4" />
-                    <span className="text-xs font-medium uppercase">Views</span>
+                <div className="p-2.5 rounded-lg bg-zinc-800/50 text-center">
+                  <div className="flex items-center justify-center gap-1 text-violet-400 mb-0.5">
+                    <Eye className="w-3.5 h-3.5" />
+                    <span className="text-[10px] font-medium uppercase">Views</span>
                   </div>
-                  <p className="text-2xl font-semibold text-white">
+                  <p className="text-base font-semibold text-white">
                     {item.viewCount?.toLocaleString() || 0}
                   </p>
                 </div>
-                <div className="p-4 rounded-xl bg-zinc-800/50">
-                  <div className="flex items-center gap-2 text-amber-400 mb-1">
-                    <BarChart3 className="w-4 h-4" />
-                    <span className="text-xs font-medium uppercase">Conv. Rate</span>
+                <div className="p-2.5 rounded-lg bg-zinc-800/50 text-center">
+                  <div className="flex items-center justify-center gap-1 text-amber-400 mb-0.5">
+                    <BarChart3 className="w-3.5 h-3.5" />
+                    <span className="text-[10px] font-medium uppercase">Conv.</span>
                   </div>
-                  <p className="text-2xl font-semibold text-white">
+                  <p className="text-base font-semibold text-white">
                     {item.conversionRate ? `${(Number(item.conversionRate) * 100).toFixed(1)}%` : '-'}
                   </p>
                 </div>
@@ -237,8 +266,8 @@ export function DetailModal({
             </div>
 
             {/* Details */}
-            <div className="space-y-3">
-              <h3 className="text-sm font-medium text-zinc-400 uppercase tracking-wider">Details</h3>
+            <div className="space-y-2">
+              <h3 className="text-xs font-medium text-zinc-400 uppercase tracking-wider">Details</h3>
               <div className="space-y-2">
                 <div className="flex items-center justify-between py-2 border-b border-zinc-800/50">
                   <span className="text-zinc-500 flex items-center gap-2">
@@ -278,11 +307,121 @@ export function DetailModal({
               </div>
             </div>
 
+            {/* Board Details */}
+            {(() => {
+              const bm = (item.boardMetadata ?? null) as GalleryBoardMetadata | null;
+              const hasBoard = item.postOrigin || item.pricingTier || item.pageType || bm;
+              if (!hasBoard) return null;
+              return (
+                <div className="space-y-2">
+                  <h3 className="text-xs font-medium text-zinc-400 uppercase tracking-wider">Board Details</h3>
+                  <div className="space-y-2">
+                    {item.postOrigin && (
+                      <div className="flex items-center justify-between py-2 border-b border-zinc-800/50">
+                        <span className="text-zinc-500">Post Origin</span>
+                        <span className="px-2 py-0.5 rounded-md text-xs font-semibold bg-cyan-500/15 text-cyan-400">
+                          {item.postOrigin.replace(/_/g, ' ')}
+                        </span>
+                      </div>
+                    )}
+                    {item.pricingTier && (
+                      <div className="flex items-center justify-between py-2 border-b border-zinc-800/50">
+                        <span className="text-zinc-500">Tier</span>
+                        <span className="text-zinc-300">{TIER_LABELS[item.pricingTier] || item.pricingTier}</span>
+                      </div>
+                    )}
+                    {item.pageType && (
+                      <div className="flex items-center justify-between py-2 border-b border-zinc-800/50">
+                        <span className="text-zinc-500">Page Type</span>
+                        <span className="text-zinc-300">{PAGE_TYPE_LABELS[item.pageType] || item.pageType}</span>
+                      </div>
+                    )}
+                    {bm?.contentCount && (
+                      <div className="flex items-center justify-between py-2 border-b border-zinc-800/50">
+                        <span className="text-zinc-500 flex items-center gap-2"><Images className="w-4 h-4" />Content</span>
+                        <span className="text-zinc-300">{bm.contentCount}</span>
+                      </div>
+                    )}
+                    {bm?.contentLength && (
+                      <div className="flex items-center justify-between py-2 border-b border-zinc-800/50">
+                        <span className="text-zinc-500 flex items-center gap-2"><Film className="w-4 h-4" />Length</span>
+                        <span className="text-zinc-300">{bm.contentLength}</span>
+                      </div>
+                    )}
+                    {/* Links */}
+                    {(bm?.driveLink || bm?.postLinkOnlyfans || bm?.postLinkFansly || bm?.gifUrl || bm?.gifUrlFansly) && (
+                      <div className="pt-2 space-y-2">
+                        {bm?.driveLink && (
+                          <a href={bm.driveLink.startsWith('http') ? bm.driveLink : `https://${bm.driveLink}`} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 text-xs text-brand-blue hover:underline">
+                            <Globe className="w-3.5 h-3.5" />Google Drive
+                            <ExternalLink className="w-3 h-3 ml-auto" />
+                          </a>
+                        )}
+                        {bm?.postLinkOnlyfans && (
+                          <a href={bm.postLinkOnlyfans} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 text-xs text-sky-400 hover:underline">
+                            <Link2 className="w-3.5 h-3.5" />OnlyFans Post
+                            <ExternalLink className="w-3 h-3 ml-auto" />
+                          </a>
+                        )}
+                        {bm?.postLinkFansly && (
+                          <a href={bm.postLinkFansly} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 text-xs text-indigo-400 hover:underline">
+                            <Link2 className="w-3.5 h-3.5" />Fansly Post
+                            <ExternalLink className="w-3 h-3 ml-auto" />
+                          </a>
+                        )}
+                        {bm?.gifUrl && (
+                          <a href={bm.gifUrl} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 text-xs text-pink-400 hover:underline">
+                            <Film className="w-3.5 h-3.5" />GIF Preview
+                            <ExternalLink className="w-3 h-3 ml-auto" />
+                          </a>
+                        )}
+                        {bm?.gifUrlFansly && (
+                          <a href={bm.gifUrlFansly} target="_blank" rel="noopener noreferrer" className="flex items-center gap-2 text-xs text-pink-400 hover:underline">
+                            <Film className="w-3.5 h-3.5" />GIF Preview (Fansly)
+                            <ExternalLink className="w-3 h-3 ml-auto" />
+                          </a>
+                        )}
+                      </div>
+                    )}
+                    {/* Collaborators */}
+                    {((bm?.internalModelTags && bm.internalModelTags.length > 0) || (bm?.externalCreatorTags && bm.externalCreatorTags.length > 0)) && (
+                      <div className="pt-2 space-y-2">
+                        {bm?.internalModelTags && bm.internalModelTags.length > 0 && (
+                          <div>
+                            <span className="text-[10px] uppercase tracking-wider text-zinc-500 font-medium flex items-center gap-1 mb-1.5">
+                              <Users className="w-3 h-3" />Internal Models
+                            </span>
+                            <div className="flex flex-wrap gap-1">
+                              {bm.internalModelTags.map((t) => (
+                                <span key={t} className="px-2 py-0.5 rounded-md text-xs bg-brand-blue/15 text-brand-blue font-medium">{t}</span>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                        {bm?.externalCreatorTags && bm.externalCreatorTags.length > 0 && (
+                          <div>
+                            <span className="text-[10px] uppercase tracking-wider text-zinc-500 font-medium flex items-center gap-1 mb-1.5">
+                              <Users className="w-3 h-3" />External Creators
+                            </span>
+                            <div className="flex flex-wrap gap-1">
+                              {bm.externalCreatorTags.map((t) => (
+                                <span key={t} className="px-2 py-0.5 rounded-md text-xs bg-brand-light-pink/15 text-brand-light-pink font-medium">{t}</span>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            })()}
+
             {/* Caption */}
             {item.captionUsed && (
-              <div className="space-y-3">
+              <div className="space-y-2">
                 <div className="flex items-center justify-between">
-                  <h3 className="text-sm font-medium text-zinc-400 uppercase tracking-wider">Caption</h3>
+                  <h3 className="text-xs font-medium text-zinc-400 uppercase tracking-wider">Caption</h3>
                   <button
                     onClick={() => copyToClipboard(item.captionUsed!, 'Caption')}
                     className="text-xs text-zinc-500 hover:text-white flex items-center gap-1 transition-colors"
@@ -299,7 +438,7 @@ export function DetailModal({
           </div>
 
           {/* Footer Actions */}
-          <div className="flex items-center gap-2 p-6 border-t border-zinc-800 bg-zinc-900/80">
+          <div className="flex items-center gap-2 px-5 py-3 border-t border-zinc-800 bg-zinc-900/80">
             {onEditContentType && (
               <button
                 onClick={onEditContentType}
@@ -330,6 +469,7 @@ export function DetailModal({
           </div>
         </div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/components/gallery/GalleryItem.tsx
+++ b/components/gallery/GalleryItem.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import React from 'react';
-import { DollarSign, Eye, ShoppingCart, Calendar, BarChart3, Archive, MoreVertical, Tag } from 'lucide-react';
+import { DollarSign, Eye, ShoppingCart, Calendar, BarChart3, Archive, MoreVertical, Tag, Film, Images } from 'lucide-react';
 import { CONTENT_TYPE_LABELS, PLATFORM_LABELS, type GalleryContentType, type GalleryPlatform } from '@/lib/constants/gallery';
-import type { GalleryItemWithModel } from '@/types/gallery';
+import type { GalleryItemWithModel, GalleryBoardMetadata } from '@/types/gallery';
 
 interface GalleryItemProps {
   item: GalleryItemWithModel;
@@ -47,8 +47,33 @@ const platformColors: Record<string, string> = {
   OTHER: 'bg-zinc-500/20 text-zinc-400',
 };
 
+const postOriginColors: Record<string, string> = {
+  OTP: 'bg-cyan-500/20 text-cyan-400',
+  PTR: 'bg-amber-500/20 text-amber-400',
+  PPV: 'bg-emerald-500/20 text-emerald-400',
+  GAME: 'bg-yellow-500/20 text-yellow-400',
+  LIVE: 'bg-red-500/20 text-red-400',
+  TIP_ME: 'bg-green-500/20 text-green-400',
+  VIP: 'bg-violet-500/20 text-violet-400',
+  OTM: 'bg-teal-500/20 text-teal-400',
+  DM_FUNNEL: 'bg-orange-500/20 text-orange-400',
+  RENEW_ON: 'bg-lime-500/20 text-lime-400',
+  CUSTOM: 'bg-zinc-500/20 text-zinc-400',
+};
+
+const TIER_LABELS: Record<string, string> = {
+  PORN_ACCURATE: 'Porn Accurate',
+  PORN_SCAM: 'Porn Scam',
+  GF_ACCURATE: 'GF Accurate',
+  GF_SCAM: 'GF Scam',
+};
+
+const isValidUrl = (url: string | null | undefined) =>
+  !!url && url.startsWith('http') && url !== '/placeholder-gallery.png';
+
 export function GalleryItem({ item, onClick, onEdit, onEditType, onPerformance, onArchive }: GalleryItemProps) {
   const [showMenu, setShowMenu] = React.useState(false);
+  const [imgError, setImgError] = React.useState(false);
 
   const revenue = Number(item.revenue) || 0;
   const salesCount = item.salesCount || 0;
@@ -59,6 +84,7 @@ export function GalleryItem({ item, onClick, onEdit, onEditType, onPerformance, 
   const platformLabel = PLATFORM_LABELS[item.platform as GalleryPlatform] || item.platform;
   const contentTypeColor = contentTypeColors[item.contentType] || contentTypeColors.OTHER;
   const platformColor = platformColors[item.platform] || platformColors.OTHER;
+  const boardMeta = (item.boardMetadata ?? null) as GalleryBoardMetadata | null;
 
   return (
     <div
@@ -70,20 +96,19 @@ export function GalleryItem({ item, onClick, onEdit, onEditType, onPerformance, 
 
       {/* Preview Image */}
       <div className="relative aspect-[4/3] overflow-hidden bg-zinc-800/50">
-        {item.previewUrl ? (
+        {isValidUrl(item.previewUrl) && !imgError ? (
           <img
             src={item.previewUrl}
             alt={item.title || 'Gallery item'}
             className="w-full h-full object-cover transition-transform duration-500 group-hover:scale-105"
-            onError={(e) => {
-              e.currentTarget.style.display = 'none';
-            }}
+            onError={() => setImgError(true)}
           />
         ) : (
-          <div className="w-full h-full flex items-center justify-center">
-            <div className="w-16 h-16 rounded-full bg-gradient-to-br from-violet-500/30 to-fuchsia-500/30 flex items-center justify-center">
-              <BarChart3 className="w-8 h-8 text-violet-400/50" />
+          <div className="w-full h-full flex flex-col items-center justify-center gap-3 bg-gradient-to-br from-zinc-800/80 to-zinc-900/80">
+            <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-brand-light-pink/20 to-brand-blue/20 flex items-center justify-center border border-white/[0.06]">
+              <BarChart3 className="w-7 h-7 text-brand-light-pink/60" />
             </div>
+            <span className="text-[11px] text-zinc-500 font-medium">{item.title || 'No Preview'}</span>
           </div>
         )}
 
@@ -99,6 +124,11 @@ export function GalleryItem({ item, onClick, onEdit, onEditType, onPerformance, 
             <span className={`px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider ${platformColor}`}>
               {platformLabel}
             </span>
+            {item.postOrigin && (
+              <span className={`px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wider ${postOriginColors[item.postOrigin] || postOriginColors.CUSTOM}`}>
+                {item.postOrigin.replace(/_/g, ' ')}
+              </span>
+            )}
           </div>
 
           {/* Menu */}
@@ -181,20 +211,47 @@ export function GalleryItem({ item, onClick, onEdit, onEditType, onPerformance, 
         {/* Model Info */}
         {item.model && (
           <div className="flex items-center gap-2">
-            {item.model.profileImageUrl ? (
-              <img
-                src={item.model.profileImageUrl}
-                alt={item.model.displayName}
-                className="w-6 h-6 rounded-full object-cover"
-              />
-            ) : (
-              <div className="w-6 h-6 rounded-full bg-gradient-to-br from-violet-500/30 to-fuchsia-500/30 flex items-center justify-center">
+            <div className="w-6 h-6 rounded-full bg-gradient-to-br from-violet-500/30 to-fuchsia-500/30 flex items-center justify-center shrink-0 overflow-hidden">
+              {isValidUrl(item.model.profileImageUrl) ? (
+                <img
+                  src={item.model.profileImageUrl!}
+                  alt={item.model.displayName}
+                  className="w-full h-full object-cover"
+                  onError={(e) => {
+                    e.currentTarget.style.display = 'none';
+                    e.currentTarget.parentElement!.innerHTML = `<span class="text-xs font-medium text-white/80">${item.model!.displayName.charAt(0)}</span>`;
+                  }}
+                />
+              ) : (
                 <span className="text-xs font-medium text-white/80">
                   {item.model.displayName.charAt(0)}
                 </span>
-              </div>
-            )}
+              )}
+            </div>
             <span className="text-sm text-zinc-400 truncate">{item.model.displayName}</span>
+          </div>
+        )}
+
+        {/* Content Info */}
+        {(item.pricingTier || boardMeta?.contentLength || boardMeta?.contentCount) && (
+          <div className="flex flex-wrap items-center gap-1.5 text-[10px]">
+            {item.pricingTier && (
+              <span className="px-1.5 py-0.5 rounded bg-amber-500/10 text-amber-400 font-medium">
+                {TIER_LABELS[item.pricingTier] || item.pricingTier}
+              </span>
+            )}
+            {boardMeta?.contentCount && (
+              <span className="flex items-center gap-1 text-zinc-400">
+                <Images className="w-3 h-3" />
+                {boardMeta.contentCount}
+              </span>
+            )}
+            {boardMeta?.contentLength && (
+              <span className="flex items-center gap-1 text-zinc-400">
+                <Film className="w-3 h-3" />
+                {boardMeta.contentLength}
+              </span>
+            )}
           </div>
         )}
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,8 +55,8 @@ model User {
   trackerActivityLogs      TrackerActivityLog[]
   trainingImages           TrainingImage[]
   trainingJobs             TrainingJob[]
-  workspace_members        WorkspaceMember[]
   dailyActivities          UserDailyActivity[]
+  workspace_members        WorkspaceMember[]
 
   @@index([currentOrganizationId])
   @@map("users")
@@ -1366,10 +1366,10 @@ model SextingSet {
   category      String
   s3FolderPath  String
   status        String         @default("draft")
-  sortOrder     Int            @default(0)
   scheduledDate DateTime?
   createdAt     DateTime       @default(now())
   updatedAt     DateTime       @updatedAt
+  sortOrder     Int            @default(0)
   images        SextingImage[]
 
   @@index([userId])
@@ -2001,6 +2001,10 @@ model gallery_items {
   updatedAt        DateTime      @updatedAt
   createdBy        String?
   boardItemId      String?       @unique
+  postOrigin       String?
+  pricingTier      String?
+  pageType         String?
+  boardMetadata    Json?
   board_items      BoardItem?    @relation(fields: [boardItemId], references: [id])
   model            of_models?    @relation(fields: [modelId], references: [id])
   organization     Organization? @relation(fields: [organizationId], references: [id], onDelete: Cascade)
@@ -2010,6 +2014,9 @@ model gallery_items {
   @@index([contentType])
   @@index([platform])
   @@index([postedAt])
+  @@index([postOrigin])
+  @@index([pricingTier])
+  @@index([pageType])
 }
 
 model plan_features {
@@ -2361,20 +2368,20 @@ model TrackerTeam {
 }
 
 model PageTrackerEntry {
-  id             String           @id @default(cuid())
-  profileId      String           @unique
-  teamId         String?
-  platformType   String?
-  managingSystem String?
+  id                  String           @id @default(cuid())
+  profileId           String           @unique
+  teamId              String?
+  platformType        String?
+  managingSystem      String?
   trackerStatus       String           @default("ACTIVE")
-  pausedContentStyles String[]         @default([])
   notes               String?
-  organizationId String
-  createdAt      DateTime         @default(now())
-  updatedAt      DateTime         @updatedAt
-  organization   Organization     @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  profile        InstagramProfile @relation(fields: [profileId], references: [id], onDelete: Cascade)
-  team           TrackerTeam?     @relation(fields: [teamId], references: [id])
+  organizationId      String
+  createdAt           DateTime         @default(now())
+  updatedAt           DateTime         @updatedAt
+  pausedContentStyles String[]         @default([])
+  organization        Organization     @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  profile             InstagramProfile @relation(fields: [profileId], references: [id], onDelete: Cascade)
+  team                TrackerTeam?     @relation(fields: [teamId], references: [id])
 
   @@index([teamId])
   @@index([organizationId])

--- a/types/gallery.ts
+++ b/types/gallery.ts
@@ -5,6 +5,19 @@ import type {
   GalleryPlatform,
 } from "@/lib/constants/gallery";
 
+/** OTP/PTR board-specific metadata stored as JSON */
+export interface GalleryBoardMetadata {
+  contentLength?: string;
+  contentCount?: string;
+  driveLink?: string;
+  postLinkOnlyfans?: string;
+  postLinkFansly?: string;
+  gifUrl?: string;
+  gifUrlFansly?: string;
+  internalModelTags?: string[];
+  externalCreatorTags?: string[];
+}
+
 /**
  * Gallery Item - Represents a piece of posted content with performance metrics
  */
@@ -41,6 +54,12 @@ export interface GalleryItem {
   postedAt: Date;
   origin: GalleryOrigin | string | null;
   sourceId: string | null;
+
+  // OTP/PTR fields
+  postOrigin: string | null;
+  pricingTier: string | null;
+  pageType: string | null;
+  boardMetadata: GalleryBoardMetadata | null;
 
   // Archive
   isArchived: boolean;


### PR DESCRIPTION
… handling

- Extract OTP/PTR metadata (postOrigin, pricingTier, pageType, boardMetadata) in mark-final endpoint
- Add Board Details section to gallery detail modal with links, collaborators, and content info
- Show post origin badge, tier, and content count/length on gallery cards
- Fix broken model avatar with graceful fallback to initial letter
- Fix infinite loading spinner when no preview image exists
- Render detail modal via portal to prevent parent scroll issues
- Compact modal layout to fit viewport with 4-column stats row
- Add gallery_items schema columns: postOrigin, pricingTier, pageType, boardMetadata