### PR TITLE
feat: add task queue system to GIF Maker Workspace

### DIFF
--- a/components/gif-maker-workspace/GifMakerWorkspace.tsx
+++ b/components/gif-maker-workspace/GifMakerWorkspace.tsx
@@ -1,17 +1,20 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState, lazy, Suspense } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, lazy, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import { useVideoEditorStore } from "@/stores/video-editor-store";
 import { useShallow } from "zustand/react/shallow";
 import { useInstagramProfiles, type InstagramProfile } from "@/lib/hooks/useInstagramProfiles.query";
+import { useInstagramProfile } from "@/lib/hooks/useInstagramProfile.query";
+import { useGifQueue, type GifQueueTicket } from "@/lib/hooks/useGifQueue.query";
 import { EditorToolbar } from "@/components/gif-maker/EditorToolbar";
 import { EditorPreview } from "@/components/gif-maker/EditorPreview";
 import { OverlayPanel } from "@/components/gif-maker/panels/OverlayPanel";
 import { PropertiesPanel } from "@/components/gif-maker/panels/PropertiesPanel";
 import { Timeline } from "@/components/gif-maker/timeline/Timeline";
-import { ModelVaultBrowser } from "./ModelVaultBrowser";
 import { WorkspaceClipPanel } from "./WorkspaceClipPanel";
