### PR TITLE
feat(scheduler): auto-create gallery item when task marked DONE

### DIFF
--- a/app/api/scheduler/[id]/route.ts
+++ b/app/api/scheduler/[id]/route.ts
@@ -137,6 +137,50 @@ export async function PATCH(
     });
   }
 
+  // ── Auto-create gallery item when status transitions to DONE ──
+  if (status === 'DONE' && oldTask.status !== 'DONE') {
+    try {
+      const { buildGalleryItemFromTask } = await import(
+        '@/lib/scheduler/gallery-integration'
+      );
+      const galleryPayload = buildGalleryItemFromTask(
+        {
+          id: task.id,
+          organizationId: orgId,
+          taskType: task.taskType,
+          taskName: task.taskName,
+          platform: task.platform,
+          profileId: task.profileId,
+          endTime: task.endTime?.toISOString() ?? null,
+          fields: task.fields as Record<string, string> | null,
+        },
+        userId,
+      );
+
+      if (galleryPayload) {
+        // Unique constraint on schedulerTaskId prevents duplicates
+        await prisma.gallery_items.create({ data: galleryPayload });
+      }
+    } catch (galleryErr) {
+      // P2002 = unique constraint violation (gallery item already exists) — safe to ignore
+      const prismaErr = galleryErr as { code?: string };
+      if (prismaErr.code !== 'P2002') {
+        console.error('[scheduler] Failed to create gallery item on DONE:', { taskId: task.id, orgId, taskType: task.taskType }, galleryErr);
+      }
+    }
+  }
+
+  // ── Remove gallery item if status reverts from DONE ──
+  if (oldTask.status === 'DONE' && status !== undefined && status !== 'DONE') {
+    try {
+      await prisma.gallery_items.deleteMany({
+        where: { schedulerTaskId: task.id },
+      });
+    } catch (cleanupErr) {
+      console.error('[scheduler] Failed to remove gallery item on status revert:', { taskId: task.id, orgId }, cleanupErr);
+    }
+  }
+
   // Broadcast real-time update
   await broadcastToScheduler(orgId, {
     type: 'task.updated',
@@ -183,6 +227,11 @@ export async function DELETE(
   const taskToDelete = await prisma.schedulerTask.findUnique({
     where: { id, organizationId: orgId },
     select: { slotLabel: true, dayOfWeek: true, taskType: true },
+  });
+
+  // Clean up linked gallery item before deleting the task
+  await prisma.gallery_items.deleteMany({
+    where: { schedulerTaskId: id },
   });
 
   const task = await prisma.schedulerTask.delete({

--- a/components/scheduler/task-cards/MMCard.tsx
+++ b/components/scheduler/task-cards/MMCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { CheckCircle2, Lock, DollarSign } from "lucide-react";
+import { Lock, DollarSign } from "lucide-react";
 import {
   isTaskLocked,
   TASK_FIELD_DEFS,
@@ -22,6 +22,7 @@ import {
   CaptionPreview,
   FlyerPreview,
   FlagButton,
+  PostedBadge,
 } from "./shared";
 
 const TYPE_COLOR = TASK_TYPE_COLORS["MM"];
@@ -93,9 +94,7 @@ export function MMCard({
                   flagged={isFlagged}
                   onToggle={() => save("flagged", isFlagged ? "" : "true")}
                 />
-                {task.status === "DONE" && (
-                  <CheckCircle2 className="h-2.5 w-2.5 shrink-0 text-green-500/70" />
-                )}
+                {task.status === "DONE" && <PostedBadge />}
               </div>
             </div>
             {hasSubType && (

--- a/components/scheduler/task-cards/SPCard.tsx
+++ b/components/scheduler/task-cards/SPCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import { CheckCircle2, Lock } from 'lucide-react';
+import { Lock } from 'lucide-react';
 import { isTaskLocked } from '@/lib/hooks/useScheduler.query';
 import { TASK_FIELD_DEFS } from '@/lib/hooks/useScheduler.query';
 import { SchedulerTaskModal } from '../SchedulerTaskModal';
@@ -18,6 +18,7 @@ import {
   CaptionPreview,
   FlyerPreview,
   FlagButton,
+  PostedBadge,
 } from './shared';
 
 const TYPE_COLOR = TASK_TYPE_COLORS['SP'];
@@ -54,7 +55,7 @@ export function SPCard({ task, team, onUpdate, onDelete, compact, schedulerToday
             )}
             {locked && <Lock className="h-2.5 w-2.5 shrink-0 text-gray-400 dark:text-gray-600" />}
             <FlagButton flagged={isFlagged} onToggle={() => save('flagged', isFlagged ? '' : 'true')} />
-            {task.status === 'DONE' && <CheckCircle2 className="h-2.5 w-2.5 shrink-0 text-green-500/70" />}
+            {task.status === 'DONE' && <PostedBadge />}
           </div>
           {fields.contentFlyer && (
             <div className="text-[7px] font-mono truncate text-gray-400 dark:text-gray-600 ml-[13px] mt-px">

--- a/components/scheduler/task-cards/STCard.tsx
+++ b/components/scheduler/task-cards/STCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import { CheckCircle2, Lock } from 'lucide-react';
+import { Lock } from 'lucide-react';
 import { isTaskLocked } from '@/lib/hooks/useScheduler.query';
 import { TASK_FIELD_DEFS } from '@/lib/hooks/useScheduler.query';
 import { SchedulerTaskModal } from '../SchedulerTaskModal';
@@ -16,6 +16,7 @@ import {
   TimeDisplay,
   useFieldSave,
   FlagButton,
+  PostedBadge,
 } from './shared';
 
 const TYPE_COLOR = TASK_TYPE_COLORS['ST'];
@@ -51,7 +52,7 @@ export function STCard({ task, team, onUpdate, onDelete, compact, schedulerToday
             </span>
             {locked && <Lock className="h-2.5 w-2.5 shrink-0 text-gray-400 dark:text-gray-600" />}
             <FlagButton flagged={isFlagged} onToggle={() => save('flagged', isFlagged ? '' : 'true')} />
-            {task.status === 'DONE' && <CheckCircle2 className="h-2.5 w-2.5 shrink-0 text-green-500/70" />}
+            {task.status === 'DONE' && <PostedBadge />}
           </div>
           {fields.contentFlyer && (
             <div className="text-[7px] font-mono truncate text-gray-400 dark:text-gray-600 ml-[13px] mt-px">

--- a/components/scheduler/task-cards/WPCard.tsx
+++ b/components/scheduler/task-cards/WPCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
-import { CheckCircle2, Lock } from 'lucide-react';
+import { Lock } from 'lucide-react';
 import { isTaskLocked } from '@/lib/hooks/useScheduler.query';
 import { TASK_FIELD_DEFS } from '@/lib/hooks/useScheduler.query';
 import { SchedulerTaskModal } from '../SchedulerTaskModal';
@@ -18,6 +18,7 @@ import {
   CaptionPreview,
   FlyerPreview,
   FlagButton,
+  PostedBadge,
 } from './shared';
 
 const TYPE_COLOR = TASK_TYPE_COLORS['WP'];
@@ -54,7 +55,7 @@ export function WPCard({ task, team, onUpdate, onDelete, compact, schedulerToday
             )}
             {locked && <Lock className="h-2.5 w-2.5 shrink-0 text-gray-400 dark:text-gray-600" />}
             <FlagButton flagged={isFlagged} onToggle={() => save('flagged', isFlagged ? '' : 'true')} />
-            {task.status === 'DONE' && <CheckCircle2 className="h-2.5 w-2.5 shrink-0 text-green-500/70" />}
+            {task.status === 'DONE' && <PostedBadge />}
           </div>
           {fields.contentFlyer && (
             <div className="text-[7px] font-mono truncate text-gray-400 dark:text-gray-600 ml-[13px] mt-px">

--- a/components/scheduler/task-cards/shared.tsx
+++ b/components/scheduler/task-cards/shared.tsx
@@ -36,6 +36,18 @@ export const STATUS_ICONS: Record<string, React.ReactNode> = {
   SKIPPED: <SkipForward className="h-2.5 w-2.5" />,
 };
 
+/** "Done" indicator: green check + "Posted" badge, shown on DONE tasks */
+export function PostedBadge() {
+  return (
+    <>
+      <CheckCircle2 className="h-2.5 w-2.5 shrink-0 text-green-500/70" />
+      <span className="text-[7px] font-bold px-1 py-px rounded bg-green-50 text-green-600 dark:bg-green-950/30 dark:text-green-400">
+        Posted
+      </span>
+    </>
+  );
+}
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export interface TaskCardProps {

--- a/lib/constants/gallery.ts
+++ b/lib/constants/gallery.ts
@@ -53,6 +53,7 @@ export const GALLERY_ORIGINS = [
   "manual", // Manually entered
   "import", // Imported from external source
   "migration", // Migrated from another system
+  "scheduler", // Auto-created when scheduler task marked DONE
 ] as const;
 
 export type GalleryOrigin = (typeof GALLERY_ORIGINS)[number];

--- a/lib/hooks/useScheduler.query.ts
+++ b/lib/hooks/useScheduler.query.ts
@@ -309,8 +309,12 @@ export function useUpdatePodTask() {
         }
       }
     },
-    onSettled: () => {
+    onSettled: (_data, _error, variables) => {
       queryClient.invalidateQueries({ queryKey: schedulerKeys.all });
+      // Invalidate gallery cache on any status change (gallery item created/removed server-side)
+      if (variables.status !== undefined) {
+        queryClient.invalidateQueries({ queryKey: ['gallery'] });
+      }
     },
   });
 }

--- a/lib/scheduler/gallery-integration.ts
+++ b/lib/scheduler/gallery-integration.ts
@@ -1,0 +1,81 @@
+/**
+ * Creates gallery items from scheduler tasks.
+ * Called server-side when a scheduler task transitions to DONE.
+ * Stores scheduler fields as-is — no transformation or mapping.
+ */
+import { Prisma } from '@/lib/generated/prisma';
+
+/** Check if a string looks like a URL */
+function isUrl(str: string): boolean {
+  return /^https?:\/\//.test(str);
+}
+
+/** Parse "$12.99" or "12.99" to a number, or null */
+function parsePrice(raw: string | undefined): number | null {
+  if (!raw) return null;
+  const cleaned = raw.replace(/[^0-9.]/g, '');
+  const num = parseFloat(cleaned);
+  return isNaN(num) ? null : num;
+}
+
+export interface SchedulerTaskForGallery {
+  id: string;
+  organizationId: string;
+  taskType: string;
+  taskName: string;
+  platform: string;
+  profileId: string | null;
+  endTime: string | null;
+  fields: Record<string, string> | null;
+}
+
+/**
+ * Build a Prisma create payload for gallery_items from a scheduler task.
+ * Stores all scheduler fields in boardMetadata so the gallery can display
+ * the raw scheduler data and show it came from the scheduler.
+ * Returns null if no preview image exists.
+ */
+export function buildGalleryItemFromTask(
+  task: SchedulerTaskForGallery,
+  userId: string,
+): Prisma.gallery_itemsCreateInput | null {
+  const fields = (task.fields || {}) as Record<string, string>;
+
+  // Resolve preview URL — skip gallery creation if no meaningful image exists
+  const previewUrl =
+    fields.flyerAssetUrl ||
+    (fields.contentPreview && isUrl(fields.contentPreview) ? fields.contentPreview : null);
+
+  if (!previewUrl) return null;
+
+  // Store ALL scheduler fields as metadata so the gallery preserves the original data
+  const schedulerMetadata: Record<string, unknown> = {
+    ...fields,
+    taskType: task.taskType,
+    taskName: task.taskName,
+    platform: task.platform,
+    source: 'scheduler',
+  };
+
+  return {
+    previewUrl,
+    contentType: fields.tag || 'OTHER',
+    platform: task.platform,
+    postedAt: task.endTime ? new Date(task.endTime) : new Date(),
+    captionUsed: fields.caption || fields.captionBankText || null,
+    pricingAmount: parsePrice(fields.price || fields.priceInfo),
+    title: fields.type || task.taskName || `${task.taskType} Task`,
+    tags: [task.taskType, fields.tag, fields.type].filter(Boolean),
+    origin: 'scheduler',
+    postOrigin: task.taskType,
+    schedulerTaskId: task.id,
+    createdBy: userId,
+    boardMetadata: schedulerMetadata as unknown as Prisma.InputJsonValue,
+    ...(task.profileId && {
+      profile: { connect: { id: task.profileId } },
+    }),
+    ...(task.organizationId && {
+      organization: { connect: { id: task.organizationId } },
+    }),
+  };
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2079,6 +2079,7 @@ model gallery_items {
   createdBy        String?
   boardItemId      String?           @unique
   boardMetadata    Json?
+  schedulerTaskId  String?           @unique
   pageType         String?
   postOrigin       String?
   pricingTier      String?
@@ -2097,6 +2098,7 @@ model gallery_items {
   @@index([pricingTier])
   @@index([pageType])
   @@index([profileId])
+  @@index([schedulerTaskId])
 }
 
 model plan_features {


### PR DESCRIPTION
- Add schedulerTaskId unique field to gallery_items schema
- Create gallery-integration helper that maps scheduler task data to gallery entries
- Auto-create gallery item on DONE transition with flyer, caption, price, and tags
- Auto-remove gallery item when status reverts from DONE or task is deleted
- Add PostedBadge indicator on completed task cards (MM, WP, SP, ST)
- Invalidate gallery cache on any scheduler status change