### PR TITLE
feat: complete GIF Maker Workspace with export flow, board integratio…

### DIFF
--- a/app/[tenant]/(dashboard)/layout.tsx
+++ b/app/[tenant]/(dashboard)/layout.tsx
@@ -190,6 +190,11 @@ export default function DashboardLayout({
                     href: `/${tenant}/workspace/caption-workspace`,
                     icon: FileText,
                   },
+                  {
+                    name: "GIF Maker Workspace",
+                    href: `/${tenant}/workspace/gif-maker`,
+                    icon: Film,
+                  },
                 ],
               },
             ]

--- a/app/[tenant]/(dashboard)/spaces/[slug]/templates/OtpPtrTaskDetailModal.tsx
+++ b/app/[tenant]/(dashboard)/spaces/[slug]/templates/OtpPtrTaskDetailModal.tsx
@@ -43,6 +43,7 @@ import { useOrgMembers } from '@/lib/hooks/useOrgMembers.query';
 import { MentionDropdown, type MentionDropdownHandle } from '../../board/MentionDropdown';
 import { CommentContent } from '../../board/CommentContent';
 import { extractMentionedClerkIds } from '@/lib/mention-utils';
+import { FlyerPicker } from '@/components/gif-maker-workspace/FlyerPicker';
 import { useOrgRole } from '@/lib/hooks/useOrgRole.query';
 import {
   useBoardItemComments,
@@ -448,6 +449,8 @@ export function OtpPtrTaskDetailModal({
   const { canManageQueue } = useOrgRole();
   const otpPtrQAMutation = useOtpPtrQAAction();
   const [showRejectInput, setShowRejectInput] = useState(false);
+  const [showFlyerPicker, setShowFlyerPicker] = useState(false);
+  const [flyerPickerTarget, setFlyerPickerTarget] = useState<'gifUrl' | 'gifUrlFansly'>('gifUrl');
   const [rejectReason, setRejectReason] = useState('');
   const [confirmRevoke, setConfirmRevoke] = useState(false);
 
@@ -1344,6 +1347,36 @@ export function OtpPtrTaskDetailModal({
                       </div>
                     </div>
 
+                    {/* Create in GIF Maker + Select from Flyers */}
+                    <div className="flex items-center gap-2 pt-1">
+                      <button
+                        onClick={() => {
+                          const matchedProfile = influencerProfiles?.find(
+                            (p) => p.name.toLowerCase() === model.toLowerCase()
+                          );
+                          const profileParam = matchedProfile ? `&profileId=${matchedProfile.id}` : '';
+                          window.open(
+                            `/${params.tenant}/workspace/gif-maker?boardItemId=${task.id}${profileParam}`,
+                            '_blank'
+                          );
+                        }}
+                        className="flex-1 flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-lg text-[10px] font-semibold text-brand-blue bg-brand-blue/10 border border-brand-blue/20 hover:bg-brand-blue/20 transition-colors"
+                      >
+                        <Film className="w-3 h-3" />
+                        Create in GIF Maker
+                      </button>
+                      <button
+                        onClick={() => {
+                          setFlyerPickerTarget('gifUrl');
+                          setShowFlyerPicker(true);
+                        }}
+                        className="flex-1 flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-lg text-[10px] font-semibold text-brand-light-pink bg-brand-light-pink/10 border border-brand-light-pink/20 hover:bg-brand-light-pink/20 transition-colors"
+                      >
+                        <ImageIcon className="w-3 h-3" />
+                        Select from Flyers
+                      </button>
+                    </div>
+
                     {/* GIF URLs — show per platform */}
                     <div className="pt-2 border-t border-white/[0.04]">
                       <SideLabel>GIF URL{platforms.length > 1 ? 's' : ''}</SideLabel>
@@ -1351,7 +1384,10 @@ export function OtpPtrTaskDetailModal({
                         <div>
                           <EditableField value={gifUrl} placeholder="https://..." onSave={(v) => updateMeta({ gifUrl: v })} />
                           {gifUrl && (
-                            <a href={gifUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-brand-blue hover:underline mt-0.5 inline-block">Open</a>
+                            <div className="flex items-center gap-2 mt-1">
+                              <a href={gifUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-brand-blue hover:underline">Open</a>
+                              <img src={gifUrl} alt="Flyer preview" className="w-12 h-12 rounded object-cover border border-zinc-700/50" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+                            </div>
                           )}
                         </div>
                       ) : (
@@ -1360,14 +1396,20 @@ export function OtpPtrTaskDetailModal({
                             <span className="text-[10px] font-medium text-brand-blue">OnlyFans</span>
                             <EditableField value={gifUrl} placeholder="OF GIF URL..." onSave={(v) => updateMeta({ gifUrl: v })} />
                             {gifUrl && (
-                              <a href={gifUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-brand-blue hover:underline mt-0.5 inline-block">Open</a>
+                              <div className="flex items-center gap-2 mt-1">
+                                <a href={gifUrl} target="_blank" rel="noopener noreferrer" className="text-xs text-brand-blue hover:underline">Open</a>
+                                <img src={gifUrl} alt="OF flyer" className="w-12 h-12 rounded object-cover border border-zinc-700/50" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+                              </div>
                             )}
                           </div>
                           <div>
                             <span className="text-[10px] font-medium text-brand-light-pink">Fansly</span>
                             <EditableField value={gifUrlFansly} placeholder="Fansly GIF URL..." onSave={(v) => updateMeta({ gifUrlFansly: v })} />
                             {gifUrlFansly && (
-                              <a href={gifUrlFansly} target="_blank" rel="noopener noreferrer" className="text-xs text-brand-blue hover:underline mt-0.5 inline-block">Open</a>
+                              <div className="flex items-center gap-2 mt-1">
+                                <a href={gifUrlFansly} target="_blank" rel="noopener noreferrer" className="text-xs text-brand-blue hover:underline">Open</a>
+                                <img src={gifUrlFansly} alt="Fansly flyer" className="w-12 h-12 rounded object-cover border border-zinc-700/50" onError={(e) => { (e.target as HTMLImageElement).style.display = 'none'; }} />
+                              </div>
                             )}
                           </div>
                         </div>
@@ -1375,6 +1417,25 @@ export function OtpPtrTaskDetailModal({
                     </div>
                   </div>
                 </Section>
+
+                {/* Flyer Picker Modal */}
+                {showFlyerPicker && createPortal(
+                  <FlyerPicker
+                    profileId={influencerProfiles?.find((p) => p.name.toLowerCase() === model.toLowerCase())?.id ?? null}
+                    onSelect={(url) => {
+                      updateMeta({ [flyerPickerTarget]: url });
+                      setShowFlyerPicker(false);
+                    }}
+                    onDelete={(deletedUrl) => {
+                      const updates: Record<string, string> = {};
+                      if (gifUrl === deletedUrl) updates.gifUrl = '';
+                      if (gifUrlFansly === deletedUrl) updates.gifUrlFansly = '';
+                      if (Object.keys(updates).length > 0) updateMeta(updates);
+                    }}
+                    onClose={() => setShowFlyerPicker(false)}
+                  />,
+                  document.body
+                )}
 
                 {/* PPV/Bundle Details */}
                 {(postOrigin === 'PPV') && (

--- a/app/api/flyer-assets/[id]/route.ts
+++ b/app/api/flyer-assets/[id]/route.ts
@@ -14,6 +14,14 @@ const s3Client = new S3Client({
 const BUCKET_NAME =
   process.env.AWS_S3_BUCKET || process.env.S3_BUCKET || 'tastycreative';
 
+async function getUserOrg(userId: string) {
+  const user = await prisma.user.findUnique({
+    where: { clerkId: userId },
+    select: { currentOrganizationId: true },
+  });
+  return user?.currentOrganizationId ?? null;
+}
+
 // GET /api/flyer-assets/[id] — Get a single flyer asset
 export async function GET(
   _request: NextRequest,
@@ -25,10 +33,15 @@ export async function GET(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
+    const orgId = await getUserOrg(userId);
+    if (!orgId) {
+      return NextResponse.json({ error: 'No active organization' }, { status: 400 });
+    }
+
     const { id } = await params;
 
-    const asset = await prisma.flyerAsset.findUnique({
-      where: { id },
+    const asset = await prisma.flyerAsset.findFirst({
+      where: { id, organizationId: orgId },
     });
 
     if (!asset) {
@@ -59,10 +72,15 @@ export async function DELETE(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
+    const orgId = await getUserOrg(userId);
+    if (!orgId) {
+      return NextResponse.json({ error: 'No active organization' }, { status: 400 });
+    }
+
     const { id } = await params;
 
-    const asset = await prisma.flyerAsset.findUnique({
-      where: { id },
+    const asset = await prisma.flyerAsset.findFirst({
+      where: { id, organizationId: orgId },
     });
 
     if (!asset) {
@@ -82,7 +100,6 @@ export async function DELETE(
       );
     } catch (s3Error) {
       console.error('Failed to delete S3 object:', s3Error);
-      // Continue with DB deletion even if S3 fails
     }
 
     // Delete from database

--- a/app/api/flyer-assets/upload/route.ts
+++ b/app/api/flyer-assets/upload/route.ts
@@ -39,6 +39,24 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Validate file type
+    const ALLOWED_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp'];
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      return NextResponse.json(
+        { error: 'Invalid file type. Allowed: PNG, JPEG, GIF, WebP' },
+        { status: 400 }
+      );
+    }
+
+    // Validate file size (max 100MB)
+    const MAX_FILE_SIZE = 100 * 1024 * 1024;
+    if (file.size > MAX_FILE_SIZE) {
+      return NextResponse.json(
+        { error: 'File too large (max 100MB)' },
+        { status: 413 }
+      );
+    }
+
     // Get user's current org
     const user = await prisma.user.findUnique({
       where: { clerkId: userId },

--- a/components/gif-maker-workspace/FlyerPicker.tsx
+++ b/components/gif-maker-workspace/FlyerPicker.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState } from "react";
+import { useFlyerAssets, useDeleteFlyerAsset, type FlyerAsset } from "@/lib/hooks/useFlyerAssets.query";
+import { Loader2, Trash2, X, Image as ImageIcon } from "lucide-react";
+
+interface FlyerPickerProps {
+  profileId: string | null;
+  onSelect: (url: string) => void;
+  onDelete?: (deletedUrl: string) => void;
+  onClose: () => void;
+}
+
+export function FlyerPicker({ profileId, onSelect, onDelete, onClose }: FlyerPickerProps) {
+  const { data: assets, isLoading } = useFlyerAssets(profileId);
+  const deleteMutation = useDeleteFlyerAsset();
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const handleDelete = async (e: React.MouseEvent, asset: FlyerAsset) => {
+    e.stopPropagation();
+    if (!profileId) return;
+    setDeletingId(asset.id);
+    try {
+      await deleteMutation.mutateAsync({ assetId: asset.id, profileId });
+      onDelete?.(asset.url);
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-[9999] flex items-center justify-center" onClick={onClose}>
+      <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
+      <div
+        className="relative bg-zinc-900 border border-zinc-700/50 rounded-2xl shadow-2xl w-[480px] max-h-[500px] flex flex-col overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-800/50">
+          <div className="flex items-center gap-2">
+            <ImageIcon className="w-4 h-4 text-brand-blue" />
+            <span className="text-sm font-semibold text-zinc-100">Select Flyer</span>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1 rounded-lg hover:bg-zinc-800 text-zinc-400 hover:text-zinc-200 transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto p-3">
+          {!profileId ? (
+            <div className="flex flex-col items-center justify-center py-12 text-center">
+              <ImageIcon className="w-8 h-8 text-zinc-700 mb-2" />
+              <p className="text-xs text-zinc-500">No model selected</p>
+            </div>
+          ) : isLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="w-5 h-5 text-brand-blue animate-spin" />
+            </div>
+          ) : !assets || assets.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-12 text-center">
+              <ImageIcon className="w-8 h-8 text-zinc-700 mb-2" />
+              <p className="text-xs text-zinc-500">No flyers created yet</p>
+              <p className="text-[10px] text-zinc-600 mt-1">
+                Create flyers in the GIF Maker Workspace
+              </p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-3 gap-2">
+              {assets.map((asset) => (
+                <div
+                  key={asset.id}
+                  onClick={() => onSelect(asset.url)}
+                  className="relative group cursor-pointer rounded-xl overflow-hidden border border-zinc-800/50 hover:border-brand-blue/40 transition-all aspect-square bg-zinc-800/40"
+                >
+                  <img
+                    src={asset.url}
+                    alt={asset.fileName}
+                    className="w-full h-full object-cover"
+                  />
+                  {/* Hover overlay */}
+                  <div className="absolute inset-0 bg-black/0 group-hover:bg-black/40 transition-colors flex items-center justify-center">
+                    <span className="text-xs font-medium text-white opacity-0 group-hover:opacity-100 transition-opacity">
+                      Select
+                    </span>
+                  </div>
+                  {/* Delete button */}
+                  <button
+                    onClick={(e) => handleDelete(e, asset)}
+                    disabled={deletingId === asset.id}
+                    className="absolute top-1 right-1 p-1 rounded-md bg-black/60 text-zinc-400 hover:text-red-400 hover:bg-black/80 opacity-0 group-hover:opacity-100 transition-all"
+                  >
+                    {deletingId === asset.id ? (
+                      <Loader2 className="w-3 h-3 animate-spin" />
+                    ) : (
+                      <Trash2 className="w-3 h-3" />
+                    )}
+                  </button>
+                  {/* File type badge */}
+                  <div className="absolute bottom-1 left-1 px-1.5 py-0.5 rounded bg-black/60 text-[9px] font-semibold text-zinc-300 uppercase">
+                    {asset.fileType}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/gif-maker-workspace/GifMakerWorkspace.tsx
+++ b/components/gif-maker-workspace/GifMakerWorkspace.tsx
@@ -60,6 +60,8 @@ export function GifMakerWorkspace() {
     }))
   );
   const setCurrentFrame = useVideoEditorStore((s) => s.setCurrentFrame);
+  const setWorkspaceMode = useVideoEditorStore((s) => s.setWorkspaceMode);
+  const clearWorkspaceMode = useVideoEditorStore((s) => s.clearWorkspaceMode);
 
   // Auto-select profile from URL params
   useEffect(() => {
@@ -68,6 +70,20 @@ export function GifMakerWorkspace() {
       if (profile) setSelectedProfile(profile);
     }
   }, [initialProfileId, profiles, selectedProfile]);
+
+  // Sync workspace mode with store
+  useEffect(() => {
+    if (selectedProfile) {
+      setWorkspaceMode(selectedProfile.id, boardItemId);
+    } else {
+      clearWorkspaceMode();
+    }
+  }, [selectedProfile, boardItemId, setWorkspaceMode, clearWorkspaceMode]);
+
+  // Clean up workspace mode on unmount
+  useEffect(() => {
+    return () => clearWorkspaceMode();
+  }, [clearWorkspaceMode]);
 
   const handleFrameChange = useCallback(
     (frame: number) => {

--- a/components/gif-maker/EditorToolbar.tsx
+++ b/components/gif-maker/EditorToolbar.tsx
@@ -195,14 +195,68 @@ export function EditorToolbar({ playerRef }: EditorToolbarProps) {
         .toISOString()
         .replace(/[:.]/g, "-")
         .slice(0, 19);
-      downloadBlob(gifBlob, `editor-${timestamp}.gif`);
 
-      setExportState({
-        isExporting: false,
-        progress: 100,
-        phase: "done",
-        message: `Exported! (${(gifBlob.size / 1024 / 1024).toFixed(2)} MB)`,
-      });
+      // Check workspace mode — upload to S3 if active
+      const store = useVideoEditorStore.getState();
+      if (store.workspaceMode && store.workspaceProfileId) {
+        setExportState({
+          progress: 95,
+          phase: "encoding",
+          message: "Uploading to flyer library...",
+        });
+
+        try {
+          const formData = new FormData();
+          formData.append("file", new File([gifBlob], `flyer-${timestamp}.gif`, { type: "image/gif" }));
+          formData.append("profileId", store.workspaceProfileId);
+          if (store.workspaceBoardItemId) {
+            formData.append("boardItemId", store.workspaceBoardItemId);
+          }
+
+          const uploadRes = await fetch("/api/flyer-assets/upload", {
+            method: "POST",
+            body: formData,
+          });
+
+          if (uploadRes.ok) {
+            const { asset } = await uploadRes.json();
+            // Copy URL to clipboard
+            await navigator.clipboard.writeText(asset.url).catch(() => {});
+            setExportState({
+              isExporting: false,
+              progress: 100,
+              phase: "done",
+              message: `Saved to flyer library! URL copied. (${(gifBlob.size / 1024 / 1024).toFixed(2)} MB)`,
+            });
+          } else {
+            // Upload failed — fall back to download
+            downloadBlob(gifBlob, `flyer-${timestamp}.gif`);
+            setExportState({
+              isExporting: false,
+              progress: 100,
+              phase: "done",
+              message: `Upload failed — downloaded instead. (${(gifBlob.size / 1024 / 1024).toFixed(2)} MB)`,
+            });
+          }
+        } catch {
+          // Upload error — fall back to download
+          downloadBlob(gifBlob, `flyer-${timestamp}.gif`);
+          setExportState({
+            isExporting: false,
+            progress: 100,
+            phase: "done",
+            message: `Upload error — downloaded instead. (${(gifBlob.size / 1024 / 1024).toFixed(2)} MB)`,
+          });
+        }
+      } else {
+        downloadBlob(gifBlob, `editor-${timestamp}.gif`);
+        setExportState({
+          isExporting: false,
+          progress: 100,
+          phase: "done",
+          message: `Exported! (${(gifBlob.size / 1024 / 1024).toFixed(2)} MB)`,
+        });
+      }
 
       player.seekToFrame(0);
     } catch (error) {

--- a/components/gif-maker/ExportImageButton.tsx
+++ b/components/gif-maker/ExportImageButton.tsx
@@ -7,6 +7,7 @@ import {
   useRef,
   useEffect,
 } from "react";
+import { createPortal } from "react-dom";
 import {
   ImageDown,
   ChevronDown,
@@ -83,6 +84,7 @@ export function ExportImageButton({ playerRef }: ExportImageButtonProps) {
   const [quality, setQuality] = useState<ExportQuality>("max");
   const [isCapturing, setIsCapturing] = useState(false);
   const [justDone, setJustDone] = useState(false);
+  const [doneMessage, setDoneMessage] = useState<string | null>(null);
 
   const popoverRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLDivElement>(null);
@@ -124,7 +126,7 @@ export function ExportImageButton({ playerRef }: ExportImageButtonProps) {
           const ctx = outCanvas.getContext("2d");
           ctx?.drawImage(rawCanvas, 0, 0, settings.width, settings.height);
         } else {
-          // Fallback: html2canvas for image/collage compositions
+          // Fallback: try html2canvas, but catch errors from unsupported CSS (lab(), oklch())
           const container = player.getContainerElement();
           if (container) {
             const containerRect = container.getBoundingClientRect();
@@ -132,18 +134,35 @@ export function ExportImageButton({ playerRef }: ExportImageButtonProps) {
               containerRect.width > 0
                 ? settings.width / containerRect.width
                 : 1;
-            const captured = await html2canvas(container, {
-              scale,
-              useCORS: true,
-              allowTaint: true,
-              backgroundColor: "#000000",
-              logging: false,
-            });
-            outCanvas = document.createElement("canvas");
-            outCanvas.width = settings.width;
-            outCanvas.height = settings.height;
-            const ctx = outCanvas.getContext("2d");
-            ctx?.drawImage(captured, 0, 0, settings.width, settings.height);
+            try {
+              const captured = await html2canvas(container, {
+                scale,
+                useCORS: true,
+                allowTaint: true,
+                backgroundColor: "#000000",
+                logging: false,
+              });
+              outCanvas = document.createElement("canvas");
+              outCanvas.width = settings.width;
+              outCanvas.height = settings.height;
+              const ctx = outCanvas.getContext("2d");
+              ctx?.drawImage(captured, 0, 0, settings.width, settings.height);
+            } catch {
+              // html2canvas failed (e.g. unsupported CSS color functions like lab())
+              // Manual fallback: draw video/image elements directly from the container
+              outCanvas = document.createElement("canvas");
+              outCanvas.width = settings.width;
+              outCanvas.height = settings.height;
+              const ctx = outCanvas.getContext("2d");
+              if (ctx) {
+                ctx.fillStyle = "#000000";
+                ctx.fillRect(0, 0, settings.width, settings.height);
+                const mediaEl = container.querySelector("video, img") as HTMLVideoElement | HTMLImageElement | null;
+                if (mediaEl) {
+                  ctx.drawImage(mediaEl, 0, 0, settings.width, settings.height);
+                }
+              }
+            }
           }
         }
 
@@ -156,24 +175,71 @@ export function ExportImageButton({ playerRef }: ExportImageButtonProps) {
         const qualityValue =
           QUALITY_OPTIONS.find((q) => q.id === quality)?.value ?? 0.95;
 
-        if (fmt === "png") {
-          exportCanvasAsPng(outCanvas, `creative-${timestamp}.png`);
-        } else if (fmt === "jpeg") {
-          exportCanvasAsJpg(
-            outCanvas,
-            `creative-${timestamp}.jpg`,
-            qualityValue
-          );
-        } else {
-          exportCanvasAsWebP(
-            outCanvas,
-            `creative-${timestamp}.webp`,
-            qualityValue
-          );
-        }
+        // Check workspace mode — upload to S3 if active
+        const store = useVideoEditorStore.getState();
+        const downloadFallback = (canvas: HTMLCanvasElement) => {
+          if (fmt === "png") exportCanvasAsPng(canvas, `flyer-${timestamp}.png`);
+          else if (fmt === "jpeg") exportCanvasAsJpg(canvas, `flyer-${timestamp}.jpg`, qualityValue);
+          else exportCanvasAsWebP(canvas, `flyer-${timestamp}.webp`, qualityValue);
+          setJustDone(true);
+          setTimeout(() => setJustDone(false), 2000);
+        };
 
-        setJustDone(true);
-        setTimeout(() => setJustDone(false), 2000);
+        if (store.workspaceMode && store.workspaceProfileId) {
+          try {
+            const mimeType = fmt === "png" ? "image/png" : fmt === "jpeg" ? "image/jpeg" : "image/webp";
+            const ext = FORMATS[fmt].ext;
+            const blob = await new Promise<Blob>((resolve, reject) => {
+              outCanvas!.toBlob(
+                (b) => (b ? resolve(b) : reject(new Error("Canvas toBlob failed"))),
+                mimeType,
+                qualityValue
+              );
+            });
+
+            const formData = new FormData();
+            formData.append("file", new File([blob], `flyer-${timestamp}.${ext}`, { type: mimeType }));
+            formData.append("profileId", store.workspaceProfileId);
+            if (store.workspaceBoardItemId) {
+              formData.append("boardItemId", store.workspaceBoardItemId);
+            }
+
+            const uploadRes = await fetch("/api/flyer-assets/upload", {
+              method: "POST",
+              body: formData,
+            });
+
+            if (uploadRes.ok) {
+              const { asset } = await uploadRes.json();
+              await navigator.clipboard.writeText(asset.url).catch(() => {});
+              setJustDone(true);
+              setDoneMessage("Saved! URL copied");
+              setTimeout(() => { setJustDone(false); setDoneMessage(null); }, 3000);
+            } else {
+              downloadFallback(outCanvas!);
+            }
+          } catch {
+            downloadFallback(outCanvas!);
+          }
+        } else {
+          if (fmt === "png") {
+            exportCanvasAsPng(outCanvas, `creative-${timestamp}.png`);
+          } else if (fmt === "jpeg") {
+            exportCanvasAsJpg(
+              outCanvas,
+              `creative-${timestamp}.jpg`,
+              qualityValue
+            );
+          } else {
+            exportCanvasAsWebP(
+              outCanvas,
+              `creative-${timestamp}.webp`,
+              qualityValue
+            );
+          }
+          setJustDone(true);
+          setTimeout(() => setJustDone(false), 2000);
+        }
       } catch (error) {
         console.error("Image export error:", error);
       } finally {
@@ -214,7 +280,7 @@ export function ExportImageButton({ playerRef }: ExportImageButtonProps) {
             <ImageDown className="h-3.5 w-3.5" />
           )}
           <span className="font-semibold tracking-wide text-[11px]">
-            {justDone ? "Saved!" : currentFormat.label}
+            {justDone ? (doneMessage ?? "Saved!") : currentFormat.label}
           </span>
         </button>
 
@@ -241,12 +307,15 @@ export function ExportImageButton({ playerRef }: ExportImageButtonProps) {
         </button>
       </div>
 
-      {/* Popover */}
-      {isOpen && !disabled && (
+      {/* Popover — rendered via portal to avoid overflow clipping */}
+      {isOpen && !disabled && createPortal(
         <div
           ref={popoverRef}
-          className="absolute top-[calc(100%+6px)] right-0 w-[228px] bg-zinc-950/95 backdrop-blur-xl border border-zinc-800/80 rounded-2xl shadow-2xl shadow-black/60 overflow-hidden z-50"
+          className="fixed w-[228px] bg-zinc-950/95 backdrop-blur-xl border border-zinc-800/80 rounded-2xl shadow-2xl shadow-black/60 overflow-hidden"
           style={{
+            zIndex: 9999,
+            top: triggerRef.current ? triggerRef.current.getBoundingClientRect().bottom + 6 : 0,
+            left: triggerRef.current ? triggerRef.current.getBoundingClientRect().right - 228 : 0,
             animation: "popoverIn 0.15s cubic-bezier(0.16,1,0.3,1) forwards",
           }}
         >
@@ -362,7 +431,8 @@ export function ExportImageButton({ playerRef }: ExportImageButtonProps) {
               Export {currentFormat.label}
             </button>
           </div>
-        </div>
+        </div>,
+        document.body
       )}
 
       <style>{`

--- a/lib/hooks/useFlyerAssets.query.ts
+++ b/lib/hooks/useFlyerAssets.query.ts
@@ -90,7 +90,13 @@ export function useDeleteFlyerAsset() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (assetId: string) => {
+    mutationFn: async ({
+      assetId,
+      profileId,
+    }: {
+      assetId: string;
+      profileId: string;
+    }) => {
       const response = await fetch(`/api/flyer-assets/${assetId}`, {
         method: 'DELETE',
       });
@@ -101,9 +107,9 @@ export function useDeleteFlyerAsset() {
 
       return response.json();
     },
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({
-        queryKey: ['flyer-assets'],
+        queryKey: ['flyer-assets', variables.profileId],
       });
     },
   });

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1468,6 +1468,7 @@ model Organization {
   instagramProfiles             InstagramProfile[]
   marketplaceModels             MarketplaceModel[]
   notifications                 Notification[]
+  org_teams                     org_teams[]
   invites                       OrganizationInvite[]
   subscriptionPlan              SubscriptionPlan?             @relation(fields: [subscriptionPlanId], references: [id])
   trackerEntries                PageTrackerEntry[]
@@ -1486,20 +1487,21 @@ model Organization {
 }
 
 model TeamMember {
-  id               String       @id @default(cuid())
+  id               String             @id @default(cuid())
   userId           String
   organizationId   String
-  role             TeamRole     @default(MEMBER)
-  canInviteMembers Boolean      @default(false)
-  canManageBilling Boolean      @default(false)
-  canManageMembers Boolean      @default(false)
+  role             TeamRole           @default(MEMBER)
+  canInviteMembers Boolean            @default(false)
+  canManageBilling Boolean            @default(false)
+  canManageMembers Boolean            @default(false)
   lastActiveAt     DateTime?
   invitedBy        String?
-  joinedAt         DateTime     @default(now())
-  createdAt        DateTime     @default(now())
-  updatedAt        DateTime     @default(now()) @updatedAt
-  organization     Organization @relation(fields: [organizationId], references: [id], onDelete: Cascade)
-  user             User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+  joinedAt         DateTime           @default(now())
+  createdAt        DateTime           @default(now())
+  updatedAt        DateTime           @default(now()) @updatedAt
+  org_team_members org_team_members[]
+  organization     Organization       @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+  user             User               @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([userId, organizationId])
   @@index([organizationId])
@@ -2419,6 +2421,36 @@ model TrackerActivityLog {
   @@index([organizationId, createdAt(sort: Desc)])
   @@index([userId])
   @@map("tracker_activity_logs")
+}
+
+model org_team_members {
+  id           String     @id
+  teamId       String
+  teamMemberId String
+  assignedAt   DateTime   @default(now())
+  assignedBy   String?
+  org_teams    org_teams  @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  team_members TeamMember @relation(fields: [teamMemberId], references: [id], onDelete: Cascade)
+
+  @@unique([teamId, teamMemberId])
+  @@index([teamId])
+  @@index([teamMemberId])
+}
+
+model org_teams {
+  id               String             @id
+  organizationId   String
+  name             String
+  description      String?
+  color            String?
+  tabPermissions   Json               @default("{}")
+  createdAt        DateTime           @default(now())
+  updatedAt        DateTime
+  org_team_members org_team_members[]
+  organizations    Organization       @relation(fields: [organizationId], references: [id], onDelete: Cascade)
+
+  @@unique([organizationId, name])
+  @@index([organizationId])
 }
 
 enum SyncStatus {

--- a/stores/video-editor-store.ts
+++ b/stores/video-editor-store.ts
@@ -41,6 +41,13 @@ interface VideoEditorState {
   // Export
   exportState: ExportState;
 
+  // Workspace mode (GIF Maker Workspace)
+  workspaceMode: boolean;
+  workspaceProfileId: string | null;
+  workspaceBoardItemId: string | null;
+  setWorkspaceMode: (profileId: string | null, boardItemId?: string | null) => void;
+  clearWorkspaceMode: () => void;
+
   // ─── Clip Actions ──────────────────
   addClip: (clip: Omit<VideoClip, "startFrame"> | Omit<ImageClip, "startFrame">) => void;
   removeClip: (clipId: string) => void;
@@ -156,6 +163,15 @@ export const useVideoEditorStore = create<VideoEditorState>()((set, get) => ({
   selectedOverlayId: null,
   settings: DEFAULT_SETTINGS,
   exportState: DEFAULT_EXPORT_STATE,
+
+  // Workspace mode defaults
+  workspaceMode: false,
+  workspaceProfileId: null,
+  workspaceBoardItemId: null,
+  setWorkspaceMode: (profileId, boardItemId) =>
+    set({ workspaceMode: !!profileId, workspaceProfileId: profileId, workspaceBoardItemId: boardItemId ?? null }),
+  clearWorkspaceMode: () =>
+    set({ workspaceMode: false, workspaceProfileId: null, workspaceBoardItemId: null }),
 
   // ─── Clip Actions ──────────────────
 


### PR DESCRIPTION

- Add workspace export: GIF/image uploads save to FlyerAsset library with URL copied to clipboard
- Add board modal integration: "Create in GIF Maker" and "Select from Flyers" buttons in Flyer Team section
- Add FlyerPicker modal with grid view, delete support, and auto-clear of matching board URLs on delete
- Add GIF Maker Workspace to sidebar under Content Ops
- Add org-scoped auth checks on flyer asset GET/DELETE routes
- Add file type validation (PNG/JPEG/GIF/WebP) and 100MB size limit on upload
- Fix ExportImageButton dropdown clipping via portal rendering
- Fix html2canvas crash on Tailwind v4 lab() colors with canvas fallback