### PR TITLE
fix: auto-fill all task fields when selecting a caption from picker

### DIFF
--- a/components/scheduler/SchedulerCreateTaskModal.tsx
+++ b/components/scheduler/SchedulerCreateTaskModal.tsx
@@ -161,7 +161,18 @@ export function SchedulerCreateTaskModal({
         next.price = `$${selection.price.toFixed(2)}`;
       }
       if (selection.gifUrl) {
-        next.contentPreview = prev.contentPreview || selection.gifUrl;
+        next.contentPreview = selection.gifUrl;
+      }
+      if (selection.contentType) {
+        next.tag = selection.contentType;
+      }
+      if (selection.contentCount) {
+        next.paywallContent = selection.contentLength
+          ? `${selection.contentCount} (${selection.contentLength})`
+          : selection.contentCount;
+      }
+      if (selection.sextingSetName) {
+        next.folderName = selection.sextingSetName;
       }
       return next;
     });
@@ -173,6 +184,11 @@ export function SchedulerCreateTaskModal({
       delete next.captionId;
       delete next.captionBankText;
       next.caption = '';
+      next.contentPreview = '';
+      next.tag = '';
+      next.paywallContent = '';
+      next.price = '';
+      next.folderName = '';
       return next;
     });
   }, []);

--- a/components/scheduler/SchedulerTaskModal.tsx
+++ b/components/scheduler/SchedulerTaskModal.tsx
@@ -360,6 +360,9 @@ export function SchedulerTaskModal({
       flyerAssetUrl: sel.gifUrl,
       flyerAssetId: sel.boardItemId || '',
     };
+    if (sel.gifUrl) {
+      patch.contentPreview = sel.gifUrl;
+    }
     if (sel.sextingSetName) {
       patch.caption = sel.captionText;
       patch.sextingSetName = sel.sextingSetName;


### PR DESCRIPTION
Caption selection now populates contentPreview (GIF URL), tag, paywallContent, price, and folderName in both create and edit modals. Clearing a caption resets all auto-filled fields. Fixes GIF preview not showing in edit modal.