+import { QueueDrawer } from "./QueueDrawer";
+import { QueueRail } from "./QueueRail";
 import type { PreviewPlayerRef } from "@/components/gif-maker/PreviewPlayer";
 import {
   Film,
@@ -19,10 +22,6 @@ import {
   LayoutGrid,
   Sparkles,
   BookOpen,
-  Search,
-  User,
-  ChevronDown,
-  X,
 } from "lucide-react";
 
 const LayoutPicker = lazy(() =>
@@ -47,10 +46,11 @@ export function GifMakerWorkspace() {
   const boardItemId = searchParams.get("boardItemId");
 
   const [selectedProfile, setSelectedProfile] = useState<InstagramProfile | null>(null);
-  const { data: profiles, isLoading: loadingProfiles } = useInstagramProfiles();
+  const { data: profiles } = useInstagramProfiles();
 
   const playerRef = useRef<PreviewPlayerRef>(null);
 
+  // ─── Editor state ────────────────────────────────
   const { settings, clips, overlays, totalDurationInFrames } = useVideoEditorStore(
     useShallow((s) => ({
       settings: s.settings,
@@ -63,6 +63,36 @@ export function GifMakerWorkspace() {
   const setWorkspaceMode = useVideoEditorStore((s) => s.setWorkspaceMode);
   const clearWorkspaceMode = useVideoEditorStore((s) => s.clearWorkspaceMode);
 
+  // ─── Queue state ─────────────────────────────────
+  const { queue, isLoading: loadingQueue, error: queueError, refetch: refetchQueue } = useGifQueue();
+  const {
+    activeTicketId,
+    setActiveTicket,
+    queueDrawerOpen,
+    setQueueDrawerOpen,
+  } = useVideoEditorStore(
+    useShallow((s) => ({
+      activeTicketId: s.activeTicketId,
+      setActiveTicket: s.setActiveTicket,
+      queueDrawerOpen: s.queueDrawerOpen,
+      setQueueDrawerOpen: s.setQueueDrawerOpen,
+    }))
+  );
+
+  const activeTicket = useMemo(
+    () => queue.find((t) => t.id === activeTicketId) ?? null,
+    [queue, activeTicketId]
+  );
+
+  const currentIndex = useMemo(
+    () => queue.findIndex((t) => t.id === activeTicketId),
+    [queue, activeTicketId]
+  );
+
+  // Fetch model context for context strip
+  const { data: modelContextProfile } = useInstagramProfile(activeTicket?.profileId);
+
+  // ─── Profile selection ───────────────────────────
   // Auto-select profile from URL params
   useEffect(() => {
     if (initialProfileId && profiles && !selectedProfile) {
@@ -71,20 +101,67 @@ export function GifMakerWorkspace() {
     }
   }, [initialProfileId, profiles, selectedProfile]);
 
+  // Auto-select profile from active ticket
+  useEffect(() => {
+    if (activeTicket?.profileId && profiles) {
+      const profile = profiles.find((p) => p.id === activeTicket.profileId);
+      if (profile) {
+        setSelectedProfile(profile);
+      } else {
+        console.warn(`Profile ${activeTicket.profileId} not found for ticket ${activeTicket.id}`);
+      }
+    }
+  }, [activeTicket, profiles]);
+
   // Sync workspace mode with store
   useEffect(() => {
     if (selectedProfile) {
-      setWorkspaceMode(selectedProfile.id, boardItemId);
+      setWorkspaceMode(selectedProfile.id, activeTicket?.boardItemId ?? boardItemId);
     } else {
       clearWorkspaceMode();
     }
-  }, [selectedProfile, boardItemId, setWorkspaceMode, clearWorkspaceMode]);
+  }, [selectedProfile, boardItemId, activeTicket?.boardItemId, setWorkspaceMode, clearWorkspaceMode]);
 
   // Clean up workspace mode on unmount
   useEffect(() => {
     return () => clearWorkspaceMode();
   }, [clearWorkspaceMode]);
 
+  // ─── Queue actions ───────────────────────────────
+  const handleStartEditing = useCallback(
+    (ticket: GifQueueTicket) => {
+      setActiveTicket(ticket.id);
+      setQueueDrawerOpen(false);
+      if (ticket.profileId) {
+        setWorkspaceMode(ticket.profileId, ticket.boardItemId);
+      }
+    },
+    [setActiveTicket, setQueueDrawerOpen, setWorkspaceMode]
+  );
+
+  const handleNextTask = useCallback(() => {
+    if (currentIndex < queue.length - 1) {
+      handleStartEditing(queue[currentIndex + 1]);
+    }
+  }, [currentIndex, queue, handleStartEditing]);
+
+  const handlePrevTask = useCallback(() => {
+    if (currentIndex > 0) {
+      handleStartEditing(queue[currentIndex - 1]);
+    }
+  }, [currentIndex, queue, handleStartEditing]);
+
+  // Watch for "Next Task" signal from export toast (via Zustand store)
+  const pendingNextTask = useVideoEditorStore((s) => s.pendingNextTask);
+  useEffect(() => {
+    if (pendingNextTask) {
+      useVideoEditorStore.getState().pendingNextTask = false;
+      useVideoEditorStore.setState({ pendingNextTask: false });
+      handleNextTask();
+    }
+  }, [pendingNextTask, handleNextTask]);
+
+  // ─── Playback ────────────────────────────────────
   const handleFrameChange = useCallback(
     (frame: number) => {
       setCurrentFrame(frame);
@@ -102,7 +179,7 @@ export function GifMakerWorkspace() {
     }
   }, []);
 
-  // Keyboard shortcuts
+  // ─── Keyboard shortcuts ──────────────────────────
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (
@@ -118,6 +195,14 @@ export function GifMakerWorkspace() {
       const frameFps = state.settings.fps;
 
       switch (e.code) {
+        case "Escape": {
+          const store = useVideoEditorStore.getState();
+          if (store.queueDrawerOpen) {
+            e.preventDefault();
+            store.setQueueDrawerOpen(false);
+          }
+          break;
+        }
         case "Space": {
           e.preventDefault();
           handleTogglePlayback();
@@ -220,23 +305,25 @@ export function GifMakerWorkspace() {
           <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] h-[800px] bg-indigo-600/3 rounded-full blur-[200px]" />
         </div>
 
-        {/* Model Selector Bar */}
-        <div className="relative z-20">
-          <ModelSelectorBar
-            profiles={profiles ?? []}
-            selectedProfile={selectedProfile}
-            onSelect={setSelectedProfile}
-            loading={loadingProfiles}
-          />
-        </div>
-
         {/* Top Toolbar */}
         <div className="relative z-10">
           <EditorToolbar playerRef={playerRef} />
         </div>
 
-        {/* Main Content Area */}
+        {/* Main Content Area — with rail + drawer */}
         <div className="flex flex-1 min-h-0 overflow-hidden relative z-10">
+          {/* Queue Rail — visible when a ticket is active and drawer is closed */}
+          {activeTicketId && !queueDrawerOpen && (
+            <QueueRail
+              onOpenDrawer={() => setQueueDrawerOpen(true)}
+              activeTicket={activeTicket}
+              queueLength={queue.length}
+              currentIndex={currentIndex}
+              onPrevTask={handlePrevTask}
+              onNextTask={handleNextTask}
+            />
+          )}
+
           {/* Left Panel */}
           <div className="w-60 min-w-[240px] flex flex-col bg-zinc-900/40 backdrop-blur-xl border-r border-zinc-800/50">
             <WorkspaceLeftPanelTabs selectedProfileId={selectedProfile?.id ?? null} />
@@ -253,11 +340,21 @@ export function GifMakerWorkspace() {
             />
           </div>
 
-          {/* Right Panel: Properties Inspector */}
+          {/* Right Panel: Properties with Context Strip */}
           <div className="w-72 min-w-[280px] bg-zinc-900/40 backdrop-blur-xl border-l border-zinc-800/50 overflow-y-auto">
-            <PropertiesPanel />
+            <PropertiesPanel activeTicket={activeTicket} modelContext={modelContextProfile} />
           </div>
         </div>
+
+        {/* Queue Drawer — overlays the full content area */}
+        <QueueDrawer
+          isOpen={queueDrawerOpen}
+          onClose={() => setQueueDrawerOpen(false)}
+          queue={queue}
+          selectedTicketId={activeTicketId}
+          onSelectTicket={setActiveTicket}
+          onStartEditing={handleStartEditing}
+        />
 
         {/* Resize handle */}
         <div className="h-1 w-full cursor-row-resize group flex-shrink-0 bg-[#0a0a0b] relative z-10">
@@ -277,17 +374,15 @@ export function GifMakerWorkspace() {
               <span>System Ready</span>
             </div>
             <div className="h-3 w-px bg-zinc-800" />
-            <span>GIF Maker Workspace v1.0</span>
-            {selectedProfile && (
+            <span>GIF Maker Workspace v2.0</span>
+            {activeTicket && (
               <>
                 <div className="h-3 w-px bg-zinc-800" />
-                <span className="text-brand-light-pink">{selectedProfile.name}</span>
-              </>
-            )}
-            {boardItemId && (
-              <>
+                <span className="text-brand-light-pink">{activeTicket.modelName}</span>
                 <div className="h-3 w-px bg-zinc-800" />
-                <span className="text-brand-blue">Board Item Linked</span>
+                <span className="text-brand-blue">
+                  Task {currentIndex + 1} of {queue.length}
+                </span>
               </>
             )}
           </div>
@@ -300,183 +395,6 @@ export function GifMakerWorkspace() {
         </footer>
       </div>
     </>
-  );
-}
-
-// ─── Model Selector Bar ─────────────────────────────────
-
-function ModelSelectorBar({
-  profiles,
-  selectedProfile,
-  onSelect,
-  loading,
-}: {
-  profiles: InstagramProfile[];
-  selectedProfile: InstagramProfile | null;
-  onSelect: (profile: InstagramProfile | null) => void;
-  loading: boolean;
-}) {
-  const [open, setOpen] = useState(false);
-  const [search, setSearch] = useState("");
-  const dropdownRef = useRef<HTMLDivElement>(null);
-
-  const filtered = profiles.filter(
-    (p) =>
-      p.name.toLowerCase().includes(search.toLowerCase()) ||
-      (p.username && p.username.toLowerCase().includes(search.toLowerCase()))
-  );
-
-  // Close on outside click
-  useEffect(() => {
-    const handleClick = (e: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    };
-    if (open) document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [open]);
-
-  return (
-    <div className="h-12 bg-zinc-900/60 backdrop-blur-xl border-b border-zinc-800/50 px-4 flex items-center gap-3">
-      {/* Label */}
-      <div className="flex items-center gap-2 text-xs text-zinc-400 flex-shrink-0">
-        <User className="w-4 h-4" />
-        <span className="font-medium">Model:</span>
-      </div>
-
-      {/* Selector */}
-      <div className="relative" ref={dropdownRef}>
-        <div
-          role="button"
-          tabIndex={0}
-          onClick={() => setOpen(!open)}
-          onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setOpen(!open); } }}
-          className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-zinc-800/60 border border-zinc-700/50 hover:border-zinc-600/50 transition-colors min-w-[200px] cursor-pointer"
-        >
-          {selectedProfile ? (
-            <>
-              {selectedProfile.profileImageUrl ? (
-                <img
-                  src={selectedProfile.profileImageUrl}
-                  alt={selectedProfile.name}
-                  className="w-5 h-5 rounded-full object-cover flex-shrink-0"
-                />
-              ) : (
-                <div className="w-5 h-5 rounded-full bg-gradient-to-br from-brand-light-pink to-brand-dark-pink flex items-center justify-center flex-shrink-0">
-                  <span className="text-[10px] font-medium text-white">
-                    {selectedProfile.name.charAt(0)}
-                  </span>
-                </div>
-              )}
-              <span className="text-xs font-medium text-zinc-100 truncate flex-1">
-                {selectedProfile.name}
-              </span>
-              <div className="flex items-center gap-1 flex-shrink-0">
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    onSelect(null);
-                    setOpen(false);
-                  }}
-                  className="p-1 rounded-md hover:bg-red-500/15 text-zinc-500 hover:text-red-400 transition-colors"
-                >
-                  <X className="w-3 h-3" />
-                </button>
-                <ChevronDown
-                  className={`w-3.5 h-3.5 text-zinc-400 transition-transform ${open ? "rotate-180" : ""}`}
-                />
-              </div>
-            </>
-          ) : (
-            <>
-              <span className="text-xs text-zinc-500 flex-1">
-                {loading ? "Loading..." : "Select a model..."}
-              </span>
-              <ChevronDown
-                className={`w-3.5 h-3.5 text-zinc-400 flex-shrink-0 transition-transform ${open ? "rotate-180" : ""}`}
-              />
-            </>
-          )}
-        </div>
-
-        {/* Dropdown */}
-        {open && (
-          <div className="absolute top-full left-0 mt-1 w-[300px] bg-zinc-900 border border-zinc-700/50 rounded-xl shadow-2xl overflow-hidden z-50">
-            {/* Search */}
-            <div className="p-2 border-b border-zinc-800/50">
-              <div className="relative">
-                <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-zinc-500" />
-                <input
-                  type="text"
-                  value={search}
-                  onChange={(e) => setSearch(e.target.value)}
-                  placeholder="Search models..."
-                  className="w-full pl-8 pr-3 py-1.5 bg-zinc-800/60 border border-zinc-700/30 rounded-lg text-xs text-zinc-100 placeholder-zinc-500 outline-none focus:border-brand-light-pink/50"
-                  autoFocus
-                />
-              </div>
-            </div>
-
-            {/* List */}
-            <div className="max-h-[300px] overflow-y-auto py-1">
-              {filtered.length === 0 ? (
-                <div className="px-4 py-6 text-center text-xs text-zinc-500">
-                  No models found
-                </div>
-              ) : (
-                filtered.map((profile) => (
-                  <button
-                    key={profile.id}
-                    onClick={() => {
-                      onSelect(profile);
-                      setOpen(false);
-                      setSearch("");
-                    }}
-                    className={`w-full flex items-center gap-2.5 px-3 py-2 hover:bg-zinc-800/60 transition-colors ${
-                      selectedProfile?.id === profile.id ? "bg-brand-light-pink/10" : ""
-                    }`}
-                  >
-                    {profile.profileImageUrl ? (
-                      <img
-                        src={profile.profileImageUrl}
-                        alt={profile.name}
-                        className="w-6 h-6 rounded-full object-cover flex-shrink-0"
-                      />
-                    ) : (
-                      <div className="w-6 h-6 rounded-full bg-gradient-to-br from-brand-light-pink to-brand-dark-pink flex items-center justify-center flex-shrink-0">
-                        <span className="text-[10px] font-medium text-white">
-                          {profile.name.charAt(0)}
-                        </span>
-                      </div>
-                    )}
-                    <div className="flex-1 min-w-0 text-left">
-                      <div className="text-xs font-medium text-zinc-100 truncate">
-                        {profile.name}
-                      </div>
-                      {profile.username && (
-                        <div className="text-[10px] text-zinc-500">@{profile.username}</div>
-                      )}
-                    </div>
-                    {selectedProfile?.id === profile.id && (
-                      <span className="w-1.5 h-1.5 rounded-full bg-brand-light-pink flex-shrink-0" />
-                    )}
-                  </button>
-                ))
-              )}
-            </div>
-          </div>
-        )}
-      </div>
-
-      {/* Board item indicator */}
-      {useSearchParams().get("boardItemId") && (
-        <div className="flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-brand-blue/10 border border-brand-blue/20">
-          <span className="w-1.5 h-1.5 rounded-full bg-brand-blue" />
-          <span className="text-[10px] font-medium text-brand-blue">From Board</span>
-        </div>
-      )}
-    </div>
   );
 }
 

--- a/components/gif-maker-workspace/QueueDrawer.tsx
+++ b/components/gif-maker-workspace/QueueDrawer.tsx
@@ -1,0 +1,409 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import { X, Play, FileVideo, FileImage, AlertCircle, X as XIcon, ShieldAlert } from 'lucide-react';
+import { QueuePanel } from './QueuePanel';
+import type { GifQueueTicket } from '@/lib/hooks/useGifQueue.query';
+import { useInstagramProfile } from '@/lib/hooks/useInstagramProfile.query';
+import { urgencyConfig, safeUrgency } from './queue-constants';
+
+interface QueueDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  queue: GifQueueTicket[];
+  selectedTicketId: string | null;
+  onSelectTicket: (ticketId: string) => void;
+  onStartEditing: (ticket: GifQueueTicket) => void;
+}
+
+export function QueueDrawer({
+  isOpen,
+  onClose,
+  queue,
+  selectedTicketId,
+  onSelectTicket,
+  onStartEditing,
+}: QueueDrawerProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const selectedTicket = useMemo(
+    () => queue.find((t) => t.id === selectedTicketId) ?? null,
+    [queue, selectedTicketId]
+  );
+
+  // Filter queue for the QueuePanel (single filter, not double)
+  const filteredQueue = useMemo(() => {
+    if (!searchQuery) return queue;
+    const q = searchQuery.toLowerCase();
+    return queue.filter(
+      (t) =>
+        t.modelName.toLowerCase().includes(q) ||
+        t.description.toLowerCase().includes(q) ||
+        t.id.toLowerCase().includes(q)
+    );
+  }, [queue, searchQuery]);
+
+  const { data: modelContext, isLoading: loadingContext, error: contextError } = useInstagramProfile(selectedTicket?.profileId);
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        role="presentation"
+        className={`fixed inset-0 z-40 bg-black/30 backdrop-blur-[2px] transition-opacity duration-250 ${
+          isOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'
+        }`}
+        onClick={onClose}
+      />
+
+      {/* Drawer */}
+      <div
+        className={`fixed inset-0 z-50 flex flex-col transition-transform duration-250 ease-[cubic-bezier(0.4,0,0.2,1)] ${
+          isOpen ? 'translate-x-0' : '-translate-x-full'
+        }`}
+      >
+        {/* Container with rounded corners and brand borders */}
+        <div className="m-4 flex flex-col flex-1 min-h-0 border border-brand-mid-pink/20 rounded-2xl shadow-lg overflow-hidden bg-white dark:bg-gray-900/90 backdrop-blur-xl">
+          {/* Header — matches Caption Workspace header exactly */}
+          <div className="flex items-center justify-between h-[60px] px-4 lg:px-6 border-b border-brand-mid-pink/20 bg-white/90 dark:bg-gray-900/90 backdrop-blur-xl shrink-0 rounded-t-2xl">
+            <div className="flex items-center gap-3">
+              <div className="w-9 h-9 lg:w-10 lg:h-10 rounded-xl bg-linear-to-br from-brand-mid-pink to-brand-light-pink shadow-lg shadow-brand-mid-pink/30 flex items-center justify-center">
+                <FileVideo className="w-4 h-4 lg:w-5 lg:h-5 text-white" />
+              </div>
+              <div>
+                <h2 className="text-base lg:text-lg font-semibold text-gray-900 dark:text-gray-100">GIF Maker Workspace</h2>
+                <p className="text-[10px] lg:text-xs text-gray-500 dark:text-gray-400">Create GIFs for tasks</p>
+              </div>
+              <span className="px-2 py-1 bg-brand-mid-pink/15 text-brand-mid-pink dark:text-brand-light-pink rounded text-[10px] lg:text-xs font-semibold">
+                {queue.length} in queue
+              </span>
+            </div>
+            <button
+              onClick={onClose}
+              className="p-1.5 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-800 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+            >
+              <X size={18} />
+            </button>
+          </div>
+
+          {/* 3-column layout — matches Caption Workspace grid */}
+          <div className="flex flex-1 min-h-0 overflow-hidden">
+            {/* Left: Queue List (280px) */}
+            <div className="w-[280px] border-r border-brand-mid-pink/20 shrink-0 overflow-hidden flex flex-col">
+              <QueuePanel
+                queue={filteredQueue}
+                selectedTicketId={selectedTicketId}
+                onSelectTicket={onSelectTicket}
+                searchQuery={searchQuery}
+                onSearchChange={setSearchQuery}
+              />
+            </div>
+
+            {/* Center: Content Preview + Start Editing (flex-1, vertical 50/50 split like Caption Workspace) */}
+            <div className="flex-1 flex flex-col min-w-0">
+              {selectedTicket ? (
+                <>
+                  {/* Workflow instruction bar */}
+                  <div className="px-4 py-2 bg-brand-blue/10 border-b border-brand-mid-pink/10 shrink-0">
+                    <p className="text-xs text-brand-blue font-medium">
+                      Create a GIF for this task, then export to flyer library.
+                    </p>
+                  </div>
+
+                  {/* Top half: Content media preview */}
+                  <div className="flex-1 basis-1/2 flex items-center justify-center overflow-hidden bg-brand-off-white dark:bg-gray-800 relative min-h-0">
+                    <ContentPreview ticket={selectedTicket} />
+                  </div>
+
+                  {/* Resizer divider — matches Caption Workspace style */}
+                  <div className="h-1.5 shrink-0 bg-brand-mid-pink/10 hover:bg-brand-mid-pink/20 transition-colors flex items-center justify-center">
+                    <div className="w-12 h-1 rounded-full bg-brand-mid-pink/40" />
+                  </div>
+
+                  {/* Bottom half: Caption + Start Editing */}
+                  <div className="flex-1 basis-1/2 flex flex-col min-h-0 bg-white dark:bg-gray-900/80">
+                    {/* Caption display */}
+                    <div className="flex-1 overflow-y-auto custom-scrollbar p-4">
+                      {selectedTicket.captionText ? (
+                        <div>
+                          <span className="text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide block mb-2">Caption</span>
+                          <p className="text-sm text-gray-900 dark:text-gray-100 leading-relaxed whitespace-pre-wrap">
+                            {selectedTicket.captionText}
+                          </p>
+                        </div>
+                      ) : (
+                        <div className="flex flex-col items-center justify-center h-full text-gray-400 dark:text-gray-500 gap-2">
+                          <FileImage size={24} />
+                          <p className="text-xs">No caption for this task</p>
+                        </div>
+                      )}
+                    </div>
+
+                    {/* Start Editing CTA — pinned at bottom of lower half */}
+                    <div className="shrink-0 p-4 border-t border-brand-mid-pink/10 flex gap-3">
+                      <button
+                        onClick={() => onStartEditing(selectedTicket)}
+                        className="flex-1 py-3 rounded-xl bg-gradient-to-r from-brand-light-pink to-brand-mid-pink text-white text-sm font-semibold hover:opacity-90 transition-opacity flex items-center justify-center gap-2 shadow-lg shadow-brand-mid-pink/20"
+                      >
+                        <Play size={16} />
+                        Start Editing
+                      </button>
+                    </div>
+                  </div>
+                </>
+              ) : (
+                <div className="flex-1 flex flex-col items-center justify-center text-gray-400 dark:text-gray-500 gap-3 bg-brand-off-white dark:bg-gray-800">
+                  <Play size={32} />
+                  <p className="text-sm">Select a task to preview</p>
+                </div>
+              )}
+            </div>
+
+            {/* Right: Model Context (320px) — matches Caption Workspace ContextPanel */}
+            <div className="w-[320px] border-l border-brand-mid-pink/20 shrink-0 overflow-hidden flex flex-col bg-white dark:bg-gray-900/80">
+              {/* Tabs */}
+              <div className="flex border-b border-brand-mid-pink/20 shrink-0">
+                <div className="flex-1 py-3 text-xs font-semibold text-center border-b-2 border-brand-mid-pink bg-brand-off-white dark:bg-gray-800 text-gray-900 dark:text-gray-100">
+                  Model Context
+                </div>
+              </div>
+
+              {/* Context content */}
+              <div className="flex-1 overflow-y-auto custom-scrollbar">
+                {selectedTicket ? (
+                  loadingContext ? (
+                    <div className="flex items-center justify-center h-full text-gray-400 dark:text-gray-500 text-xs">
+                      Loading model context...
+                    </div>
+                  ) : contextError ? (
+                    <div className="p-4 text-center text-red-500 text-xs">
+                      <AlertCircle size={20} className="mx-auto mb-2" />
+                      Failed to load model context
+                    </div>
+                  ) : modelContext ? (
+                    <ModelContextPanel profile={modelContext} />
+                  ) : null
+                ) : (
+                  <div className="flex items-center justify-center h-full text-gray-400 dark:text-gray-500 text-xs">
+                    Select a task to see model context
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ─── Content Preview ───────────────────────────────────────
+
+function ContentPreview({ ticket }: { ticket: GifQueueTicket }) {
+  const items = ticket.contentItems;
+
+  if (items.length === 0 && !ticket.contentUrl) {
+    return (
+      <div className="flex flex-col items-center gap-2 text-gray-400 dark:text-gray-500">
+        <FileImage size={40} />
+        <span className="text-xs">No content attached</span>
+      </div>
+    );
+  }
+
+  const previewUrl = items[0]?.url ?? ticket.contentUrl;
+  if (!previewUrl) return null;
+
+  const isGDrive =
+    previewUrl.includes('drive.google.com') || previewUrl.includes('googleusercontent.com');
+
+  if (isGDrive) {
+    const previewSrc = previewUrl.includes('/preview')
+      ? previewUrl
+      : previewUrl.replace(/\/view.*$/, '/preview');
+    return (
+      <div className="w-full max-w-xl aspect-video rounded-xl overflow-hidden border border-brand-mid-pink/10">
+        <iframe
+          src={previewSrc}
+          className="w-full h-full"
+          allow="autoplay"
+          sandbox="allow-scripts allow-same-origin"
+        />
+      </div>
+    );
+  }
+
+  const isVideo = /\.(mp4|webm|mov)(\?|$)/i.test(previewUrl);
+  if (isVideo) {
+    return (
+      <video
+        src={previewUrl}
+        controls
+        className="max-w-xl max-h-[50vh] rounded-xl border border-brand-mid-pink/10"
+      />
+    );
+  }
+
+  return (
+    <img
+      src={previewUrl}
+      alt="Content preview"
+      className="max-w-xl max-h-[50vh] rounded-xl object-contain border border-brand-mid-pink/10"
+    />
+  );
+}
+
+// ─── Model Context Panel (matches Caption Workspace ContextPanel) ─────
+
+function ModelContextPanel({
+  profile,
+}: {
+  profile: NonNullable<ReturnType<typeof useInstagramProfile>['data']>;
+}) {
+  const bible = profile.modelBible;
+  const restrictions = bible?.restrictions;
+
+  return (
+    <div className="p-4 overflow-auto custom-scrollbar">
+      {/* Profile header */}
+      <div className="flex items-center gap-3 mb-5 pb-4 border-b border-brand-mid-pink/20">
+        {profile.profileImageUrl ? (
+          <img
+            src={profile.profileImageUrl}
+            alt={profile.name}
+            className="w-12 h-12 rounded-xl object-cover shadow-lg shadow-brand-mid-pink/30"
+          />
+        ) : (
+          <div className="w-12 h-12 rounded-xl bg-linear-to-br from-brand-light-pink to-brand-blue flex items-center justify-center">
+            <span className="text-base font-semibold text-white">{profile.name.charAt(0)}</span>
+          </div>
+        )}
+        <div>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">{profile.name}</h3>
+          {profile.pageStrategy && (
+            <span className="mt-1 inline-block px-2 py-1 bg-brand-mid-pink/15 text-brand-mid-pink dark:text-brand-light-pink rounded text-[10px] font-semibold">
+              {profile.pageStrategy}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Personality */}
+      {bible?.personalityDescription && (
+        <div className="mb-5">
+          <span className="text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2 block">Personality</span>
+          <div className="p-3 bg-brand-off-white dark:bg-gray-800 rounded-xl text-sm leading-relaxed border border-brand-mid-pink/10 text-gray-700 dark:text-gray-300">
+            {bible.personalityDescription}
+          </div>
+        </div>
+      )}
+
+      {/* Background */}
+      {bible?.backstory && (
+        <div className="mb-5">
+          <span className="text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2 block">Background</span>
+          <div className="p-3 bg-brand-off-white dark:bg-gray-800 rounded-xl text-sm leading-relaxed border border-brand-mid-pink/10 text-gray-700 dark:text-gray-300">
+            {bible.backstory}
+          </div>
+        </div>
+      )}
+
+      {/* Lingo & Keywords */}
+      {bible?.lingoKeywords && bible.lingoKeywords.length > 0 && (
+        <div className="mb-5">
+          <span className="text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2 block">Lingo &amp; Keywords</span>
+          <div className="flex flex-wrap gap-2">
+            {bible.lingoKeywords.map((word) => (
+              <span
+                key={word}
+                className="px-2.5 py-1.5 bg-brand-off-white dark:bg-gray-800 hover:bg-brand-mid-pink/10 border border-brand-mid-pink/20 hover:border-brand-mid-pink/50 rounded-lg text-xs text-gray-700 dark:text-gray-300 transition-all cursor-pointer"
+              >
+                &ldquo;{word}&rdquo;
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Preferred Emojis */}
+      {bible?.preferredEmojis && bible.preferredEmojis.length > 0 && (
+        <div className="mb-5">
+          <span className="text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2 block">Emojis</span>
+          <div className="flex flex-wrap gap-2">
+            {bible.preferredEmojis.map((e) => (
+              <span
+                key={e}
+                className="px-2.5 py-1.5 bg-brand-off-white dark:bg-gray-800 hover:bg-brand-mid-pink/10 border border-brand-mid-pink/20 hover:border-brand-mid-pink/50 rounded-lg text-lg transition-all cursor-pointer"
+              >
+                {e}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Operator Notes */}
+      {bible?.captionOperatorNotes && (
+        <div className="mb-5">
+          <span className="text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2 block">Operator Notes</span>
+          <div className="p-3 bg-brand-blue/5 dark:bg-brand-blue/10 border border-brand-blue/20 rounded-xl text-sm leading-relaxed text-gray-700 dark:text-gray-300 whitespace-pre-wrap">
+            {bible.captionOperatorNotes}
+          </div>
+        </div>
+      )}
+
+      {/* Restrictions */}
+      {restrictions && (
+        <div className="mb-5">
+          <div className="flex items-center gap-2 mb-2">
+            <ShieldAlert size={11} className="text-red-500 dark:text-red-400" />
+            <span className="text-[11px] font-semibold text-red-500 dark:text-red-400 uppercase tracking-wide">Restrictions</span>
+          </div>
+          <div className="p-3 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-900/50 rounded-xl">
+            {restrictions.contentLimitations && (
+              <p className="text-xs text-red-600 dark:text-red-300 py-1 flex items-center gap-2">
+                <XIcon size={10} className="shrink-0" /> {restrictions.contentLimitations}
+              </p>
+            )}
+            {restrictions.wallRestrictions && (
+              <p className="text-xs text-red-600 dark:text-red-300 py-1 flex items-center gap-2">
+                <XIcon size={10} className="shrink-0" /> {restrictions.wallRestrictions}
+              </p>
+            )}
+            {restrictions.mmExclusions && (
+              <p className="text-xs text-red-600 dark:text-red-300 py-1 flex items-center gap-2">
+                <XIcon size={10} className="shrink-0" /> {restrictions.mmExclusions}
+              </p>
+            )}
+            {restrictions.customsToAvoid && (
+              <p className="text-xs text-red-600 dark:text-red-300 py-1 flex items-center gap-2">
+                <XIcon size={10} className="shrink-0" /> {restrictions.customsToAvoid}
+              </p>
+            )}
+            {restrictions.wordingToAvoid && restrictions.wordingToAvoid.length > 0 && (
+              <div className="mt-2 pt-2 border-t border-red-200 dark:border-red-900/50">
+                <div className="flex flex-wrap gap-1">
+                  {restrictions.wordingToAvoid.map((w) => (
+                    <span key={w} className="px-1.5 py-0.5 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded text-[10px]">
+                      {w}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Page Strategy */}
+      {profile.pageStrategy && (
+        <div className="mb-5">
+          <span className="text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide mb-2 block">Page Strategy</span>
+          <div className="p-3 bg-brand-off-white dark:bg-gray-800 rounded-xl text-sm leading-relaxed border border-brand-mid-pink/10 text-gray-700 dark:text-gray-300">
+            {profile.pageStrategy}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/gif-maker-workspace/QueuePanel.tsx
+++ b/components/gif-maker-workspace/QueuePanel.tsx
@@ -1,0 +1,222 @@
+'use client';
+
+import { memo } from 'react';
+import { Search, X, Calendar, CheckCircle2, GripVertical } from 'lucide-react';
+import { useInView } from 'react-intersection-observer';
+import type { GifQueueTicket } from '@/lib/hooks/useGifQueue.query';
+import { urgencyConfig, safeUrgency } from './queue-constants';
+
+interface GifQueuePanelProps {
+  queue: GifQueueTicket[];
+  selectedTicketId: string | null;
+  onSelectTicket: (ticketId: string) => void;
+  searchQuery: string;
+  onSearchChange: (query: string) => void;
+}
+
+// Lazy-loaded image component with intersection observer
+const LazyImage = memo(function LazyImage({
+  src,
+  alt,
+  fallback,
+}: {
+  src: string | null | undefined;
+  alt: string;
+  fallback: string;
+}) {
+  const { ref, inView } = useInView({
+    triggerOnce: true,
+    threshold: 0.1,
+    rootMargin: '100px',
+  });
+
+  if (!src) {
+    return (
+      <div className="w-6 h-6 rounded-md bg-linear-to-br from-brand-light-pink to-brand-blue flex items-center justify-center text-[10px] font-semibold text-white">
+        {fallback}
+      </div>
+    );
+  }
+
+  return (
+    <div ref={ref} className="w-6 h-6 rounded-md overflow-hidden bg-brand-mid-pink/20">
+      {inView ? (
+        <img src={src} alt={alt} loading="lazy" className="w-full h-full object-cover" />
+      ) : (
+        <div className="w-full h-full bg-brand-mid-pink/10 animate-pulse" />
+      )}
+    </div>
+  );
+});
+
+// Memoized queue item component — mirrors Caption Workspace QueueItem exactly
+const QueueItem = memo(function QueueItem({
+  ticket,
+  isSelected,
+  onSelect,
+}: {
+  ticket: GifQueueTicket;
+  isSelected: boolean;
+  onSelect: () => void;
+}) {
+  const config = urgencyConfig[safeUrgency(ticket.urgency)];
+
+  return (
+    <div
+      onClick={onSelect}
+      className={`p-3 border-b border-brand-mid-pink/10 cursor-pointer transition-all ${
+        isSelected
+          ? 'bg-brand-off-white dark:bg-gray-900/50 border-l-4 border-l-brand-mid-pink'
+          : 'border-l-4 border-l-transparent hover:bg-brand-off-white/50 dark:hover:bg-gray-900/30'
+      }`}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between gap-2 mb-1.5 min-w-0">
+        <div className="flex items-center gap-1.5 min-w-0">
+          {/* Drag handle (visual only — no drag in GIF workspace) */}
+          <div className="shrink-0 p-1 -ml-1 hover:bg-brand-mid-pink/10 rounded">
+            <GripVertical size={12} className="text-gray-400" />
+          </div>
+          <span className="text-xs font-semibold text-gray-500 dark:text-gray-400 truncate" title={ticket.id}>
+            {ticket.id}
+          </span>
+        </div>
+        <div className="shrink-0 flex items-center gap-1">
+          {ticket.hasGif && (
+            <span className="px-1.5 py-0.5 bg-green-100 dark:bg-green-900/40 text-green-600 dark:text-green-400 rounded text-[10px] font-bold flex items-center gap-0.5">
+              <CheckCircle2 size={9} />
+              GIF
+            </span>
+          )}
+          <span className={`px-2 py-0.5 ${config.bg} ${config.textColor} rounded text-[10px] font-bold`}>
+            {config.label}
+          </span>
+        </div>
+      </div>
+
+      {/* Model info */}
+      <div className="flex items-center gap-2 mb-1.5">
+        <LazyImage
+          src={ticket.profileImageUrl}
+          alt={ticket.modelName}
+          fallback={ticket.modelAvatar}
+        />
+        <span className="text-sm font-medium text-gray-900 dark:text-gray-100">{ticket.modelName}</span>
+      </div>
+
+      {/* Description */}
+      <div className="text-xs text-gray-500 dark:text-gray-400 mb-1.5 line-clamp-2">
+        {ticket.description}
+      </div>
+
+      {/* Tags */}
+      <div className="flex flex-wrap gap-1 mb-1.5">
+        {[...new Set(ticket.contentTypes)].map((type, idx) => (
+          <span key={`ct-${type}-${idx}`} className="px-1.5 py-0.5 bg-brand-off-white dark:bg-gray-800 rounded text-[10px] font-medium text-gray-700 dark:text-gray-300 border border-brand-mid-pink/10 whitespace-nowrap">
+            {type}
+          </span>
+        ))}
+        {[...new Set(ticket.messageTypes)].map((type, idx) => (
+          <span key={`mt-${type}-${idx}`} className="px-1.5 py-0.5 bg-brand-blue/10 rounded text-[10px] font-medium text-brand-blue border border-brand-blue/20 whitespace-nowrap">
+            {type}
+          </span>
+        ))}
+      </div>
+
+      {/* Release date — same format as Caption Workspace */}
+      <div className="flex items-center gap-1 text-[10px] text-gray-500 dark:text-gray-400">
+        <Calendar size={10} />
+        {new Date(ticket.releaseDate).toLocaleString('en-US', {
+          month: 'short',
+          day: 'numeric',
+          hour: 'numeric',
+          minute: '2-digit',
+          hour12: true,
+        })}
+      </div>
+    </div>
+  );
+});
+
+export function QueuePanel({
+  queue,
+  selectedTicketId,
+  onSelectTicket,
+  searchQuery,
+  onSearchChange,
+}: GifQueuePanelProps) {
+  return (
+    <div className="flex flex-col h-full border-r border-brand-mid-pink/20 bg-white dark:bg-gray-900/80">
+      {/* Header */}
+      <div className="shrink-0 px-4 py-3 border-b border-brand-mid-pink/20">
+        <div className="flex items-center justify-between mb-3">
+          <span className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+            MY QUEUE
+          </span>
+          <span className="text-[10px] text-gray-400 dark:text-gray-500">
+            {queue.length} items
+          </span>
+        </div>
+
+        {/* Search bar */}
+        <div className="relative">
+          <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => onSearchChange(e.target.value)}
+            placeholder="Search model or description..."
+            className="w-full pl-9 pr-8 py-2 bg-brand-off-white dark:bg-gray-800 border border-brand-mid-pink/20 focus:border-brand-mid-pink focus:ring-1 focus:ring-brand-mid-pink/30 rounded-lg text-xs text-gray-900 dark:text-gray-100 placeholder:text-gray-400"
+          />
+          {searchQuery && (
+            <button
+              onClick={() => onSearchChange('')}
+              className="absolute right-2.5 top-1/2 -translate-y-1/2 p-0.5 hover:bg-gray-200 dark:hover:bg-gray-700 rounded transition-colors"
+            >
+              <X size={12} className="text-gray-400" />
+            </button>
+          )}
+        </div>
+
+        {/* Drag hint */}
+        {queue.length > 1 && !searchQuery && (
+          <p className="mt-2 text-[10px] text-gray-400 dark:text-gray-500 flex items-center gap-1">
+            <GripVertical size={10} />
+            Drag to reorder
+          </p>
+        )}
+      </div>
+
+      {/* Queue list */}
+      <div className="flex-1 overflow-auto custom-scrollbar">
+        {queue.length === 0 ? (
+          <div className="flex flex-col items-center justify-center h-full py-8 px-4 text-center">
+            <div className="w-12 h-12 rounded-full bg-brand-mid-pink/10 flex items-center justify-center mb-3">
+              <Search size={20} className="text-brand-mid-pink" />
+            </div>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              {searchQuery ? 'No matching items found' : 'No items in queue'}
+            </p>
+            {searchQuery && (
+              <button
+                onClick={() => onSearchChange('')}
+                className="mt-2 text-xs text-brand-mid-pink hover:underline"
+              >
+                Clear search
+              </button>
+            )}
+          </div>
+        ) : (
+          queue.map((ticket) => (
+            <QueueItem
+              key={ticket.id}
+              ticket={ticket}
+              isSelected={ticket.id === selectedTicketId}
+              onSelect={() => onSelectTicket(ticket.id)}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/gif-maker-workspace/QueueRail.tsx
+++ b/components/gif-maker-workspace/QueueRail.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { LayoutList, ChevronUp, ChevronDown } from 'lucide-react';
+import type { GifQueueTicket } from '@/lib/hooks/useGifQueue.query';
+import { urgencyConfig, safeUrgency } from './queue-constants';
+
+interface QueueRailProps {
+  onOpenDrawer: () => void;
+  activeTicket: GifQueueTicket | null;
+  queueLength: number;
+  currentIndex: number;
+  onPrevTask: () => void;
+  onNextTask: () => void;
+}
+
+export function QueueRail({
+  onOpenDrawer,
+  activeTicket,
+  queueLength,
+  currentIndex,
+  onPrevTask,
+  onNextTask,
+}: QueueRailProps) {
+  const urgency = safeUrgency(activeTicket?.urgency ?? 'medium');
+  const dotColor = urgencyConfig[urgency].dotColor;
+
+  return (
+    <div className="w-9 flex flex-col items-center py-3 gap-3 bg-white dark:bg-gray-900/80 border-r border-brand-mid-pink/20 shrink-0">
+      {/* Urgency dot */}
+      <div className="relative">
+        <span
+          className={`block w-2.5 h-2.5 rounded-full ${dotColor} ${
+            urgency === 'urgent' ? 'animate-pulse' : ''
+          }`}
+        />
+        {urgency === 'urgent' && (
+          <span className={`absolute inset-0 w-2.5 h-2.5 rounded-full ${dotColor} animate-ping opacity-50`} />
+        )}
+      </div>
+
+      {/* Queue icon */}
+      <button
+        onClick={onOpenDrawer}
+        className="p-1.5 rounded-lg hover:bg-brand-mid-pink/10 text-gray-500 dark:text-gray-400 hover:text-brand-mid-pink transition-colors"
+        title="Open queue"
+      >
+        <LayoutList size={14} />
+      </button>
+
+      {/* Counter */}
+      <div className="flex flex-col items-center text-[9px] text-gray-500 dark:text-gray-400 font-mono leading-tight">
+        <span>{currentIndex + 1}</span>
+        <span className="text-gray-300 dark:text-gray-600">/</span>
+        <span>{queueLength}</span>
+      </div>
+
+      <div className="flex-1" />
+
+      {/* Prev/Next */}
+      <button
+        onClick={onPrevTask}
+        disabled={currentIndex <= 0}
+        className="p-1 rounded hover:bg-brand-mid-pink/10 text-gray-500 dark:text-gray-400 hover:text-brand-mid-pink disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+        title="Previous task"
+      >
+        <ChevronUp size={14} />
+      </button>
+      <button
+        onClick={onNextTask}
+        disabled={currentIndex >= queueLength - 1}
+        className="p-1 rounded hover:bg-brand-mid-pink/10 text-gray-500 dark:text-gray-400 hover:text-brand-mid-pink disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+        title="Next task"
+      >
+        <ChevronDown size={14} />
+      </button>
+    </div>
+  );
+}

--- a/components/gif-maker-workspace/TaskContextStrip.tsx
+++ b/components/gif-maker-workspace/TaskContextStrip.tsx
@@ -1,0 +1,223 @@
+'use client';
+
+import { ChevronDown, ChevronUp, Copy, ShieldAlert, X as XIcon, Calendar } from 'lucide-react';
+import { toast } from 'sonner';
+import type { GifQueueTicket } from '@/lib/hooks/useGifQueue.query';
+import type { InstagramProfileDetail } from '@/lib/hooks/useInstagramProfile.query';
+import { urgencyConfig, safeUrgency } from './queue-constants';
+
+interface TaskContextStripProps {
+  ticket: GifQueueTicket | null;
+  modelContext: InstagramProfileDetail | null;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+}
+
+export function TaskContextStrip({ ticket, modelContext, isExpanded, onToggleExpand }: TaskContextStripProps) {
+  if (!ticket) return null;
+
+  const config = urgencyConfig[safeUrgency(ticket.urgency)];
+  const bible = modelContext?.modelBible;
+  const restrictions = bible?.restrictions;
+
+  const handleCopyCaption = async () => {
+    if (!ticket.captionText) return;
+    try {
+      await navigator.clipboard.writeText(ticket.captionText);
+      toast.success('Caption copied');
+    } catch {
+      toast.error('Failed to copy caption');
+    }
+  };
+
+  const releaseFormatted = ticket.releaseDate
+    ? new Date(ticket.releaseDate).toLocaleString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true,
+      })
+    : null;
+
+  return (
+    <div className="border-b border-brand-mid-pink/20 bg-white dark:bg-gray-900/80">
+      {/* Header — always visible */}
+      <div className="flex items-center gap-2 px-3 py-2.5">
+        {ticket.profileImageUrl ? (
+          <img
+            src={ticket.profileImageUrl}
+            alt={ticket.modelName}
+            className="w-8 h-8 rounded-lg object-cover shrink-0 shadow-sm shadow-brand-mid-pink/20"
+          />
+        ) : (
+          <div className="w-8 h-8 rounded-lg bg-linear-to-br from-brand-light-pink to-brand-blue flex items-center justify-center shrink-0 shadow-sm shadow-brand-mid-pink/20">
+            <span className="text-[10px] font-bold text-white">{ticket.modelName.slice(0, 2).toUpperCase()}</span>
+          </div>
+        )}
+
+        <div className="flex-1 min-w-0">
+          <span className="text-xs font-semibold text-gray-900 dark:text-gray-100 block truncate">{ticket.modelName}</span>
+          {releaseFormatted && (
+            <span className="text-[10px] text-gray-500 dark:text-gray-400 flex items-center gap-1">
+              <Calendar size={9} />
+              Release: {releaseFormatted}
+            </span>
+          )}
+        </div>
+
+        <span className={`px-2 py-0.5 ${config.bg} ${config.textColor} rounded text-[10px] font-bold shrink-0`}>
+          {config.label}
+        </span>
+      </div>
+
+      {/* Content type tags — always visible */}
+      {(ticket.contentTypes.length > 0 || ticket.messageTypes.length > 0) && (
+        <div className="px-3 pb-2 flex flex-wrap gap-1">
+          {ticket.contentTypes.map((ct) => (
+            <span key={ct} className="px-1.5 py-0.5 bg-brand-off-white dark:bg-gray-800 rounded text-[10px] font-medium text-gray-700 dark:text-gray-300 border border-brand-mid-pink/10">
+              {ct}
+            </span>
+          ))}
+          {ticket.messageTypes.map((mt) => (
+            <span key={mt} className="px-1.5 py-0.5 bg-brand-blue/10 rounded text-[10px] font-medium text-brand-blue border border-brand-blue/20">
+              {mt}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Caption preview — always visible when caption exists */}
+      {ticket.captionText && (
+        <div className="px-3 pb-2">
+          <div className="p-2.5 bg-brand-off-white dark:bg-gray-800 rounded-lg border border-brand-mid-pink/10">
+            <div className="flex items-start justify-between gap-2 mb-1">
+              <span className="text-[9px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">Caption</span>
+              <button onClick={handleCopyCaption} className="p-0.5 rounded hover:bg-gray-200 dark:hover:bg-gray-700 text-gray-400 hover:text-gray-600 transition-colors shrink-0">
+                <Copy size={10} />
+              </button>
+            </div>
+            <p className={`text-[11px] text-gray-700 dark:text-gray-300 leading-relaxed whitespace-pre-wrap ${isExpanded ? '' : 'line-clamp-3'}`}>
+              {ticket.captionText}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Restrictions quick view — always visible when restrictions exist */}
+      {restrictions && !isExpanded && (
+        <div className="px-3 pb-2">
+          <div className="flex items-center gap-1 flex-wrap">
+            {restrictions.contentLimitations && (
+              <span className="px-1.5 py-0.5 bg-red-50 dark:bg-red-950/30 text-red-600 dark:text-red-400 border border-red-200 dark:border-red-900/50 rounded text-[9px] flex items-center gap-1">
+                <XIcon size={8} className="shrink-0" /> {restrictions.contentLimitations.slice(0, 40)}
+              </span>
+            )}
+            {restrictions.wallRestrictions && (
+              <span className="px-1.5 py-0.5 bg-red-50 dark:bg-red-950/30 text-red-600 dark:text-red-400 border border-red-200 dark:border-red-900/50 rounded text-[9px] flex items-center gap-1">
+                <XIcon size={8} className="shrink-0" /> {restrictions.wallRestrictions.slice(0, 40)}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Expanded: full model context */}
+      {isExpanded && (
+        <div className="px-3 pb-3 max-h-[40vh] overflow-y-auto custom-scrollbar space-y-3">
+          {/* Personality */}
+          {bible?.personalityDescription && (
+            <div className="border-t border-brand-mid-pink/20 pt-2">
+              <span className="text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide block mb-2">Personality</span>
+              <div className="p-3 bg-brand-off-white dark:bg-gray-800 rounded-xl text-sm leading-relaxed border border-brand-mid-pink/10 text-gray-700 dark:text-gray-300">
+                {bible.personalityDescription}
+              </div>
+            </div>
+          )}
+
+          {/* Background */}
+          {bible?.backstory && (
+            <div className="border-t border-brand-mid-pink/20 pt-2">
+              <span className="text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide block mb-2">Background</span>
+              <div className="p-3 bg-brand-off-white dark:bg-gray-800 rounded-xl text-sm leading-relaxed border border-brand-mid-pink/10 text-gray-700 dark:text-gray-300">
+                {bible.backstory}
+              </div>
+            </div>
+          )}
+
+          {/* Lingo */}
+          {bible?.lingoKeywords && bible.lingoKeywords.length > 0 && (
+            <div className="border-t border-brand-mid-pink/20 pt-2">
+              <span className="text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide block mb-2">Lingo &amp; Keywords</span>
+              <div className="flex flex-wrap gap-2">
+                {bible.lingoKeywords.map((word) => (
+                  <span key={word} className="px-2.5 py-1.5 bg-brand-off-white dark:bg-gray-800 hover:bg-brand-mid-pink/10 border border-brand-mid-pink/20 hover:border-brand-mid-pink/50 rounded-lg text-xs text-gray-700 dark:text-gray-300 transition-all cursor-pointer">
+                    &ldquo;{word}&rdquo;
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Restrictions — full view */}
+          {restrictions && (
+            <div className="border-t border-brand-mid-pink/20 pt-2">
+              <div className="flex items-center gap-2 mb-2">
+                <ShieldAlert size={11} className="text-red-500 dark:text-red-400" />
+                <span className="text-[11px] font-semibold text-red-500 dark:text-red-400 uppercase tracking-wide">Restrictions</span>
+              </div>
+              <div className="p-3 bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-900/50 rounded-xl space-y-1">
+                {restrictions.contentLimitations && (
+                  <p className="text-xs text-red-600 dark:text-red-300 py-1 flex items-center gap-2">
+                    <XIcon size={10} className="shrink-0" /> {restrictions.contentLimitations}
+                  </p>
+                )}
+                {restrictions.wallRestrictions && (
+                  <p className="text-xs text-red-600 dark:text-red-300 py-1 flex items-center gap-2">
+                    <XIcon size={10} className="shrink-0" /> {restrictions.wallRestrictions}
+                  </p>
+                )}
+                {restrictions.mmExclusions && (
+                  <p className="text-xs text-red-600 dark:text-red-300 py-1 flex items-center gap-2">
+                    <XIcon size={10} className="shrink-0" /> {restrictions.mmExclusions}
+                  </p>
+                )}
+                {restrictions.wordingToAvoid && restrictions.wordingToAvoid.length > 0 && (
+                  <div className="mt-2 pt-2 border-t border-red-200 dark:border-red-900/50">
+                    <div className="flex flex-wrap gap-1">
+                      {restrictions.wordingToAvoid.map((w) => (
+                        <span key={w} className="px-1.5 py-0.5 bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-300 rounded text-[10px]">
+                          {w}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {/* Operator Notes */}
+          {bible?.captionOperatorNotes && (
+            <div className="border-t border-brand-mid-pink/20 pt-2">
+              <span className="text-[10px] font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide block mb-2">Operator Notes</span>
+              <div className="p-3 bg-brand-blue/5 dark:bg-brand-blue/10 border border-brand-blue/20 rounded-xl text-sm leading-relaxed text-gray-700 dark:text-gray-300 whitespace-pre-wrap">
+                {bible.captionOperatorNotes}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Expand/Collapse toggle */}
+      <div className="px-3 pb-2 flex justify-end">
+        <button
+          onClick={onToggleExpand}
+          className="flex items-center gap-1 px-2 py-1 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-500 dark:text-gray-400 transition-colors text-[10px]"
+        >
+          {isExpanded ? <><ChevronUp size={12} /> Collapse</> : <><ChevronDown size={12} /> Expand</>}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/gif-maker-workspace/queue-constants.ts
+++ b/components/gif-maker-workspace/queue-constants.ts
@@ -1,0 +1,38 @@
+export type UrgencyLevel = 'urgent' | 'high' | 'medium' | 'low';
+
+export const VALID_URGENCIES = new Set<UrgencyLevel>(['urgent', 'high', 'medium', 'low']);
+
+export const urgencyConfig: Record<UrgencyLevel, { bg: string; textColor: string; borderColor: string; label: string; dotColor: string }> = {
+  urgent: {
+    bg: 'bg-red-500/15',
+    textColor: 'text-red-400',
+    borderColor: 'border-red-500/30',
+    label: 'URGENT',
+    dotColor: 'bg-red-500',
+  },
+  high: {
+    bg: 'bg-orange-500/15',
+    textColor: 'text-orange-400',
+    borderColor: 'border-orange-500/30',
+    label: 'HIGH',
+    dotColor: 'bg-orange-500',
+  },
+  medium: {
+    bg: 'bg-yellow-500/15',
+    textColor: 'text-yellow-400',
+    borderColor: 'border-yellow-500/30',
+    label: 'MEDIUM',
+    dotColor: 'bg-yellow-500',
+  },
+  low: {
+    bg: 'bg-green-500/15',
+    textColor: 'text-green-400',
+    borderColor: 'border-green-500/30',
+    label: 'LOW',
+    dotColor: 'bg-green-500',
+  },
+};
+
+export function safeUrgency(value: string): UrgencyLevel {
+  return VALID_URGENCIES.has(value as UrgencyLevel) ? (value as UrgencyLevel) : 'medium';
+}

--- a/components/gif-maker/EditorToolbar.tsx
+++ b/components/gif-maker/EditorToolbar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { RefObject, useCallback } from "react";
+import { toast } from "sonner";
 import { useVideoEditorStore } from "@/stores/video-editor-store";
 import { useEditorHistory } from "@/lib/hooks/useEditorHistory";
 import {
@@ -272,6 +273,20 @@ export function EditorToolbar({ playerRef }: EditorToolbarProps) {
               phase: "done",
               message: `Saved to flyer library! URL copied. (${sizeDisplay}${sizeWarning})`,
             });
+
+            // Auto-advance toast for queue mode
+            const currentStore = useVideoEditorStore.getState();
+            if (currentStore.activeTicketId) {
+              toast.success("GIF saved! Ready for next task?", {
+                action: {
+                  label: "Next Task →",
+                  onClick: () => {
+                    useVideoEditorStore.getState().requestNextTask();
+                  },
+                },
+                duration: 5000,
+              });
+            }
           } else {
             downloadBlob(gifBlob, `flyer-${timestamp}.gif`);
             setExportState({

--- a/components/gif-maker/panels/PropertiesPanel.tsx
+++ b/components/gif-maker/panels/PropertiesPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import { useVideoEditorStore } from "@/stores/video-editor-store";
 import { ClipProperties } from "./ClipProperties";
 import { TextOverlayProperties } from "./TextOverlayProperties";
@@ -8,8 +9,16 @@ import { StickerOverlayProperties } from "./StickerOverlayProperties";
 import { ShapeOverlayProperties } from "./ShapeOverlayProperties";
 import { Settings2, MousePointerClick } from "lucide-react";
 import { KeyframePanel } from "./KeyframePanel";
+import { TaskContextStrip } from "@/components/gif-maker-workspace/TaskContextStrip";
+import type { GifQueueTicket } from "@/lib/hooks/useGifQueue.query";
+import type { InstagramProfileDetail } from "@/lib/hooks/useInstagramProfile.query";
 
-export function PropertiesPanel() {
+interface PropertiesPanelProps {
+  activeTicket?: GifQueueTicket | null;
+  modelContext?: InstagramProfileDetail | null;
+}
+
+export function PropertiesPanel({ activeTicket, modelContext }: PropertiesPanelProps = {}) {
   // Derive selected items directly in selectors — only re-renders when the
   // selected clip/overlay itself changes, not when any unrelated clip updates
   const selectedClip = useVideoEditorStore((s) =>
@@ -19,6 +28,13 @@ export function PropertiesPanel() {
     s.selectedOverlayId ? (s.overlays.find((o) => o.id === s.selectedOverlayId) ?? null) : null
   );
 
+  // Smart expand/collapse: auto-collapse when clip/overlay selected, auto-expand when cleared
+  const [contextExpanded, setContextExpanded] = useState(true);
+  const hasSelection = !!selectedClip || !!selectedOverlay;
+  useEffect(() => {
+    setContextExpanded(!hasSelection);
+  }, [hasSelection]);
+
   return (
     <div className="h-full flex flex-col">
       <div className="flex items-center gap-2 px-4 h-9 bg-[#161925] border-b border-[#2d3142] sticky top-0 z-10 flex-shrink-0">
@@ -27,6 +43,16 @@ export function PropertiesPanel() {
           Properties
         </h3>
       </div>
+
+      {/* Task Context Strip — only in workspace queue mode */}
+      {activeTicket && (
+        <TaskContextStrip
+          ticket={activeTicket}
+          modelContext={modelContext ?? null}
+          isExpanded={contextExpanded}
+          onToggleExpand={() => setContextExpanded((v) => !v)}
+        />
+      )}
 
       <div className="flex-1 overflow-y-auto">
         {selectedClip ? (

--- a/lib/hooks/useGifQueue.query.ts
+++ b/lib/hooks/useGifQueue.query.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useCaptionQueue, type CaptionQueueItem } from './useCaptionQueue.query';
+import { safeUrgency } from '@/components/gif-maker-workspace/queue-constants';
+
+export interface GifQueueTicket {
+  id: string;
+  profileId: string | null;
+  boardItemId: string | null;
+  modelName: string;
+  modelAvatar: string;
+  profileImageUrl: string | null;
+  description: string;
+  urgency: 'urgent' | 'high' | 'medium' | 'low';
+  releaseDate: string;
+  contentTypes: string[];
+  messageTypes: string[];
+  workflowType: string | null;
+  status: string;
+  captionText: string | null;
+  contentUrl: string | null;
+  contentSourceType: string | null;
+  contentItems: CaptionQueueItem['contentItems'];
+  hasGif: boolean;
+}
+
+export function useGifQueue() {
+  const { data: rawQueue, isLoading, error, refetch } = useCaptionQueue();
+
+  const queue: GifQueueTicket[] = useMemo(() => {
+    if (!rawQueue) return [];
+    return rawQueue
+      .filter(item => !['completed'].includes(item.status))
+      .map(item => ({
+        id: item.id,
+        profileId: item.profileId,
+        boardItemId: item.boardItemId ?? null,
+        modelName: item.modelName,
+        modelAvatar: item.modelAvatar,
+        profileImageUrl: item.profileImageUrl,
+        description: item.description,
+        urgency: safeUrgency(item.urgency),
+        releaseDate: item.releaseDate,
+        contentTypes: item.contentTypes,
+        messageTypes: item.messageTypes,
+        workflowType: item.workflowType ?? null,
+        status: item.status,
+        captionText: item.captionText,
+        contentUrl: item.contentUrl ?? null,
+        contentSourceType: item.contentSourceType ?? null,
+        contentItems: item.contentItems || [],
+        hasGif: false,
+      }));
+  }, [rawQueue]);
+
+  return { queue, isLoading, error, refetch };
+}

--- a/stores/video-editor-store.ts
+++ b/stores/video-editor-store.ts
@@ -64,6 +64,15 @@ interface VideoEditorState {
   setWorkspaceMode: (profileId: string | null, boardItemId?: string | null) => void;
   clearWorkspaceMode: () => void;
 
+  // Queue mode (GIF Maker Workspace with task queue)
+  activeTicketId: string | null;
+  setActiveTicket: (ticketId: string | null) => void;
+  queueDrawerOpen: boolean;
+  setQueueDrawerOpen: (open: boolean) => void;
+  /** Signal set by export toast — GifMakerWorkspace watches this to advance */
+  pendingNextTask: boolean;
+  requestNextTask: () => void;
+
   // ─── Clip Actions ──────────────────
   addClip: (clip: Omit<VideoClip, "startFrame"> | Omit<ImageClip, "startFrame">) => void;
   removeClip: (clipId: string) => void;
@@ -234,7 +243,22 @@ export const useVideoEditorStore = create<VideoEditorState>()((set, get) => ({
   setWorkspaceMode: (profileId, boardItemId) =>
     set({ workspaceMode: !!profileId, workspaceProfileId: profileId, workspaceBoardItemId: boardItemId ?? null }),
   clearWorkspaceMode: () =>
-    set({ workspaceMode: false, workspaceProfileId: null, workspaceBoardItemId: null }),
+    set({
+      workspaceMode: false,
+      workspaceProfileId: null,
+      workspaceBoardItemId: null,
+      activeTicketId: null,
+      queueDrawerOpen: true,
+      pendingNextTask: false,
+    }),
+
+  // Queue mode defaults
+  activeTicketId: null,
+  setActiveTicket: (ticketId) => set({ activeTicketId: ticketId }),
+  queueDrawerOpen: true,
+  setQueueDrawerOpen: (open) => set({ queueDrawerOpen: open }),
+  pendingNextTask: false,
+  requestNextTask: () => set({ pendingNextTask: true }),
 
   // ─── Clip Actions ──────────────────
 


### PR DESCRIPTION
Integrate caption queue tasks into the GIF Maker Workspace with a two-mode drawer UI. Users can browse tasks, view model context and captions, then create GIFs with auto-advance on export.

- Add QueueDrawer with sliding overlay showing task list, content preview, and model context panel
- Add QueueRail (36px) for quick drawer access and task navigation
- Add TaskContextStrip in right panel showing model info, caption, and restrictions alongside clip/overlay properties
- Add useGifQueue hook wrapping existing caption queue API
- Extend Zustand store with queue state (activeTicketId, drawer)
- Auto-select model profile from active task
- Show "Next Task" toast action after GIF export